### PR TITLE
fix(runner): respect retry: 0 instead of coercing to default 5

### DIFF
--- a/packages/subsquid-pipes/src/runtime/node/runner.test.ts
+++ b/packages/subsquid-pipes/src/runtime/node/runner.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createDevRunner } from './runner.js'
+
+describe('createDevRunner', () => {
+  const originalLogLevel = process.env['LOG_LEVEL']
+
+  beforeEach(() => {
+    // Silence the default logger created inside Runner so test output stays clean.
+    process.env['LOG_LEVEL'] = 'silent'
+  })
+
+  afterEach(() => {
+    if (originalLogLevel === undefined) {
+      delete process.env['LOG_LEVEL']
+    } else {
+      process.env['LOG_LEVEL'] = originalLogLevel
+    }
+  })
+
+  it('fails fast when retry is explicitly 0 and re-throws the original error', async () => {
+    const boom = new Error('boom')
+    const handler = vi.fn(async () => {
+      throw boom
+    })
+
+    const runner = createDevRunner(
+      [
+        {
+          id: 'fail-fast',
+          params: {},
+          handler,
+        },
+      ],
+      { retry: 0 },
+    )
+
+    await expect(runner.start()).rejects.toBe(boom)
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('defaults to 5 attempts when retry is not provided', async () => {
+    const boom = new Error('boom')
+    const handler = vi.fn(async () => {
+      throw boom
+    })
+
+    const runner = createDevRunner([
+      {
+        id: 'default-retries',
+        params: {},
+        handler,
+      },
+    ])
+
+    await expect(runner.start()).rejects.toBe(boom)
+    expect(handler).toHaveBeenCalledTimes(5)
+  })
+})

--- a/packages/subsquid-pipes/src/runtime/node/runner.ts
+++ b/packages/subsquid-pipes/src/runtime/node/runner.ts
@@ -59,7 +59,7 @@ class Runner<T extends SerializableObject = any> {
 
     await Promise.all(
       this.pipes.map(async (pipe) => {
-        const maxAttempts = this.config.retry || 5
+        const maxAttempts = this.config.retry ?? 5
         let attempts = 0
 
         const logger = this.#logger.child({ id: pipe.id })


### PR DESCRIPTION
## Summary
- `createDevRunner` used `this.config.retry || 5`, so `retry: 0` (intent: fail-fast) was silently coerced to 5 restarts.
- Switch to `??` (nullish coalescing) so the default only applies when the field is absent.

## Test plan
- [x] `pnpm vitest run src/runtime/node/runner.test.ts` from `packages/subsquid-pipes/`
- [x] New regression: `retry: 0` rejects on first failure, handler called once
- [x] Existing default behavior (`retry` omitted → 5 attempts) still holds