### PR TITLE
fix(portal-source): make pipe() id dedup stable for 3+ same-id transformers

### DIFF
--- a/packages/subsquid-pipes/src/core/portal-source.test.ts
+++ b/packages/subsquid-pipes/src/core/portal-source.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, expectTypeOf, it } from 'vitest'
 
 import { createTarget } from '~/core/target.js'
 import { Target } from '~/core/target.js'
-import { TransformerArgs } from '~/core/transformer.js'
+import { createTransformer, TransformerArgs } from '~/core/transformer.js'
 import { evmPortalStream } from '~/evm/index.js'
 import {
   MockPortal,
@@ -347,6 +347,39 @@ describe('Portal abstract stream', () => {
       })
 
       expect(() => stream.pipeTo(target as any)).not.toThrow()
+    })
+
+    it('should assign unique ids when 3+ transformers share the same base id', async () => {
+      mockPortal = await createMockPortal([
+        {
+          statusCode: 200,
+          data: [{ header: { number: 1, hash: '0x123', timestamp: 1000 } }],
+        },
+      ])
+
+      const stream = evmPortalStream({
+        id: 'test',
+        portal: mockPortal.url,
+        outputs: blockDecoder({ from: 0, to: 1 }),
+      })
+
+      const makeT = () =>
+        createTransformer<any, any>({
+          profiler: { name: 'dup' },
+          transform: (data) => data,
+        })
+
+      const t1 = makeT()
+      const t2 = makeT()
+      const t3 = makeT()
+      const t4 = makeT()
+
+      stream.pipe(t1).pipe(t2).pipe(t3).pipe(t4)
+
+      const ids = [t1.id(), t2.id(), t3.id(), t4.id()]
+
+      expect(new Set(ids).size).toBe(ids.length)
+      expect(ids).toEqual(['dup', 'dup 2', 'dup 3', 'dup 4'])
     })
   })
 

--- a/packages/subsquid-pipes/src/core/portal-source.ts
+++ b/packages/subsquid-pipes/src/core/portal-source.ts
@@ -272,12 +272,18 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
 
     const id = transformer.id()
 
-    // If there are multiple transformers with the same ID, we append a numeric suffix to make them unique
+    // If there are multiple transformers with the same ID, we append a numeric suffix to make them unique.
     // This is important for profiling and logging to avoid confusion between transformers
-    // when analyzing performance or debugging issues
-    const exists = this.#transformers.filter((t) => t.id() === id)
-    if (exists.length) {
-      transformer.setId(`${id} ${exists.length + 1}`)
+    // when analyzing performance or debugging issues. We keep incrementing the suffix until the
+    // candidate id is unused across the whole transformer list, so that previously-renamed
+    // transformers (e.g. `foo 2`) do not cause a new incoming `foo` to collide with them.
+    let candidate = id
+    let n = 2
+    while (this.#transformers.some((t) => t.id() === candidate)) {
+      candidate = `${id} ${n++}`
+    }
+    if (candidate !== id) {
+      transformer.setId(candidate)
     }
 
     return new PortalSource<Q, Out>({


### PR DESCRIPTION
## Summary
- `.pipe()` deduped ids by counting existing transformers whose `id()` still equals the incoming base id. After the 2nd rename, that count stopped growing, so the 3rd+ transformer collided with the 2nd.
- Replace with a uniqueness loop: bump the suffix until the candidate id is unused across the whole transformer list.

## Test plan
- [x] `pnpm vitest run src/core/portal-source.test.ts` from `packages/subsquid-pipes/`
- [x] New regression: 3 transformers sharing a base id produce 3 distinct final ids