### PR TITLE
feat(evm): explicit factory pre-indexing phase before the main loop

### DIFF
--- a/docs/examples/evm/18.factory-preindex.example.ts
+++ b/docs/examples/evm/18.factory-preindex.example.ts
@@ -1,0 +1,63 @@
+import { contractFactory, contractFactoryStore, evmDecoder, evmPortalStream } from '@subsquid/pipes/evm'
+
+import { events as factoryAbi } from './abi/uniswap.v3/factory'
+import { events as swapsAbi } from './abi/uniswap.v3/swaps'
+
+/**
+ * This example demonstrates factory pre-indexing — an explicit discovery phase
+ * that runs before the main loop starts.
+ *
+ * Without `preindex`, a factory pipe streams child events with a wildcard
+ * (topic-only) query and filters them client-side, because the child addresses
+ * are only discovered along the way. That means downloading every `Swap` event
+ * on the network, including those from unrelated contracts.
+ *
+ * With `preindex: true` the pipe runs in two phases:
+ *
+ * 1. Check run (every startup): scans only the factory-creation events up to the
+ *    finalized head and persists the discovered child addresses to the factory
+ *    database. Progress is stored alongside, so a restart only scans the gap
+ *    since the previous run — an interrupted scan resumes where it left off.
+ *
+ * 2. Main loop: for the pre-indexed range the query sends the full child address
+ *    list to the portal (server-side filter — much faster backfill, less traffic).
+ *    Above the finalized head it falls back to the usual wildcard query, where
+ *    speed doesn't matter since blocks arrive one at a time.
+ *
+ * Forks are safe by construction: the pre-indexed range never goes above the
+ * finalized head, and children discovered inline in the wildcard tail are rolled
+ * back by the regular factory fork handling.
+ */
+
+async function cli() {
+  const stream = evmPortalStream({
+    id: 'uniswap-v3-swaps-preindexed',
+    portal: 'https://portal.sqd.dev/datasets/ethereum-mainnet',
+    outputs: evmDecoder({
+      range: { from: '12,369,621' },
+      contracts: contractFactory({
+        address: '0x1f98431c8ad98523631ae4a59f267346ea31f984',
+        event: factoryAbi.PoolCreated,
+        childAddressField: 'pool',
+        // Pre-indexing requires a persistent store — discovered pools and the
+        // scan progress live in the same SQLite file
+        database: contractFactoryStore({
+          path: './uniswap3-eth-pools.sqlite',
+        }),
+        preindex: true,
+        // Optionally cap the server-side filter size; above the threshold the pipe
+        // logs a warning and falls back to the wildcard query
+        // preindex: { maxAddressFilterSize: 50_000 },
+      }),
+      events: {
+        swaps: swapsAbi.Swap,
+      },
+    }),
+  })
+
+  for await (const { data } of stream) {
+    console.log(`parsed ${data.swaps.length} swaps`)
+  }
+}
+
+void cli()

--- a/packages/subsquid-pipes/src/bitcoin/bitcoin-rpc-latency-watcher.test.ts
+++ b/packages/subsquid-pipes/src/bitcoin/bitcoin-rpc-latency-watcher.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { PortalClient } from '~/portal-client/client.js'
 import { type MockBitcoinRpc, createMockBitcoinRpc } from '~/testing/bitcoin/index.js'
 import { createTestLogger } from '~/testing/test-logger.js'
 
@@ -153,7 +154,7 @@ describe('bitcoinRpcLatencyWatcher factory', () => {
     })
 
     const builder = new BitcoinQueryBuilder<{ block: { number: true; timestamp: true } }>()
-    await transformer.setupQuery({ query: builder, logger: createTestLogger() })
+    await transformer.setupQuery({ query: builder, logger: createTestLogger(), portal: {} as PortalClient })
 
     expect(builder.getFields()).toEqual({
       block: { number: true, timestamp: true },

--- a/packages/subsquid-pipes/src/core/portal-source.ts
+++ b/packages/subsquid-pipes/src/core/portal-source.ts
@@ -360,6 +360,7 @@ export class PortalSource<Q extends QueryBuilder<any>, T = any> {
           t.setupQuery({
             query: this.#queryBuilder,
             logger: this.#logger,
+            portal: this.#portal,
           }),
         ),
     )

--- a/packages/subsquid-pipes/src/core/progress-tracker.ts
+++ b/packages/subsquid-pipes/src/core/progress-tracker.ts
@@ -218,6 +218,40 @@ export type ProgressTrackerOptions = {
   interval?: number
 }
 
+/**
+ * Builds the standard progress log payload (percent, ETA, blocks/s, bytes/s).
+ * Reused by phases that wrap a nested stream (e.g. factory pre-indexing) to keep
+ * their progress lines consistent with the main loop while adding their own prefix.
+ */
+export function formatProgressMessage({ state, interval }: ProgressEvent['progress']): Record<string, string> {
+  const bps =
+    interval.processedBlocks.perSecond > 1
+      ? formatNumber(interval.processedBlocks.perSecond, 0)
+      : interval.processedBlocks.perSecond.toFixed(2)
+
+  const msg: Record<string, string> = {
+    message: `${formatNumber(state.current)} / ${formatNumber(state.last)} (${formatNumber(state.percent)}%), ${displayEstimatedTime(state.etaSeconds)}`,
+    blocks: `${bps} blocks/second`,
+    bytes: `${humanBytes(interval.bytesDownloaded.perSecond)}/second`,
+  }
+
+  if (interval.requests.total.count > 0) {
+    msg['requests'] = [
+      interval.requests.successful.percent > 0
+        ? `${formatNumber(interval.requests.successful.percent)}% successful`
+        : false,
+      interval.requests.rateLimited.percent
+        ? `${formatNumber(interval.requests.rateLimited.percent)}% rate limited`
+        : false,
+      interval.requests.failed.percent > 0 ? `${formatNumber(interval.requests.failed.percent)}% failed` : false,
+    ]
+      .filter(Boolean)
+      .join(', ')
+  }
+
+  return msg
+}
+
 const DEFAULT_BLOCKS_BUCKETS = [1, 5, 10, 50, 100, 500, 1000, 2000, 3000, 5000]
 const DEFAULT_BYTES_BUCKETS = [
   1024, // 1kb
@@ -260,38 +294,13 @@ export function progressTracker<T>({ onProgress, onStart, interval = 5000 }: Pro
   }
 
   if (!onProgress) {
-    onProgress = ({ progress: { state, interval }, logger }) => {
-      if (state.current === 0 && state.last === 0) {
+    onProgress = ({ progress, logger }) => {
+      if (progress.state.current === 0 && progress.state.last === 0) {
         logger.info({ message: 'Initializing...' })
         return
       }
 
-      const bps =
-        interval.processedBlocks.perSecond > 1
-          ? formatNumber(interval.processedBlocks.perSecond, 0)
-          : interval.processedBlocks.perSecond.toFixed(2)
-
-      const msg: Record<string, string> = {
-        message: `${formatNumber(state.current)} / ${formatNumber(state.last)} (${formatNumber(state.percent)}%), ${displayEstimatedTime(state.etaSeconds)}`,
-        blocks: `${bps} blocks/second`,
-        bytes: `${humanBytes(interval.bytesDownloaded.perSecond)}/second`,
-      }
-
-      if (interval.requests.total.count > 0) {
-        msg['requests'] = [
-          interval.requests.successful.percent > 0
-            ? `${formatNumber(interval.requests.successful.percent)}% successful`
-            : false,
-          interval.requests.rateLimited.percent
-            ? `${formatNumber(interval.requests.rateLimited.percent)}% rate limited`
-            : false,
-          interval.requests.failed.percent > 0 ? `${formatNumber(interval.requests.failed.percent)}% failed` : false,
-        ]
-          .filter(Boolean)
-          .join(', ')
-      }
-
-      logger.info(msg)
+      logger.info(formatProgressMessage(progress))
     }
   }
 

--- a/packages/subsquid-pipes/src/core/query-builder.test.ts
+++ b/packages/subsquid-pipes/src/core/query-builder.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
+import { mockPortalRestApi } from '~/testing/index.js'
+
+import { BlockRangeConfigurationError } from './errors.js'
 import {
   type RangeRequest,
   applyRangeBound,
   mergeRangeRequests,
   rangeDifference,
   rangeIntersection,
+  resolveNaturalRange,
 } from './query-builder.js'
 
 // ── Helpers ──
@@ -217,5 +221,46 @@ describe('applyRangeBound', () => {
     const result = applyRangeBound([rr(0, 100, ['a'])], { from: 0, to: 0 })
 
     expect(result).toEqual([rr(0, 0, ['a'])])
+  })
+})
+
+// ── resolveNaturalRange ──
+
+describe('resolveNaturalRange', () => {
+  it('passes numeric boundaries through unchanged', async () => {
+    const portal = mockPortalRestApi()
+
+    expect(await resolveNaturalRange(portal, { from: 5, to: 100 })).toEqual({ from: 5, to: 100 })
+    expect(await resolveNaturalRange(portal, { from: 5 })).toEqual({ from: 5, to: undefined })
+  })
+
+  it('returns null for a range starting from latest', async () => {
+    expect(await resolveNaturalRange(mockPortalRestApi(), { from: 'latest' })).toBeNull()
+  })
+
+  it('resolves Date boundaries via the portal', async () => {
+    const portal = mockPortalRestApi({
+      resolveTimestamp: async (seconds) => seconds * 2,
+    })
+
+    const result = await resolveNaturalRange(portal, { from: new Date(1_000_000), to: new Date(2_000_000) })
+
+    expect(result).toEqual({ from: 2000, to: 4000 })
+  })
+
+  it('throws BlockRangeConfigurationError when the range is inverted', async () => {
+    await expect(resolveNaturalRange(mockPortalRestApi(), { from: 100, to: 5 })).rejects.toThrow(
+      BlockRangeConfigurationError,
+    )
+  })
+
+  it('throws BlockRangeConfigurationError for a timestamp above the chain head', async () => {
+    const portal = mockPortalRestApi({
+      resolveTimestamp: async () => {
+        throw new Error('No chunk found for timestamp')
+      },
+    })
+
+    await expect(resolveNaturalRange(portal, { from: new Date() })).rejects.toThrow(BlockRangeConfigurationError)
   })
 })

--- a/packages/subsquid-pipes/src/core/query-builder.ts
+++ b/packages/subsquid-pipes/src/core/query-builder.ts
@@ -1,9 +1,12 @@
 import { Query } from '~/portal-client/index.js'
 
+import { sha256Hex, stringToArrayBuffer } from '../internal/hash.js'
 import { Heap } from '../internal/heap.js'
 import { BlockRangeConfigurationError } from './errors.js'
 import { PortalRange, parsePortalRange } from './portal-range.js'
 import { QueryAwareTransformer, SetupQueryFn, TransformerArgs } from './transformer.js'
+
+export { stringToArrayBuffer }
 
 /**
  * A range of blocks with inclusive boundaries
@@ -167,6 +170,44 @@ export abstract class QueryBuilder<F extends {}, R = any> {
 export interface Portal {
   getHead(): Promise<{ number: number; hash: string } | undefined>
   resolveTimestamp(seconds: number): Promise<number>
+}
+
+/**
+ * Resolves a {@link NaturalRange} to concrete block numbers.
+ *
+ * - `Date` boundaries are resolved to block numbers via `portal.resolveTimestamp`
+ *   (same semantics as {@link QueryBuilder.calculateRanges}).
+ * - Returns `null` for `from: 'latest'` — such a range has no historical span to resolve.
+ */
+export async function resolveNaturalRange(portal: Portal, range: NaturalRange): Promise<Range | null> {
+  if (range.from === 'latest') return null
+
+  const resolveValue = async (value: number | Date): Promise<number> => {
+    if (typeof value === 'number') return value
+
+    try {
+      return await portal.resolveTimestamp(dateToSeconds(value))
+    } catch (error) {
+      if (error instanceof Error && error.message.toLowerCase().includes('no chunk found for timestamp')) {
+        throw new BlockRangeConfigurationError(
+          `Failed to resolve timestamp ${value.toISOString()} to a block number. The block for this timestamp may not have been produced yet.`,
+        )
+      }
+      throw error
+    }
+  }
+
+  const from = await resolveValue(range.from)
+  const to = range.to !== undefined ? await resolveValue(range.to) : undefined
+
+  // non-strict comparison on purpose. `to` can be zero
+  if (to != null && to < from) {
+    throw new BlockRangeConfigurationError(
+      `Invalid block range: 'from' (${from}) must be less than or equal to 'to' (${to})`,
+    )
+  }
+
+  return { from, to }
 }
 
 function dateToSeconds(date: Date): number {
@@ -434,29 +475,4 @@ export async function hashQuery(query: Query): Promise<string> {
   const { fromBlock, toBlock, parentBlockHash, ...unique } = query
 
   return await sha256Hex(JSON.stringify(unique))
-}
-
-/**
- * UTF-8 encode a JS string to ArrayBuffer.
- * @internal
- */
-export function stringToArrayBuffer(str: string): Uint8Array {
-  if (typeof TextEncoder !== 'undefined') {
-    return new TextEncoder().encode(str)
-  }
-
-  throw new Error(
-    'TextEncoder is not supported in this environment. Please ensure you are running in a modern JavaScript environment that supports TextEncoder (Node.js 11+, modern browsers, or include a polyfill).',
-  )
-}
-
-async function sha256Hex(data: string): Promise<string> {
-  // globalThis.crypto is available in browsers, Node 18+, and Cloudflare Workers
-  if (typeof crypto === 'undefined' || !crypto.subtle) {
-    throw new Error(
-      'crypto.subtle is not supported in this environment. Please ensure you are running in a modern JavaScript environment that supports crypto.subtle (Node.js 18+, modern browsers, or include a polyfill).',
-    )
-  }
-  const d = await crypto.subtle.digest('SHA-256', stringToArrayBuffer(data))
-  return [...new Uint8Array(d)].map((b) => b.toString(16).padStart(2, '0')).join('')
 }

--- a/packages/subsquid-pipes/src/core/transformer.ts
+++ b/packages/subsquid-pipes/src/core/transformer.ts
@@ -150,7 +150,13 @@ export function createTransformer<In, Out>(options: TransformerOptions<In, Out>)
   return new Transformer<In, Out>(options)
 }
 
-export type SetupQueryFn<Query> = (ctx: { query: Query; logger: Logger }) => void | any | Promise<void | any>
+export type SetupQueryCtx<Query> = {
+  query: Query
+  logger: Logger
+  portal: PortalClient
+}
+
+export type SetupQueryFn<Query> = (ctx: SetupQueryCtx<Query>) => void | any | Promise<void | any>
 
 // FIXME STREAMS write docs
 export class QueryAwareTransformer<

--- a/packages/subsquid-pipes/src/evm/evm-decoder.test.ts
+++ b/packages/subsquid-pipes/src/evm/evm-decoder.test.ts
@@ -3,6 +3,7 @@ import * as p from '@subsquid/evm-codec'
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 
 import { PortalRange, QueryAwareTransformer } from '~/core/index.js'
+import { PortalClient } from '~/portal-client/client.js'
 import { encodeEvent, evmPortalMockStream, mockBlock, resetMockBlockCounter } from '~/testing/evm/index.js'
 import { MockPortal, MockResponse, createMockPortal, createTestLogger, readAll } from '~/testing/index.js'
 
@@ -26,12 +27,13 @@ import { contractFactoryStore } from './factory-adapters/sqlite.js'
 async function captureQueryBuilder(
   decoder: QueryAwareTransformer<any, any, EvmQueryBuilder<any>>,
   logger = createTestLogger(),
+  portal: PortalClient = {} as PortalClient,
 ) {
   const query = new EvmQueryBuilder()
   await decoder.setupQuery({
     query,
     logger,
-    // portal: {} as any,
+    portal,
   })
   return query
 }

--- a/packages/subsquid-pipes/src/evm/evm-decoder.ts
+++ b/packages/subsquid-pipes/src/evm/evm-decoder.ts
@@ -1,12 +1,22 @@
 import type { AbiEvent, EventParams } from '@subsquid/evm-abi'
 import { Codec, Sink } from '@subsquid/evm-codec'
 
-import { BatchContext, PortalRange, ProfilerOptions, Transformer, formatWarning, parsePortalRange } from '~/core/index.js'
+import {
+  BatchContext,
+  Logger,
+  PortalRange,
+  ProfilerOptions,
+  Transformer,
+  formatWarning,
+  parsePortalRange,
+} from '~/core/index.js'
+import { resolveNaturalRange } from '~/core/query-builder.js'
 import { arrayify, findDuplicates } from '~/internal/array.js'
+import { PortalClient } from '~/portal-client/client.js'
 import { Log, LogRequest } from '~/portal-client/query/evm.js'
 
 import { evmQuery } from './evm-query-builder.js'
-import { Factory } from './factory.js'
+import { Factory, TOO_MANY_CHILDREN } from './factory.js'
 
 export type FactoryEvent<T> = {
   contract: string
@@ -61,12 +71,8 @@ export type IndexedKeys<T> = {
   [K in keyof T]: T[K] extends { indexed: true } ? K : never
 }[keyof T]
 
-type CodecValueType<T extends AbiEvent<any>, K extends keyof T['params']> = T['params'][K] extends Codec<
-  any,
-  infer TOut
->
-  ? TOut
-  : never
+type CodecValueType<T extends AbiEvent<any>, K extends keyof T['params']> =
+  T['params'][K] extends Codec<any, infer TOut> ? TOut : never
 
 export type IndexedParamsInput<T extends AbiEvent<any>> = Partial<{
   [K in IndexedKeys<T['params']>]: CodecValueType<T, K> | CodecValueType<T, K>[]
@@ -251,16 +257,13 @@ function splitEvents<T extends AbiEvent<any>>(normalizedEvents: EventWithArgs<T>
   }
 }
 
-function buildEventRequests<T extends AbiEvent<any>, C extends Contracts>(
-  eventWithArgs: EventWithArgs<T>[],
-  contracts?: C,
-) {
+function buildEventRequests<T extends AbiEvent<any>>(eventWithArgs: EventWithArgs<T>[], address?: string[]) {
   return eventWithArgs
     .map<LogRequest | undefined>((event) => {
       const topics = buildEventTopics(event.event, event.params)
       return {
         ...topics,
-        address: Factory.isFactory(contracts) ? undefined : contracts,
+        address,
         transaction: true,
       }
     })
@@ -331,34 +334,90 @@ export function evmDecoder<T extends Events, C extends Contracts>({
     contracts && !Factory.isFactory(contracts) ? contracts.map((contract) => contract.toLowerCase()) : undefined
 
   const query = evmQuery().addFields(decodedEventFields)
+  let registration: Promise<void> | undefined
 
-  if (Factory.isFactory(contracts)) {
-    query.addLog({ range: decodedRange, request: contracts.buildFactoryEventRequest() })
+  const addChildEventRequests = (range: PortalRange, address?: string[]) => {
+    if (eventsWithoutParams.length > 0) {
+      query.addLog({
+        range,
+        request: {
+          address,
+          topic0: eventTopic0,
+          transaction: true,
+        },
+      })
+    }
+
+    for (const request of buildEventRequests(eventsWithParams, address)) {
+      query.addLog({ range, request })
+    }
   }
 
-  if (eventsWithoutParams.length > 0) {
-    query.addLog({
-      range: decodedRange,
-      request: {
-        address: !Factory.isFactory(contracts) ? contracts : undefined,
-        topic0: eventTopic0,
-        transaction: true,
-      },
-    })
+  /**
+   * Runs the pre-indexing phase and registers the split child-event requests:
+   * a server-side address filter for the pre-indexed range and a wildcard tail above it.
+   * Returns `null` when the caller should fall back to a single wildcard request.
+   */
+  const setupPreindexedRequests = async (
+    factory: Factory<any>,
+    ctx: { portal: PortalClient; logger: Logger },
+  ): Promise<number | null> => {
+    const resolved = await resolveNaturalRange(ctx.portal, decodedRange)
+    if (!resolved) return null
+
+    const watermark = await factory.ensurePreindexed({ portal: ctx.portal, logger: ctx.logger, range: resolved })
+    if (watermark === null) return null
+
+    const addresses = await factory.getChildAddresses()
+    if (addresses.length > factory.maxAddressFilterSize()) {
+      ctx.logger.warn(TOO_MANY_CHILDREN(addresses.length, factory.maxAddressFilterSize()))
+
+      return null
+    }
+
+    // Children discovered up to the watermark are final — historical child events can be
+    // filtered server-side. No children below the watermark means no child events there either.
+    if (addresses.length > 0) {
+      addChildEventRequests({ from: resolved.from, to: watermark }, addresses)
+    }
+
+    if (resolved.to === undefined || resolved.to > watermark) {
+      addChildEventRequests({ from: watermark + 1, to: resolved.to })
+    }
+
+    return watermark
   }
 
-  for (const request of buildEventRequests(eventsWithParams, contracts)) {
-    query.addLog({ range: decodedRange, request })
+  const registerRequests = async (ctx: { portal: PortalClient; logger: Logger }): Promise<void> => {
+    if (Factory.isFactory(contracts)) {
+      // The factory-creation request spans the full range: inline discovery keeps
+      // running above the pre-indexed boundary
+      query.addLog({ range: decodedRange, request: contracts.buildFactoryEventRequest() })
+
+      const watermark = contracts.preindexEnabled() ? await setupPreindexedRequests(contracts, ctx) : null
+
+      if (watermark === null) {
+        addChildEventRequests(decodedRange)
+      }
+    } else {
+      addChildEventRequests(decodedRange, contracts)
+    }
   }
 
   return query
     .build({
-      setupQuery: (config) => {
+      setupQuery: async (config) => {
         const allEventTopics = normalizedEvents.map(({ event }) => event.topic)
         const duplicates = findDuplicates(allEventTopics)
         if (duplicates.length) {
           config.logger.error(DUPLICATED_EVENTS(getDuplicateEvents(events, duplicates)))
         }
+
+        // Memoized as a promise: concurrent setup calls wait for the same registration,
+        // and a failed one stays rejected — a retried stream start fails loudly instead
+        // of silently merging a query with no child-event requests
+        registration ??= registerRequests(config)
+        await registration
 
         config.query.merge(query)
       },

--- a/packages/subsquid-pipes/src/evm/evm-rpc-latency-watcher.test.ts
+++ b/packages/subsquid-pipes/src/evm/evm-rpc-latency-watcher.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
+import { PortalClient } from '~/portal-client/client.js'
 import { createTestLogger } from '~/testing/test-logger.js'
 
 import { EvmQueryBuilder } from './evm-query-builder.js'
@@ -17,7 +18,7 @@ describe('evmRpcLatencyWatcher factory', () => {
     transformer = evmRpcLatencyWatcher({ rpcUrl: ['ws://127.0.0.1:1'] })
 
     const builder = new EvmQueryBuilder<{ block: { number: true; timestamp: true } }>()
-    await transformer.setupQuery({ query: builder, logger: createTestLogger() })
+    await transformer.setupQuery({ query: builder, logger: createTestLogger(), portal: {} as PortalClient })
 
     expect(builder.getFields()).toEqual({
       block: { number: true, timestamp: true },
@@ -28,11 +29,9 @@ describe('evmRpcLatencyWatcher factory', () => {
     transformer = evmRpcLatencyWatcher({ rpcUrl: ['ws://127.0.0.1:1'] })
 
     const builder = new EvmQueryBuilder<{ block: { number: true; timestamp: true } }>()
-    await transformer.setupQuery({ query: builder, logger: createTestLogger() })
+    await transformer.setupQuery({ query: builder, logger: createTestLogger(), portal: {} as PortalClient })
 
     const requests = builder.getRequests()
-    expect(requests).toContainEqual(
-      expect.objectContaining({ range: { from: 'latest' } }),
-    )
+    expect(requests).toContainEqual(expect.objectContaining({ range: { from: 'latest' } }))
   })
 })

--- a/packages/subsquid-pipes/src/evm/factory-adapters/sqlite.ts
+++ b/packages/subsquid-pipes/src/evm/factory-adapters/sqlite.ts
@@ -1,5 +1,6 @@
 import { AbiEvent } from '@subsquid/evm-abi'
 
+import { Range } from '~/core/query-builder.js'
 import { SqliteOptions, SqliteSync, loadSqlite } from '~/drivers/sqlite/sqlite.js'
 import { jsonParse, jsonStringify } from '~/internal/json.js'
 
@@ -147,6 +148,28 @@ class SqliteFactoryAdapter<T extends EventArgs> implements FactoryPersistentAdap
     this.clearCache()
   }
 
+  async getPreindexedRange(key: string): Promise<Range | null> {
+    const row = this.#db.get<{ value: string }>('SELECT value FROM "metadata" WHERE id = ?', [`preindex:${key}`])
+    if (!row) return null
+
+    const range = jsonParse(row.value)
+    if (typeof range?.from !== 'number' || typeof range?.to !== 'number') return null
+
+    return range
+  }
+
+  async setPreindexedRange(key: string, range: Range): Promise<void> {
+    this.#db.exec(
+      `INSERT INTO "metadata" (id, value) VALUES (?, ?) ON CONFLICT (id) DO UPDATE SET "value" = excluded.value`,
+      [`preindex:${key}`, jsonStringify(range)],
+    )
+  }
+
+  /**
+   * Fork rollback. Intentionally leaves the preindex watermark untouched: the watermark
+   * is only ever advanced up to the finalized head, and forks can only happen above it
+   * (blockNumber >= finalized >= watermark), so pre-indexed children are never removed here.
+   */
   async remove(blockNumber: number): Promise<void> {
     this.#db.exec(`DELETE FROM factory WHERE block_number > ?`, [blockNumber])
     this.clearCache()

--- a/packages/subsquid-pipes/src/evm/factory-preindex.test.ts
+++ b/packages/subsquid-pipes/src/evm/factory-preindex.test.ts
@@ -1,0 +1,944 @@
+import { event, indexed } from '@subsquid/evm-abi'
+import * as p from '@subsquid/evm-codec'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PortalClient } from '~/portal-client/client.js'
+import { createMemoryTarget } from '~/targets/memory/memory-target.js'
+import { encodeEvent, mockBlock, resetMockBlockCounter } from '~/testing/evm/index.js'
+import { MockPortal, MockResponse, createMockPortal, createTestLogger, readAll } from '~/testing/index.js'
+
+import { evmDecoder } from './evm-decoder.js'
+import { evmPortalStream } from './evm-portal-source.js'
+import { EvmQueryBuilder } from './evm-query-builder.js'
+import { contractFactory, mergePreindexedRanges, preindexProgressHandlers, preindexScanRange } from './factory.js'
+import { contractFactoryStore } from './factory-adapters/sqlite.js'
+
+const POOL_CREATED_ABI = [
+  {
+    type: 'event' as const,
+    name: 'PoolCreated',
+    inputs: [
+      { name: 'token0', type: 'address', indexed: true },
+      { name: 'token1', type: 'address', indexed: true },
+      { name: 'fee', type: 'uint24', indexed: true },
+      { name: 'tickSpacing', type: 'int24', indexed: false },
+      { name: 'pool', type: 'address', indexed: false },
+    ],
+  },
+] as const
+
+const SWAP_ABI = [
+  {
+    type: 'event' as const,
+    name: 'Swap',
+    inputs: [
+      { name: 'sender', type: 'address', indexed: true },
+      { name: 'recipient', type: 'address', indexed: true },
+      { name: 'amount0', type: 'int256', indexed: false },
+      { name: 'amount1', type: 'int256', indexed: false },
+      { name: 'sqrtPriceX96', type: 'uint160', indexed: false },
+      { name: 'liquidity', type: 'uint128', indexed: false },
+      { name: 'tick', type: 'int24', indexed: false },
+    ],
+  },
+] as const
+
+const factoryAbi = {
+  PoolCreated: event(
+    '0x783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118',
+    'PoolCreated(address,address,uint24,int24,address)',
+    {
+      token0: indexed(p.address),
+      token1: indexed(p.address),
+      fee: indexed(p.uint24),
+      tickSpacing: p.int24,
+      pool: p.address,
+    },
+  ),
+}
+
+const poolAbi = {
+  Swap: event(
+    '0xc42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67',
+    'Swap(address,address,int256,int256,uint160,uint128,int24)',
+    {
+      sender: indexed(p.address),
+      recipient: indexed(p.address),
+      amount0: p.int256,
+      amount1: p.int256,
+      sqrtPriceX96: p.uint160,
+      liquidity: p.uint128,
+      tick: p.int24,
+    },
+  ),
+}
+
+// ── Addresses ──
+
+const UNISWAP_FACTORY = '0x1f98431c8ad98523631ae4a59f267346ea31f984' as `0x${string}`
+const WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as `0x${string}`
+const USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as `0x${string}`
+const USDT = '0xdac17f958d2ee523a2206206994597c13d831ec7' as `0x${string}`
+const WETH_USDC_POOL = '0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8' as `0x${string}`
+const USDT_USDC_POOL = '0x9db9e0e53058c89e5b94e29621a205198648425b' as `0x${string}`
+const UNKNOWN_POOL = '0xaaaaaac3a0ff1de082011efddc58f1908eb6e6d8' as `0x${string}`
+const SENDER = '0xdef1cafe0000000000000000000000000000dead' as `0x${string}`
+const RECIPIENT = '0xbeef0000000000000000000000000000deadbeef' as `0x${string}`
+
+// ── Helpers ──
+
+function encodePoolCreated(pool: `0x${string}`, token0 = WETH, token1 = USDC, fee = 3000, tickSpacing = 10) {
+  return encodeEvent({
+    abi: POOL_CREATED_ABI,
+    eventName: 'PoolCreated',
+    address: UNISWAP_FACTORY,
+    args: { token0, token1, fee, tickSpacing, pool },
+  })
+}
+
+function encodeSwap(address: `0x${string}`) {
+  return encodeEvent({
+    abi: SWAP_ABI,
+    eventName: 'Swap',
+    address,
+    args: { sender: SENDER, recipient: RECIPIENT, amount0: 1n, amount1: 2n, sqrtPriceX96: 3n, liquidity: 4n, tick: 5 },
+  })
+}
+
+/** Collects every /stream request body so the query shape can be asserted after the run. */
+function captureQueries(queries: any[]) {
+  return (query: any) => queries.push(query)
+}
+
+function streamResponse(blocks: ReturnType<typeof mockBlock>[], onRequest?: (query: any) => void): MockResponse {
+  const last = blocks[blocks.length - 1]
+
+  return {
+    statusCode: 200,
+    data: blocks,
+    head: { finalized: { number: last.header.number, hash: last.header.hash } },
+    validateRequest: onRequest,
+  }
+}
+
+function createPoolFactory(db: any, preindex: boolean | { maxAddressFilterSize?: number } = true) {
+  return contractFactory({
+    address: UNISWAP_FACTORY,
+    event: factoryAbi.PoolCreated,
+    childAddressField: 'pool',
+    database: db,
+    preindex,
+  })
+}
+
+describe('Factory preindex', () => {
+  let mockPortal: MockPortal | undefined
+
+  beforeEach(() => {
+    resetMockBlockCounter()
+    mockPortal = undefined
+  })
+
+  afterEach(async () => {
+    await mockPortal?.close()
+  })
+
+  it('runs the pre-pass up to the finalized head, then splits the main query', async () => {
+    const queries: any[] = []
+
+    mockPortal = await createMockPortal(
+      [
+        // pre-pass scan [1..5]: factory events only
+        streamResponse(
+          [
+            mockBlock({ number: 1, transactions: [{ logs: [encodePoolCreated(WETH_USDC_POOL)] }] }),
+            mockBlock({ number: 5 }),
+          ],
+          captureQueries(queries),
+        ),
+        // main loop [1..5]: server-side child address filter
+        streamResponse(
+          [
+            mockBlock({ number: 1, transactions: [{ logs: [encodePoolCreated(WETH_USDC_POOL)] }] }),
+            mockBlock({ number: 4, transactions: [{ logs: [encodeSwap(WETH_USDC_POOL)] }] }),
+            mockBlock({ number: 5 }),
+          ],
+          captureQueries(queries),
+        ),
+        // main loop [6..10]: wildcard tail with client-side filtering
+        streamResponse(
+          [
+            mockBlock({ number: 7, transactions: [{ logs: [encodeSwap(UNKNOWN_POOL)] }] }),
+            mockBlock({ number: 8, transactions: [{ logs: [encodeSwap(WETH_USDC_POOL)] }] }),
+            mockBlock({ number: 10 }),
+          ],
+          captureQueries(queries),
+        ),
+      ],
+      { head: { finalized: { number: 5, hash: '0x5' } } },
+    )
+
+    const db = await contractFactoryStore({ path: ':memory:' })
+    const poolFactory = createPoolFactory(db)
+
+    const stream = evmPortalStream({
+      id: 'test',
+      portal: mockPortal.url,
+      outputs: evmDecoder({
+        range: { from: 1, to: 10 },
+        contracts: poolFactory,
+        events: { swaps: poolAbi.Swap },
+      }).pipe((d) => d.swaps),
+    })
+
+    const res = await readAll(stream)
+
+    // Only swaps from the known child pool are decoded, in both ranges
+    expect(res).toHaveLength(2)
+    expect(res.map((s) => s.block.number)).toEqual([4, 8])
+    expect(res.every((s) => s.contract === WETH_USDC_POOL)).toBe(true)
+    expect(res.every((s) => s.factory?.event.pool === WETH_USDC_POOL)).toBe(true)
+
+    expect(queries).toHaveLength(3)
+
+    // Pre-pass: factory-creation events only, clamped to the finalized head
+    expect(queries[0].fromBlock).toBe(1)
+    expect(queries[0].toBlock).toBe(5)
+    expect(queries[0].logs).toEqual([
+      { address: [UNISWAP_FACTORY], topic0: [factoryAbi.PoolCreated.topic], transaction: true },
+    ])
+
+    // Historical range: factory request + server-side child address filter
+    expect(queries[1].fromBlock).toBe(1)
+    expect(queries[1].toBlock).toBe(5)
+    expect(queries[1].logs).toHaveLength(2)
+    expect(queries[1].logs).toContainEqual({ address: [UNISWAP_FACTORY], topic0: [factoryAbi.PoolCreated.topic] })
+    expect(queries[1].logs).toContainEqual({
+      address: [WETH_USDC_POOL],
+      topic0: [poolAbi.Swap.topic],
+      transaction: true,
+    })
+
+    // Tail: factory request + wildcard (no address) child request
+    expect(queries[2].fromBlock).toBe(6)
+    expect(queries[2].toBlock).toBe(10)
+    expect(queries[2].logs).toHaveLength(2)
+    expect(queries[2].logs).toContainEqual({ address: [UNISWAP_FACTORY], topic0: [factoryAbi.PoolCreated.topic] })
+    expect(queries[2].logs).toContainEqual({ topic0: [poolAbi.Swap.topic], transaction: true })
+
+    // Pre-indexed progress is persisted
+    const key = await poolFactory.preindexKey()
+    expect(await db.getPreindexedRange(key)).toEqual({ from: 1, to: 5 })
+  })
+
+  it('skips the historical child request entirely when the pre-pass finds no children', async () => {
+    const queries: any[] = []
+
+    mockPortal = await createMockPortal(
+      [
+        // pre-pass scan [1..5]: no factory events
+        streamResponse([mockBlock({ number: 5 })], captureQueries(queries)),
+        // main loop [1..5]: no children yet — factory request only
+        streamResponse([mockBlock({ number: 5 })], captureQueries(queries)),
+        // main loop [6..10]: inline discovery still works in the wildcard tail
+        streamResponse(
+          [
+            mockBlock({ number: 7, transactions: [{ logs: [encodePoolCreated(WETH_USDC_POOL)] }] }),
+            mockBlock({ number: 8, transactions: [{ logs: [encodeSwap(WETH_USDC_POOL)] }] }),
+            mockBlock({ number: 10 }),
+          ],
+          captureQueries(queries),
+        ),
+      ],
+      { head: { finalized: { number: 5, hash: '0x5' } } },
+    )
+
+    const db = await contractFactoryStore({ path: ':memory:' })
+
+    const stream = evmPortalStream({
+      id: 'test',
+      portal: mockPortal.url,
+      outputs: evmDecoder({
+        range: { from: 1, to: 10 },
+        contracts: createPoolFactory(db),
+        events: { swaps: poolAbi.Swap },
+      }).pipe((d) => d.swaps),
+    })
+
+    const res = await readAll(stream)
+
+    expect(res).toHaveLength(1)
+    expect(res[0].block.number).toBe(8)
+    expect(res[0].factory?.blockNumber).toBe(7)
+
+    expect(queries).toHaveLength(3)
+    // No children ≤ watermark means no child events there either — only the factory request remains
+    expect(queries[1].logs).toEqual([{ address: [UNISWAP_FACTORY], topic0: [factoryAbi.PoolCreated.topic] }])
+    // The wildcard tail is unaffected
+    expect(queries[2].logs).toContainEqual({ topic0: [poolAbi.Swap.topic], transaction: true })
+  })
+
+  it('scans only the gap above the covered range on restart', async () => {
+    const db = await contractFactoryStore({ path: ':memory:' })
+
+    // First run: pre-pass covers [1..5]
+    {
+      const queries: any[] = []
+      mockPortal = await createMockPortal(
+        [
+          streamResponse(
+            [
+              mockBlock({ number: 1, transactions: [{ logs: [encodePoolCreated(WETH_USDC_POOL)] }] }),
+              mockBlock({ number: 5 }),
+            ],
+            captureQueries(queries),
+          ),
+          streamResponse([mockBlock({ number: 5 })], captureQueries(queries)),
+          streamResponse([mockBlock({ number: 10 })], captureQueries(queries)),
+        ],
+        { head: { finalized: { number: 5, hash: '0x5' } } },
+      )
+
+      await readAll(
+        evmPortalStream({
+          id: 'test',
+          portal: mockPortal.url,
+          outputs: evmDecoder({
+            range: { from: 1, to: 10 },
+            contracts: createPoolFactory(db),
+            events: { swaps: poolAbi.Swap },
+          }).pipe((d) => d.swaps),
+        }),
+      )
+
+      expect(queries[0].fromBlock).toBe(1)
+      expect(queries[0].toBlock).toBe(5)
+
+      await mockPortal.close()
+    }
+
+    // Second run: finalized head advanced to 8 — the pre-pass only scans [6..8]
+    {
+      const queries: any[] = []
+      mockPortal = await createMockPortal(
+        [
+          streamResponse(
+            [
+              mockBlock({ number: 6, transactions: [{ logs: [encodePoolCreated(USDT_USDC_POOL, USDT)] }] }),
+              mockBlock({ number: 8 }),
+            ],
+            captureQueries(queries),
+          ),
+          streamResponse([mockBlock({ number: 8 })], captureQueries(queries)),
+          streamResponse([mockBlock({ number: 10 })], captureQueries(queries)),
+        ],
+        { head: { finalized: { number: 8, hash: '0x8' } } },
+      )
+
+      const poolFactory = createPoolFactory(db)
+
+      await readAll(
+        evmPortalStream({
+          id: 'test',
+          portal: mockPortal.url,
+          outputs: evmDecoder({
+            range: { from: 1, to: 10 },
+            contracts: poolFactory,
+            events: { swaps: poolAbi.Swap },
+          }).pipe((d) => d.swaps),
+        }),
+      )
+
+      // Gap scan only
+      expect(queries[0].fromBlock).toBe(6)
+      expect(queries[0].toBlock).toBe(8)
+
+      // The historical filter covers [1..8] and includes children from both runs
+      expect(queries[1].fromBlock).toBe(1)
+      expect(queries[1].toBlock).toBe(8)
+      expect(queries[1].logs).toContainEqual({
+        address: expect.arrayContaining([WETH_USDC_POOL, USDT_USDC_POOL]),
+        topic0: [poolAbi.Swap.topic],
+        transaction: true,
+      })
+
+      expect(queries[2].fromBlock).toBe(9)
+      expect(queries[2].toBlock).toBe(10)
+
+      const key = await poolFactory.preindexKey()
+      expect(await db.getPreindexedRange(key)).toEqual({ from: 1, to: 8 })
+    }
+  })
+
+  it('re-scans from scratch when factory params change (new progress key)', async () => {
+    const db = await contractFactoryStore({ path: ':memory:' })
+
+    const getPipeline = async (token0: string, queries: any[]) => {
+      mockPortal = await createMockPortal(
+        [
+          streamResponse(
+            [
+              mockBlock({
+                number: 1,
+                transactions: [
+                  { logs: [encodePoolCreated(WETH_USDC_POOL, WETH), encodePoolCreated(USDT_USDC_POOL, USDT)] },
+                ],
+              }),
+              mockBlock({ number: 5 }),
+            ],
+            captureQueries(queries),
+          ),
+          streamResponse([mockBlock({ number: 5 })], captureQueries(queries)),
+        ],
+        { head: { finalized: { number: 5, hash: '0x5' } } },
+      )
+
+      const factory = contractFactory({
+        address: UNISWAP_FACTORY,
+        event: { event: factoryAbi.PoolCreated, params: { token0 } },
+        childAddressField: 'pool',
+        database: db,
+        preindex: true,
+      })
+
+      return {
+        factory,
+        stream: evmPortalStream({
+          id: 'test',
+          portal: mockPortal.url,
+          outputs: evmDecoder({
+            range: { from: 1, to: 5 },
+            contracts: factory,
+            events: { swaps: poolAbi.Swap },
+          }).pipe((d) => d.swaps),
+        }),
+      }
+    }
+
+    const firstQueries: any[] = []
+    const first = await getPipeline(WETH, firstQueries)
+    await readAll(first.stream)
+    expect(firstQueries[0].fromBlock).toBe(1)
+    await mockPortal?.close()
+
+    const secondQueries: any[] = []
+    const second = await getPipeline(USDT, secondQueries)
+    await readAll(second.stream)
+
+    // Different params → different key → full re-scan instead of a gap scan
+    expect(secondQueries[0].fromBlock).toBe(1)
+    expect(secondQueries[0].toBlock).toBe(5)
+
+    // Both progress rows coexist under their own keys
+    const firstKey = await first.factory.preindexKey()
+    const secondKey = await second.factory.preindexKey()
+    expect(firstKey).not.toBe(secondKey)
+    expect(await db.getPreindexedRange(firstKey)).toEqual({ from: 1, to: 5 })
+    expect(await db.getPreindexedRange(secondKey)).toEqual({ from: 1, to: 5 })
+
+    // And the historical filter only picks up children matching the current params
+    expect(secondQueries[1].logs).toContainEqual({
+      address: [USDT_USDC_POOL],
+      topic0: [poolAbi.Swap.topic],
+      transaction: true,
+    })
+  })
+
+  it('persists progress per batch and resumes an interrupted pre-pass from it', async () => {
+    const db = await contractFactoryStore({ path: ':memory:' })
+    const spy = vi.spyOn(db, 'setPreindexedRange')
+
+    // First run stops at finalized head 3 — as if the process was interrupted before
+    // the chain range was fully covered
+    mockPortal = await createMockPortal(
+      [
+        streamResponse([
+          mockBlock({ number: 2, transactions: [{ logs: [encodePoolCreated(WETH_USDC_POOL)] }] }),
+          mockBlock({ number: 3 }),
+        ]),
+      ],
+      { head: { finalized: { number: 3, hash: '0x3' } } },
+    )
+
+    const firstRun = createPoolFactory(db)
+    expect(
+      await firstRun.ensurePreindexed({
+        portal: new PortalClient({ url: mockPortal.url }),
+        logger: createTestLogger(),
+        range: { from: 1, to: 10 },
+      }),
+    ).toBe(3)
+
+    // Progress was persisted with the batch, not only at the end
+    expect(spy.mock.calls.map(([, range]) => range)).toEqual([
+      { from: 1, to: 3 },
+      { from: 1, to: 3 },
+    ])
+    await mockPortal.close()
+
+    // Second run: the finalized head advanced — only the gap above the covered range is scanned
+    const queries: any[] = []
+    mockPortal = await createMockPortal(
+      [
+        streamResponse(
+          [
+            mockBlock({ number: 7, transactions: [{ logs: [encodePoolCreated(USDT_USDC_POOL, USDT)] }] }),
+            mockBlock({ number: 10 }),
+          ],
+          captureQueries(queries),
+        ),
+      ],
+      { head: { finalized: { number: 10, hash: '0xa' } } },
+    )
+
+    const secondRun = createPoolFactory(db)
+    expect(
+      await secondRun.ensurePreindexed({
+        portal: new PortalClient({ url: mockPortal.url }),
+        logger: createTestLogger(),
+        range: { from: 1, to: 10 },
+      }),
+    ).toBe(10)
+
+    expect(queries[0].fromBlock).toBe(4)
+    expect(queries[0].toBlock).toBe(10)
+
+    const key = await secondRun.preindexKey()
+    expect(await db.getPreindexedRange(key)).toEqual({ from: 1, to: 10 })
+    expect(await db.all()).toHaveLength(2)
+  })
+
+  it('removes children discovered in the wildcard tail on fork, keeping the covered range', async () => {
+    const FORKED_POOL = '0x8ad599c3a0ff1de082011efddc58f1908eb6e6d7' as const
+
+    mockPortal = await createMockPortal(
+      [
+        // pre-pass scan [1..1]
+        streamResponse([mockBlock({ number: 1, hash: '0x1' })]),
+        // main loop [1..1]: factory request only (no children)
+        streamResponse([mockBlock({ number: 1, hash: '0x1' })]),
+        // main loop [2..3] wildcard: block 2 will be forked
+        {
+          statusCode: 200,
+          data: [mockBlock({ number: 2, hash: '0x2', transactions: [{ logs: [encodePoolCreated(FORKED_POOL)] }] })],
+          head: { finalized: { number: 1, hash: '0x1' } },
+        },
+        {
+          statusCode: 409,
+          data: { previousBlocks: [{ number: 1, hash: '0x1' }] },
+        },
+        // resumed [2..3]: swap from a pool the forked-out event had registered
+        {
+          statusCode: 200,
+          data: [
+            mockBlock({ number: 2, hash: '0x2a', transactions: [{ logs: [encodeSwap(FORKED_POOL)] }] }),
+            mockBlock({ number: 3, hash: '0x3a' }),
+          ],
+          head: { finalized: { number: 3, hash: '0x3a' } },
+        },
+      ],
+      { head: { finalized: { number: 1, hash: '0x1' } } },
+    )
+
+    const db = await contractFactoryStore({ path: ':memory:' })
+    const poolFactory = createPoolFactory(db)
+    const res: any[] = []
+
+    await evmPortalStream({
+      id: 'test-factory',
+      portal: { url: mockPortal.url },
+      outputs: evmDecoder({
+        range: { from: 1, to: 3 },
+        contracts: poolFactory,
+        events: { swaps: poolAbi.Swap },
+      }).pipe((d) => d.swaps.map((s) => ({ ...s, blockNumber: s.block.number }))),
+    }).pipeTo(
+      createMemoryTarget({
+        onData: (data) => {
+          res.push(...data)
+        },
+      }),
+    )
+
+    // The forked-out PoolCreated was rolled back, so its pool's swaps are not decoded
+    expect(res).toHaveLength(0)
+    expect(await db.all()).toHaveLength(0)
+
+    // The pre-indexed range only ever covers finalized blocks — forks never invalidate it
+    const key = await poolFactory.preindexKey()
+    expect(await db.getPreindexedRange(key)).toEqual({ from: 1, to: 1 })
+  })
+
+  it('falls back to a single wildcard pass when the dataset has no finalized head', async () => {
+    const queries: any[] = []
+
+    // No `head` option: GET /finalized-head responds 404
+    mockPortal = await createMockPortal([
+      streamResponse(
+        [
+          mockBlock({ number: 1, transactions: [{ logs: [encodePoolCreated(WETH_USDC_POOL)] }] }),
+          mockBlock({ number: 2, transactions: [{ logs: [encodeSwap(WETH_USDC_POOL)] }] }),
+          mockBlock({ number: 5 }),
+        ],
+        captureQueries(queries),
+      ),
+    ])
+
+    const db = await contractFactoryStore({ path: ':memory:' })
+
+    const res = await readAll(
+      evmPortalStream({
+        id: 'test',
+        portal: mockPortal.url,
+        outputs: evmDecoder({
+          range: { from: 1, to: 5 },
+          contracts: createPoolFactory(db),
+          events: { swaps: poolAbi.Swap },
+        }).pipe((d) => d.swaps),
+      }),
+    )
+
+    expect(res).toHaveLength(1)
+
+    // Single pass over the whole range, wildcard child request
+    expect(queries).toHaveLength(1)
+    expect(queries[0].fromBlock).toBe(1)
+    expect(queries[0].toBlock).toBe(5)
+    expect(queries[0].logs).toContainEqual({ topic0: [poolAbi.Swap.topic], transaction: true })
+  })
+
+  it('falls back to a wildcard pass when the child set exceeds maxAddressFilterSize', async () => {
+    const queries: any[] = []
+
+    mockPortal = await createMockPortal(
+      [
+        // pre-pass discovers two children — above the threshold of 1
+        streamResponse(
+          [
+            mockBlock({
+              number: 1,
+              transactions: [
+                { logs: [encodePoolCreated(WETH_USDC_POOL, WETH), encodePoolCreated(USDT_USDC_POOL, USDT)] },
+              ],
+            }),
+            mockBlock({ number: 5 }),
+          ],
+          captureQueries(queries),
+        ),
+        // main loop: single wildcard pass over the whole range
+        streamResponse(
+          [mockBlock({ number: 4, transactions: [{ logs: [encodeSwap(WETH_USDC_POOL)] }] }), mockBlock({ number: 10 })],
+          captureQueries(queries),
+        ),
+      ],
+      { head: { finalized: { number: 5, hash: '0x5' } } },
+    )
+
+    const db = await contractFactoryStore({ path: ':memory:' })
+
+    const res = await readAll(
+      evmPortalStream({
+        id: 'test',
+        portal: mockPortal.url,
+        outputs: evmDecoder({
+          range: { from: 1, to: 10 },
+          contracts: createPoolFactory(db, { maxAddressFilterSize: 1 }),
+          events: { swaps: poolAbi.Swap },
+        }).pipe((d) => d.swaps),
+      }),
+    )
+
+    expect(res).toHaveLength(1)
+
+    expect(queries).toHaveLength(2)
+    expect(queries[1].fromBlock).toBe(1)
+    expect(queries[1].toBlock).toBe(10)
+    expect(queries[1].logs).toContainEqual({ topic0: [poolAbi.Swap.topic], transaction: true })
+  })
+
+  it('serializes shared-factory pre-passes and re-scans when a later range extends below the covered one', async () => {
+    const queries: any[] = []
+
+    mockPortal = await createMockPortal(
+      [
+        // first caller's pre-pass scans its own range [5..10]
+        streamResponse(
+          [
+            mockBlock({ number: 5, transactions: [{ logs: [encodePoolCreated(WETH_USDC_POOL)] }] }),
+            mockBlock({ number: 10 }),
+          ],
+          captureQueries(queries),
+        ),
+        // second caller's range starts below the covered one — full re-scan [1..10]
+        streamResponse(
+          [
+            mockBlock({ number: 2, transactions: [{ logs: [encodePoolCreated(USDT_USDC_POOL, USDT)] }] }),
+            mockBlock({ number: 10 }),
+          ],
+          captureQueries(queries),
+        ),
+      ],
+      { head: { finalized: { number: 10, hash: '0xa' } } },
+    )
+
+    const db = await contractFactoryStore({ path: ':memory:' })
+    const poolFactory = createPoolFactory(db)
+    const portal = new PortalClient({ url: mockPortal.url })
+    const logger = createTestLogger()
+
+    const [narrow, wide] = await Promise.all([
+      poolFactory.ensurePreindexed({ portal, logger, range: { from: 5, to: 10 } }),
+      poolFactory.ensurePreindexed({ portal, logger, range: { from: 1, to: 10 } }),
+    ])
+
+    expect(narrow).toBe(10)
+    expect(wide).toBe(10)
+
+    // The runs never overlap: the narrow scan completes first, then the wide one re-scans below it
+    expect(queries).toHaveLength(2)
+    expect(queries[0].fromBlock).toBe(5)
+    expect(queries[0].toBlock).toBe(10)
+    expect(queries[1].fromBlock).toBe(1)
+    expect(queries[1].toBlock).toBe(10)
+
+    // Children from both scans are persisted and the widest range is covered
+    expect(await db.all()).toHaveLength(2)
+    expect(await db.getPreindexedRange(await poolFactory.preindexKey())).toEqual({ from: 1, to: 10 })
+  })
+
+  it('runs the shared-factory pre-pass once when the ranges match', async () => {
+    const queries: any[] = []
+
+    mockPortal = await createMockPortal(
+      [
+        streamResponse(
+          [
+            mockBlock({ number: 1, transactions: [{ logs: [encodePoolCreated(WETH_USDC_POOL)] }] }),
+            mockBlock({ number: 10 }),
+          ],
+          captureQueries(queries),
+        ),
+      ],
+      { head: { finalized: { number: 10, hash: '0xa' } } },
+    )
+
+    const db = await contractFactoryStore({ path: ':memory:' })
+    const poolFactory = createPoolFactory(db)
+    const portal = new PortalClient({ url: mockPortal.url })
+    const logger = createTestLogger()
+
+    const results = await Promise.all([
+      poolFactory.ensurePreindexed({ portal, logger, range: { from: 1, to: 10 } }),
+      poolFactory.ensurePreindexed({ portal, logger, range: { from: 1, to: 10 } }),
+    ])
+
+    expect(results).toEqual([10, 10])
+
+    // The second run found the range already covered and did not hit the stream again
+    expect(queries).toHaveLength(1)
+  })
+
+  it('stops the pre-pass mid-scan once the child set crosses the cap and resumes after raising it', async () => {
+    const db = await contractFactoryStore({ path: ':memory:' })
+
+    mockPortal = await createMockPortal(
+      [
+        // [1..2]: the first pool — still within the cap of 1
+        streamResponse([
+          mockBlock({ number: 1, transactions: [{ logs: [encodePoolCreated(WETH_USDC_POOL, WETH)] }] }),
+          mockBlock({ number: 2 }),
+        ]),
+        // [3]: the second pool crosses the cap — the scan must stop here
+        streamResponse([mockBlock({ number: 3, transactions: [{ logs: [encodePoolCreated(USDT_USDC_POOL, USDT)] }] })]),
+        // [4..10]: must never be processed
+        streamResponse([mockBlock({ number: 10 })]),
+      ],
+      { head: { finalized: { number: 10, hash: '0xa' } } },
+    )
+
+    const entries: Record<string, any>[] = []
+    const capped = createPoolFactory(db, { maxAddressFilterSize: 1 })
+    const result = await capped.ensurePreindexed({
+      // maxBytes: 1 delivers every response as its own batch instead of coalescing them
+      portal: new PortalClient({ url: mockPortal.url, maxBytes: 1 }),
+      logger: createTestLogger({ capture: (entry) => entries.push(entry) }),
+      range: { from: 1, to: 10 },
+    })
+
+    expect(result).toBeNull()
+    expect(entries.map((entry) => entry['message']).join('\n')).toContain('more than 1')
+
+    // Progress stays honest: covered only up to the aborting batch, discovered children kept
+    expect(await db.getPreindexedRange(await capped.preindexKey())).toEqual({ from: 1, to: 3 })
+    expect(await db.all()).toHaveLength(2)
+    await mockPortal?.close()
+
+    // Raising the cap resumes the scan from the abort point instead of starting over
+    const queries: any[] = []
+    mockPortal = await createMockPortal([streamResponse([mockBlock({ number: 10 })], captureQueries(queries))], {
+      head: { finalized: { number: 10, hash: '0xa' } },
+    })
+
+    const raised = createPoolFactory(db)
+    expect(
+      await raised.ensurePreindexed({
+        portal: new PortalClient({ url: mockPortal.url }),
+        logger: createTestLogger(),
+        range: { from: 1, to: 10 },
+      }),
+    ).toBe(10)
+
+    expect(queries[0].fromBlock).toBe(4)
+    expect(queries[0].toBlock).toBe(10)
+    expect(await db.getPreindexedRange(await raised.preindexKey())).toEqual({ from: 1, to: 10 })
+  })
+
+  it('skips the gap scan entirely when the persisted children already exceed the cap', async () => {
+    const db = await contractFactoryStore({ path: ':memory:' })
+
+    // Seed: a completed scan [1..5] discovering two pools under the default cap
+    mockPortal = await createMockPortal(
+      [
+        streamResponse([
+          mockBlock({
+            number: 1,
+            transactions: [
+              { logs: [encodePoolCreated(WETH_USDC_POOL, WETH), encodePoolCreated(USDT_USDC_POOL, USDT)] },
+            ],
+          }),
+          mockBlock({ number: 5 }),
+        ]),
+      ],
+      { head: { finalized: { number: 5, hash: '0x5' } } },
+    )
+
+    await createPoolFactory(db).ensurePreindexed({
+      portal: new PortalClient({ url: mockPortal.url }),
+      logger: createTestLogger(),
+      range: { from: 1, to: 10 },
+    })
+    await mockPortal?.close()
+
+    // Restart with a cap of 1: the gap [6..10] must not be scanned at all
+    const queries: any[] = []
+    mockPortal = await createMockPortal([streamResponse([mockBlock({ number: 10 })], captureQueries(queries))], {
+      head: { finalized: { number: 10, hash: '0xa' } },
+    })
+
+    const entries: Record<string, any>[] = []
+    const capped = createPoolFactory(db, { maxAddressFilterSize: 1 })
+    const result = await capped.ensurePreindexed({
+      portal: new PortalClient({ url: mockPortal.url }),
+      logger: createTestLogger({ capture: (entry) => entries.push(entry) }),
+      range: { from: 1, to: 10 },
+    })
+
+    expect(result).toBeNull()
+    expect(queries).toHaveLength(0)
+    expect(entries.map((entry) => entry['message']).join('\n')).toContain('more than 1')
+    expect(await db.getPreindexedRange(await capped.preindexKey())).toEqual({ from: 1, to: 5 })
+  })
+
+  it('logs the pre-pass under a factory preindex prefix, without a duplicate start line', async () => {
+    mockPortal = await createMockPortal(
+      [
+        streamResponse([
+          mockBlock({ number: 1, transactions: [{ logs: [encodePoolCreated(WETH_USDC_POOL)] }] }),
+          mockBlock({ number: 10 }),
+        ]),
+      ],
+      { head: { finalized: { number: 10, hash: '0xa' } } },
+    )
+
+    const db = await contractFactoryStore({ path: ':memory:' })
+    const poolFactory = createPoolFactory(db)
+
+    const entries: Record<string, any>[] = []
+    await poolFactory.ensurePreindexed({
+      portal: new PortalClient({ url: mockPortal.url }),
+      logger: createTestLogger({ capture: (entry) => entries.push(entry) }),
+      range: { from: 1, to: 10 },
+    })
+
+    const messages = entries.map((entry) => entry['message'])
+    expect(messages).toContainEqual(expect.stringContaining('factory preindex: scanning blocks 1…10'))
+    expect(messages).toContainEqual(expect.stringContaining('factory preindex: finished'))
+
+    // The nested scan stream must not announce itself as if the main loop started
+    expect(messages.filter((message) => String(message).includes('Start indexing'))).toHaveLength(0)
+  })
+
+  it('prefixes pre-pass progress ticks and keeps the start hook silent', () => {
+    const entries: Record<string, any>[] = []
+    const logger = createTestLogger({ capture: (entry) => entries.push(entry) })
+
+    const progress = {
+      state: { initial: 1, last: 100, current: 50, percent: 50, etaSeconds: 90 },
+      interval: {
+        requests: {
+          total: { count: 0 },
+          successful: { count: 0, percent: 0 },
+          rateLimited: { count: 0, percent: 0 },
+          failed: { count: 0, percent: 0 },
+        },
+        processedBlocks: { count: 50, perSecond: 25 },
+        bytesDownloaded: { count: 1024, perSecond: 512 },
+      },
+    }
+
+    const handlers = preindexProgressHandlers()
+    handlers.onStart?.({ state: { initial: 1 }, logger })
+    handlers.onProgress?.({ progress, logger })
+
+    expect(entries).toHaveLength(1)
+    expect(entries[0]['message']).toBe('factory preindex: 50 / 100 (50%), ETA: 1m 30s')
+    expect(entries[0]['blocks']).toBe('25 blocks/second')
+  })
+
+  it('fails loudly on a retried setup after the pre-pass failed, instead of silently dropping child requests', async () => {
+    const db = await contractFactoryStore({ path: ':memory:' })
+
+    const decoder = evmDecoder({
+      range: { from: 1, to: 10 },
+      contracts: createPoolFactory(db),
+      events: { swaps: poolAbi.Swap },
+    })
+
+    const portal = { getHead: () => Promise.reject(new Error('portal is down')) } as unknown as PortalClient
+
+    const setup = () => decoder.setupQuery({ query: new EvmQueryBuilder(), logger: createTestLogger(), portal })
+
+    await expect(setup()).rejects.toThrow('portal is down')
+
+    // A retry must not silently succeed with a query that carries no child-event requests
+    await expect(setup()).rejects.toThrow('portal is down')
+  })
+})
+
+describe('preindex range helpers', () => {
+  it('preindexScanRange covers first-run, gap, extended-history and up-to-date cases', () => {
+    // First run — no covered range yet
+    expect(preindexScanRange({ from: 1, to: 10 }, null)).toEqual({ from: 1, to: 10 })
+
+    // Upper gap
+    expect(preindexScanRange({ from: 1, to: 10 }, { from: 1, to: 5 })).toEqual({ from: 6, to: 10 })
+
+    // History extended below the covered range — full re-scan from the new lower bound
+    expect(preindexScanRange({ from: 1, to: 10 }, { from: 5, to: 10 })).toEqual({ from: 1, to: 10 })
+
+    // Already covered
+    expect(preindexScanRange({ from: 1, to: 10 }, { from: 1, to: 10 })).toBeNull()
+    expect(preindexScanRange({ from: 2, to: 8 }, { from: 1, to: 10 })).toBeNull()
+  })
+
+  it('mergePreindexedRanges merges contiguous ranges and drops disjoint coverage', () => {
+    expect(mergePreindexedRanges({ from: 1, to: 10 }, null)).toEqual({ from: 1, to: 10 })
+
+    // Adjacent and overlapping ranges merge
+    expect(mergePreindexedRanges({ from: 6, to: 10 }, { from: 1, to: 5 })).toEqual({ from: 1, to: 10 })
+    expect(mergePreindexedRanges({ from: 4, to: 10 }, { from: 1, to: 5 })).toEqual({ from: 1, to: 10 })
+
+    // A disjoint scan must not claim the skipped blocks in between
+    expect(mergePreindexedRanges({ from: 8, to: 10 }, { from: 1, to: 5 })).toEqual({ from: 8, to: 10 })
+  })
+})

--- a/packages/subsquid-pipes/src/evm/factory.ts
+++ b/packages/subsquid-pipes/src/evm/factory.ts
@@ -1,8 +1,13 @@
 import { AbiEvent } from '@subsquid/evm-abi'
 import type { Codec } from '@subsquid/evm-codec'
 
-import { BlockCursor, Logger, PortalRange, createTarget } from '~/core/index.js'
+import { BlockCursor, Logger, createTarget, formatWarning } from '~/core/index.js'
+import { ProgressTrackerOptions, formatProgressMessage } from '~/core/progress-tracker.js'
+import { Range } from '~/core/query-builder.js'
+import { HttpError } from '~/http-client/index.js'
 import { arrayify } from '~/internal/array.js'
+import { sha256Hex } from '~/internal/hash.js'
+import { jsonStringify } from '~/internal/json.js'
 import { PortalClient } from '~/portal-client/client.js'
 import { Log, LogRequest } from '~/portal-client/query/evm.js'
 
@@ -39,9 +44,45 @@ export interface FactoryPersistentAdapter<T extends InternalFactoryEvent<any>> {
   save(entities: T[]): Promise<void>
   remove(blockNumber: number): Promise<void>
   migrate(): Promise<void>
+  /**
+   * Optional: block range for which factory-creation events have been fully pre-indexed,
+   * keyed by a factory-config hash. Adapters that don't implement these degrade to
+   * re-scanning the full range on every start (safe — saving children is idempotent).
+   */
+  getPreindexedRange?(key: string): Promise<Range | null>
+  setPreindexedRange?(key: string, range: Range): Promise<void>
 }
 
 export type DecodedAbiEvent<T extends EventArgs> = ReturnType<AbiEvent<T>['decode']>
+
+export type PreindexOptions = {
+  /**
+   * Max number of child addresses inlined into the historical server-side filter.
+   * Above this threshold the decoder logs a warning and falls back to a wildcard
+   * (topic-only) query for the whole range.
+   *
+   * The address list is embedded into every portal stream request, so a large filter
+   * inflates each request body (~50 bytes per address) — keep it well below the
+   * portal's request-size limits.
+   *
+   * @default 5_000
+   */
+  maxAddressFilterSize?: number
+}
+
+export const DEFAULT_PREINDEX_MAX_ADDRESS_FILTER_SIZE = 5_000
+
+/** @internal */
+export const TOO_MANY_CHILDREN = (count: number, max: number) => {
+  return formatWarning({
+    title: `Factory has ${count} child contracts (more than ${max})`,
+    content: [
+      'The pre-indexed address list is too large for a server-side filter.',
+      'Falling back to a wildcard (topic-only) query for the whole range.',
+      'Raise `preindex.maxAddressFilterSize` to force the server-side filter — the scan resumes where it stopped.',
+    ],
+  })
+}
 
 export type ContractFactoryOptions<T extends EventArgs> = {
   address: string | string[]
@@ -54,11 +95,26 @@ export type ContractFactoryOptions<T extends EventArgs> = {
   database:
     | FactoryPersistentAdapter<InternalFactoryEvent<any>>
     | Promise<FactoryPersistentAdapter<InternalFactoryEvent<any>>>
+  /**
+   * Runs an explicit pre-indexing phase before the main loop starts:
+   * all factory-creation events up to the finalized head are scanned first and the
+   * discovered child addresses are persisted to the factory database. The main loop then
+   * streams child events with a server-side address filter for the pre-indexed range
+   * (fast backfill) and falls back to a wildcard (topic-only) query above it.
+   *
+   * Progress is persisted, so a completed (or interrupted) pre-index run is reused on
+   * restart — only the gap up to the current finalized head is re-scanned.
+   *
+   * Note: with a {@link PortalCache}, the historical query embeds the discovered address
+   * list, so the cache bucket changes whenever the child set grows.
+   */
+  preindex?: boolean | PreindexOptions
 }
 
 export class Factory<T extends EventArgs> {
   #batch: InternalFactoryEvent<T>[] = []
   #db?: FactoryPersistentAdapter<InternalFactoryEvent<T>>
+  #preindexRun?: Promise<number | null>
   readonly #addresses: Set<string>
   readonly #event: AbiEvent<T>
   readonly #params: IndexedParams<AbiEvent<T>>
@@ -186,28 +242,149 @@ export class Factory<T extends EventArgs> {
     return true
   }
 
-  /** @internal */
-  async runPreindex({
+  preindexEnabled(): boolean {
+    return Boolean(this.options.preindex)
+  }
+
+  maxAddressFilterSize(): number {
+    const preindex = this.options.preindex
+    const size = typeof preindex === 'object' ? preindex.maxAddressFilterSize : undefined
+
+    return size ?? DEFAULT_PREINDEX_MAX_ADDRESS_FILTER_SIZE
+  }
+
+  /**
+   * Stable hash of the factory configuration (addresses, event topics, indexed params).
+   * Keys the persisted pre-index progress so that a config change safely restarts
+   * discovery from scratch while reusing the same database file.
+   *
+   * @internal
+   */
+  async preindexKey(): Promise<string> {
+    return sha256Hex(
+      jsonStringify({
+        addresses: this.factoryAddress().sort(),
+        request: this.buildFactoryEventRequest(),
+        params: this.#params,
+      }),
+    )
+  }
+
+  /**
+   * All known child addresses of this factory, lowercased and deduplicated.
+   * Filters by factory address in memory — a shared database may hold children
+   * of other factories, and `all(params)` filters by indexed params only.
+   *
+   * @internal
+   */
+  async getChildAddresses(): Promise<string[]> {
+    const contracts = await this.getAllContracts()
+
+    const addresses = new Set<string>()
+    for (const contract of contracts) {
+      if (!this.#addresses.has(contract.factoryAddress)) continue
+
+      addresses.add(contract.childAddress.toLowerCase())
+    }
+
+    return Array.from(addresses)
+  }
+
+  /**
+   * Runs the pre-indexing phase: ensures every factory-creation event in `range`,
+   * clamped to the finalized head, has been scanned and its child addresses persisted.
+   *
+   * Returns the upper bound `W` of the pre-indexed range — the main query can safely
+   * use a server-side child-address filter for `[range.from … W]` — or `null` when
+   * pre-indexing is disabled or impossible (no finalized head, empty range).
+   *
+   * @internal
+   */
+  async ensurePreindexed(args: { portal: PortalClient; logger: Logger; range: Range }): Promise<number | null> {
+    if (!this.preindexEnabled()) return null
+
+    // Serialized rather than memoized: a factory shared between decoders never runs two
+    // concurrent pre-passes, yet each caller scans against its own range — persisted
+    // progress makes an overlapping follow-up run a cheap no-op, while a range extending
+    // below the covered one still triggers the re-scan it needs
+    const run = (this.#preindexRun ?? Promise.resolve(null)).catch(() => null).then(() => this.runPreindexPhase(args))
+    this.#preindexRun = run
+
+    return run
+  }
+
+  private async runPreindexPhase({
     portal,
-    range,
     logger,
+    range,
   }: {
     portal: PortalClient
-    range: PortalRange
     logger: Logger
-  }) {
-    const name = `factory preindexing ${this.factoryAddress().join(', ')}`
+    range: Range
+  }): Promise<number | null> {
+    await this.migrate()
 
-    logger.info(`Starting ${name}`)
+    let finalized: { number: number } | undefined
+    try {
+      finalized = await portal.getHead({ finalized: true })
+    } catch (error) {
+      if (error instanceof HttpError && error.response.status === 404) {
+        finalized = undefined
+      } else {
+        throw error
+      }
+    }
+
+    if (!finalized) {
+      logger.warn('factory preindex: the dataset does not expose a finalized head, skipping pre-indexing')
+
+      return null
+    }
+
+    const to = Math.min(finalized.number, range.to ?? Infinity)
+    if (to < range.from) return null
+
+    const db = this.assertDb()
+    if (!db.getPreindexedRange || !db.setPreindexedRange) {
+      logger.warn(
+        'factory preindex: the database adapter does not persist pre-index progress; the full range will be re-scanned on every start',
+      )
+    }
+
+    const key = await this.preindexKey()
+    const covered = normalizePreindexedRange(await db.getPreindexedRange?.(key))
+    const target = { from: range.from, to }
+
+    // With more children than fit into the server-side filter the main query falls back
+    // to a wildcard anyway, so scanning ahead of it buys nothing — bail out before the scan
+    const max = this.maxAddressFilterSize()
+    const discovered = new Set(await this.getChildAddresses())
+    if (discovered.size > max) {
+      logger.warn(TOO_MANY_CHILDREN(discovered.size, max))
+
+      return null
+    }
+
+    const scan = preindexScanRange(target, covered)
+    if (!scan) {
+      logger.info(`factory preindex: already up to date at block ${to}`)
+
+      return to
+    }
+
+    const factories = this.factoryAddress().join(', ')
+    const name = `factory preindex ${factories}`
+    logger.info(`factory preindex: scanning blocks ${scan.from}…${scan.to} for factory ${factories}`)
 
     await evmPortalStream({
       id: name,
       portal,
       logger,
+      progress: preindexProgressHandlers(),
       outputs: evmDecoder({
         profiler: { name },
         contracts: this.factoryAddress(),
-        range,
+        range: scan,
         events: {
           factory: Object.keys(this.#params).length > 0 ? { event: this.#event, params: this.#params } : this.#event,
         },
@@ -215,7 +392,7 @@ export class Factory<T extends EventArgs> {
     }).pipeTo(
       createTarget({
         write: async ({ read }) => {
-          for await (const { data } of read()) {
+          for await (const { data, ctx } of read()) {
             const res: InternalFactoryEvent<T>[] = []
 
             for (const event of data.factory) {
@@ -237,12 +414,36 @@ export class Factory<T extends EventArgs> {
             }
 
             await this.assertDb().save(res)
+
+            for (const entity of res) {
+              discovered.add(entity.childAddress.toLowerCase())
+            }
+
+            // Advance the persisted progress with every batch so an interrupted
+            // pre-index run resumes where it left off instead of starting over
+            const scanned = { from: scan.from, to: Math.min(ctx.stream.state.current.number, scan.to) }
+            await db.setPreindexedRange?.(key, mergePreindexedRanges(scanned, covered))
+
+            // Crossing the cap mid-scan: stop early — the covered range stays honest,
+            // and a later run with a raised cap resumes from it
+            if (discovered.size > max) {
+              return
+            }
           }
         },
       }),
     )
 
-    logger.info(`Finished ${name}`)
+    if (discovered.size > max) {
+      logger.warn(TOO_MANY_CHILDREN(discovered.size, max))
+
+      return null
+    }
+
+    await db.setPreindexedRange?.(key, mergePreindexedRanges(scan, covered))
+    logger.info(`factory preindex: finished, blocks ${target.from}…${target.to} covered`)
+
+    return to
   }
 
   async getAllContracts() {
@@ -262,6 +463,70 @@ export class Factory<T extends EventArgs> {
   static isFactory(address: any) {
     return address instanceof Factory
   }
+}
+
+/**
+ * Progress hooks for the pre-pass stream. The phase announces itself with its own
+ * `scanning blocks X…Y` line, so the default `Start indexing…` would read as the main
+ * loop starting; progress ticks carry a `factory preindex:` prefix for the same reason.
+ *
+ * @internal
+ */
+export function preindexProgressHandlers(): ProgressTrackerOptions {
+  return {
+    onStart: () => {},
+    onProgress: ({ progress, logger }) => {
+      if (progress.state.current === 0 && progress.state.last === 0) return
+
+      const msg = formatProgressMessage(progress)
+      logger.info({ ...msg, message: `factory preindex: ${msg['message']}` })
+    },
+  }
+}
+
+/** A fully-scanned block range with both boundaries resolved. @internal */
+export type PreindexedRange = { from: number; to: number }
+
+function normalizePreindexedRange(range: Range | null | undefined): PreindexedRange | null {
+  if (range == null || range.to == null) return null
+
+  return { from: range.from, to: range.to }
+}
+
+/**
+ * Determines which blocks the pre-index phase still has to scan to make the
+ * covered range a superset of `target`. Returns `null` when already covered.
+ *
+ * @internal
+ */
+export function preindexScanRange(target: PreindexedRange, covered: PreindexedRange | null): PreindexedRange | null {
+  if (!covered) return target
+
+  // History extended below the covered range — re-scan from the new lower bound.
+  // Saving children is idempotent and factory-event scans are cheap, so one full
+  // pass is preferred over tracking multiple disjoint covered ranges.
+  if (target.from < covered.from) return target
+
+  // Upper gap between the covered range and the target
+  if (target.to > covered.to) return { from: covered.to + 1, to: target.to }
+
+  return null
+}
+
+/**
+ * Merges a freshly scanned range into the previously covered one. When the two are
+ * disjoint, only the scanned range is kept — a single contiguous range must never
+ * claim blocks that were skipped in between.
+ *
+ * @internal
+ */
+export function mergePreindexedRanges(scanned: PreindexedRange, covered: PreindexedRange | null): PreindexedRange {
+  if (!covered) return scanned
+
+  const contiguous = scanned.from <= covered.to + 1 && covered.from <= scanned.to + 1
+  if (!contiguous) return scanned
+
+  return { from: Math.min(scanned.from, covered.from), to: Math.max(scanned.to, covered.to) }
 }
 
 /**

--- a/packages/subsquid-pipes/src/internal/hash.ts
+++ b/packages/subsquid-pipes/src/internal/hash.ts
@@ -1,0 +1,28 @@
+/**
+ * UTF-8 encode a JS string to ArrayBuffer.
+ * @internal
+ */
+export function stringToArrayBuffer(str: string): Uint8Array {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(str)
+  }
+
+  throw new Error(
+    'TextEncoder is not supported in this environment. Please ensure you are running in a modern JavaScript environment that supports TextEncoder (Node.js 11+, modern browsers, or include a polyfill).',
+  )
+}
+
+/**
+ * Returns a hex-encoded SHA-256 hash of the input string.
+ * @internal
+ */
+export async function sha256Hex(data: string): Promise<string> {
+  // globalThis.crypto is available in browsers, Node 18+, and Cloudflare Workers
+  if (typeof crypto === 'undefined' || !crypto.subtle) {
+    throw new Error(
+      'crypto.subtle is not supported in this environment. Please ensure you are running in a modern JavaScript environment that supports crypto.subtle (Node.js 18+, modern browsers, or include a polyfill).',
+    )
+  }
+  const d = await crypto.subtle.digest('SHA-256', stringToArrayBuffer(data))
+  return [...new Uint8Array(d)].map((b) => b.toString(16).padStart(2, '0')).join('')
+}

--- a/packages/subsquid-pipes/src/solana/solana-rpc-latency-watcher.test.ts
+++ b/packages/subsquid-pipes/src/solana/solana-rpc-latency-watcher.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
+import { PortalClient } from '~/portal-client/client.js'
 import { createTestLogger } from '~/testing/test-logger.js'
 
 import { SolanaQueryBuilder } from './solana-query-builder.js'
@@ -17,7 +18,7 @@ describe('solanaRpcLatencyWatcher factory', () => {
     transformer = solanaRpcLatencyWatcher({ rpcUrl: ['ws://127.0.0.1:1'] })
 
     const builder = new SolanaQueryBuilder<{ block: { number: true; timestamp: true } }>()
-    await transformer.setupQuery({ query: builder, logger: createTestLogger() })
+    await transformer.setupQuery({ query: builder, logger: createTestLogger(), portal: {} as PortalClient })
 
     expect(builder.getFields()).toEqual({
       block: { number: true, timestamp: true },
@@ -28,11 +29,9 @@ describe('solanaRpcLatencyWatcher factory', () => {
     transformer = solanaRpcLatencyWatcher({ rpcUrl: ['ws://127.0.0.1:1'] })
 
     const builder = new SolanaQueryBuilder<{ block: { number: true; timestamp: true } }>()
-    await transformer.setupQuery({ query: builder, logger: createTestLogger() })
+    await transformer.setupQuery({ query: builder, logger: createTestLogger(), portal: {} as PortalClient })
 
     const requests = builder.getRequests()
-    expect(requests).toContainEqual(
-      expect.objectContaining({ range: { from: 'latest' } }),
-    )
+    expect(requests).toContainEqual(expect.objectContaining({ range: { from: 'latest' } }))
   })
 })

--- a/packages/subsquid-pipes/src/testing/test-logger.ts
+++ b/packages/subsquid-pipes/src/testing/test-logger.ts
@@ -1,13 +1,27 @@
 import { pino, stdSerializers } from 'pino'
 
-export function createTestLogger() {
-  return pino({
+export type TestLoggerOptions = {
+  /** Receives every log entry as a parsed object instead of writing to stdout */
+  capture?: (entry: Record<string, any>) => void
+}
+
+export function createTestLogger({ capture }: TestLoggerOptions = {}) {
+  const options = {
     level: process.env['LOG_LEVEL'] || 'info',
     messageKey: 'message',
     serializers: {
       error: stdSerializers.errWithCause,
       err: stdSerializers.errWithCause,
     },
+    base: {},
+  }
+
+  if (capture) {
+    return pino(options, { write: (line: string) => capture(JSON.parse(line)) })
+  }
+
+  return pino({
+    ...options,
     transport: {
       target: 'pino-pretty',
       options: {
@@ -16,7 +30,5 @@ export function createTestLogger() {
         singleLine: true,
       },
     },
-
-    base: {},
   })
 }

--- a/packages/subsquid-pipes/src/testing/test-portal.ts
+++ b/packages/subsquid-pipes/src/testing/test-portal.ts
@@ -57,9 +57,14 @@ export async function createFinalizedMockPortal(mockResponses: MockResponse[]) {
   })
 }
 
+export type MockPortalHead = {
+  finalized?: { number: number; hash: string }
+  latest?: { number: number; hash: string }
+}
+
 export async function createMockPortal(
   mockResponses: MockResponse[],
-  { finalized = false }: { finalized?: boolean } = {},
+  { finalized = false, head }: { finalized?: boolean; head?: MockPortalHead } = {},
 ): Promise<MockPortal> {
   const promise = new Promise<Server>((resolve, reject) => {
     let requestCount = 0
@@ -80,6 +85,16 @@ export async function createMockPortal(
             },
           }),
         )
+        res.end()
+        return
+      } else if (req.url === '/finalized-head' && head?.finalized) {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.write(JSON.stringify(head.finalized))
+        res.end()
+        return
+      } else if (req.url === '/head' && head?.latest) {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.write(JSON.stringify(head.latest))
         res.end()
         return
       } else if (req.url !== streamUrl) {


### PR DESCRIPTION
## Summary

Replaces the removed `_experimental_preindex` with an explicit, automatically-managed factory pre-indexing phase, enabled declaratively:

```ts
contractFactory({
  address: '0x1f98431c8ad98523631ae4a59f267346ea31f984',
  event: factoryAbi.PoolCreated,
  childAddressField: 'pool',
  database: contractFactoryStore({ path: './pools.sqlite' }),
  preindex: true, // or { maxAddressFilterSize: 50_000 }
})
```

The old option was removed for being vague (a user-picked range silently changing query behavior). This version manages the range itself and runs as a visible, logged phase.

## How it works

1. **Check run (every startup).** Before the main loop, the pipe reads the persisted scan progress from the factory SQLite store and scans factory-creation events for the gap up to the finalized head, saving discovered child addresses. Progress advances with every batch, so an interrupted scan resumes where it stopped; a completed one only scans the delta since the last run (`factory preindex: already up to date at block N`).
2. **Main loop with a split query.** Child events in the pre-indexed range `[from … finalized]` are requested with a **server-side address filter** (fast backfill, less traffic). Above the finalized head the query falls back to the usual wildcard (topic-only) request with client-side filtering, where inline discovery keeps running as before.

Fork safety is structural: the pre-indexed range never exceeds the finalized head, so it never rolls back; children discovered inline in the wildcard tail are handled by the existing `Factory.fork()` cleanup.

Notable details:

- Progress is stored as a covered **range** (not a single watermark block) keyed by a hash of the factory config — lowering `range.from` or changing addresses/event/params between runs safely triggers a re-scan instead of silently missing children.
- If the pre-pass finds no children, the historical child request is skipped entirely (no children ≤ watermark ⇒ no child events there).
- Above `maxAddressFilterSize` children (default 5 000 — the list is embedded into every stream request body, ~50 bytes per address) the pipe warns and falls back to the wildcard query. The cap is enforced **before wasting work**: a start with more persisted children than the cap skips the gap scan entirely, and a first-run scan stops mid-way as soon as the discovered set crosses the cap. The per-batch progress stays honest, so raising the cap later resumes the scan from where it stopped.
- Datasets without a finalized head (404 on `/finalized-head`) log a warning and keep today's single-pass behavior.
- `FactoryPersistentAdapter` gains **optional** `getPreindexedRange`/`setPreindexedRange` — third-party adapters keep working and degrade to a full re-scan per start (idempotent).
- Core change: the setup-query context now carries `portal` (`SetupQueryCtx`), and `evmDecoder` registers its log requests inside `setupQuery` instead of at construction time, since the split depends on the pre-pass result. Registration is memoized as a promise: a pre-pass that failed during setup stays failed on a retried stream start instead of silently merging a query without child-event requests.
- A factory shared between several decoders **serializes** its pre-passes rather than reusing the first one: each decoder scans against its own range (a range extending below the covered one triggers the re-scan it needs), and overlapping follow-up runs become cheap no-ops thanks to the persisted progress.
- The pre-pass is fully distinguishable in the logs: `factory preindex: scanning blocks X…Y for factory 0x…`, progress ticks in the main loop's format under the same prefix (`factory preindex: 15,000,000 / 23,000,000 (65%), ETA: 1m 30s` + blocks/s, bytes/s), then `factory preindex: finished, blocks X…Y covered`. The nested scan no longer emits a second `Start indexing…` line — the only one you see belongs to the main loop.

## Coverage diff (base vs head)

| File | Lines (base → head) | Δ | Branches (base → head) | Δ |
|------|---------------------|---|------------------------|---|
| `src/core/portal-source.ts` | 93.1% → 93.1% | +0.0 | 82.5% → 83.0% | +0.4 |
| `src/core/query-builder.ts` | 94.2% → 97.2% | +3.0 | 93.7% → 95.3% | +1.6 |
| `src/core/transformer.ts` | 100.0% → 100.0% | +0.0 | 97.3% → 97.3% | +0.0 |
| `src/evm/evm-decoder.ts` | 97.3% → 97.7% | +0.4 | 91.6% → 92.8% | +1.2 |
| `src/evm/factory-adapters/sqlite.ts` | 88.6% → 97.5% | +8.9 | 85.0% → 88.9% | +3.9 |
| `src/evm/factory.ts` | 70.3% → 95.4% | +25.0 | 95.3% → 87.8% | −7.6 |
| `src/internal/hash.ts` | — → 52.9% | new | — → 60.0% | new |
| `src/testing/test-portal.ts` | 86.4% → 87.4% | +1.0 | 88.1% → 87.5% | −0.6 |
| **Total (changed files)** | **90.3% → 94.8%** | **+4.5** | **90.4% → 89.9%** | −0.5 |

Base 378 tests → head 400 tests. The `factory.ts` branch dip comes from new defensive guards (non-404 error rethrow, missing-adapter-method warnings); `hash.ts` uncovered lines are environment-guard throws (no `TextEncoder`/`crypto.subtle`) unreachable under Node. New tests use the internal testing framework (`createMockPortal` + `mockBlock`/`encodeEvent`); `createMockPortal` learned a `head` option to serve `/finalized-head` deterministically, and `createTestLogger` learned a `capture` option to assert log output. The table predates the review follow-ups (5 extra tests slightly raise `factory.ts`/`evm-decoder.ts` further; `src/core/progress-tracker.ts` was touched by a pure extract-and-reuse refactor of the progress-message formatting).

## Testing

- 17 new tests in `factory-preindex.test.ts`: query split shape, empty-children skip, gap-only re-scan on restart, params-change re-scan under a new progress key, per-batch progress persistence + interrupted-scan resume, fork in the wildcard tail, no-finality fallback, `maxAddressFilterSize` fallback, unit tests for the range helpers — plus review follow-ups: serialized shared-factory pre-passes (same range → single scan; a range extending below the covered one → re-scan), loud failure on a retried setup after a failed pre-pass, `factory preindex:`-prefixed pre-pass logging without a duplicate start line, mid-scan abort once the child set crosses the cap (with resume after raising it), and skipping the gap scan when the persisted children already exceed the cap.
- Full suite: 400 tests pass; `pnpm build` and Biome clean.
- Real-portal smoke test (Uniswap V3, blocks 12,369,621–12,400,000): pre-pass discovered 773 pools, main query carried all 773 addresses server-side; restart logged `factory preindex: already up to date at block 12400000` and went straight to the main loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

