### PR TITLE
Treat HTTP 529 as retriable error

### DIFF
--- a/packages/pipes/src/http-client/client.ts
+++ b/packages/pipes/src/http-client/client.ts
@@ -143,6 +143,7 @@ const statusTexts: Record<number, string> = {
   522: 'connection timed out',
   523: 'origin is unreachable',
   524: 'timeout occurred',
+  529: 'server is overloaded',
 }
 
 const MAX_LOG_BODY_SIZE_BYTES = 1024 * 1024 // 1MB
@@ -602,6 +603,7 @@ function isRetryableError(error: HttpResponse | Error, req?: FetchRequest): bool
       case 522:
       case 523:
       case 524:
+      case 529:
         return true
       default:
         return error.headers.has('retry-after')

--- a/packages/pipes/src/portal-client/client.test.ts
+++ b/packages/pipes/src/portal-client/client.test.ts
@@ -276,6 +276,26 @@ describe('PortalClient request accounting', () => {
       503: 1,
     })
   })
+
+  // 529 is what the portal answers under load instead of 503; surfacing it would fail a stream
+  // the portal expects the client to simply retry.
+  it('retries an overloaded portal', async () => {
+    portal = await mockPortal([
+      { statusCode: 529 },
+      {
+        statusCode: 200,
+        data: [block(1), block(2), block(3)],
+        head: { finalized: { number: 3, hash: '0x3' } },
+      },
+    ] satisfies MockResponse[])
+
+    const client = new PortalClient({ url: portal.url })
+
+    expect(await countRequests(client, false, { request: { retryAttempts: 2, retrySchedule: [1] } })).toEqual({
+      200: 1,
+      529: 1,
+    })
+  })
 })
 
 describe('PortalClient bounded range above the finalized head', () => {

--- a/packages/pipes/src/testing/test-portal.ts
+++ b/packages/pipes/src/testing/test-portal.ts
@@ -47,7 +47,7 @@ export type MockResponse =
       validateRequest?: ValidateRequest
     }
   | {
-      statusCode: 500 | 503
+      statusCode: 500 | 503 | 529
       validateRequest?: ValidateRequest
     }
 

--- a/packages/subsquid-pipes/src/http-client/client.ts
+++ b/packages/subsquid-pipes/src/http-client/client.ts
@@ -143,6 +143,7 @@ const statusTexts: Record<number, string> = {
   522: 'connection timed out',
   523: 'origin is unreachable',
   524: 'timeout occurred',
+  529: 'server is overloaded',
 }
 
 const MAX_LOG_BODY_SIZE_BYTES = 1024 * 1024 // 1MB
@@ -581,6 +582,7 @@ function isRetryableError(error: HttpResponse | Error, req?: FetchRequest): bool
       case 522:
       case 523:
       case 524:
+      case 529:
         return true
       default:
         return error.headers.has('retry-after')


### PR DESCRIPTION
See https://github.com/subsquid/sqd-portal/pull/115