### PR TITLE
feat: RPC-fallback data source for Pipes

### DIFF
--- a/packages/subsquid-pipes/package.json
+++ b/packages/subsquid-pipes/package.json
@@ -53,6 +53,8 @@
     "@google-cloud/bigquery": "8.3.0",
     "@google-cloud/bigquery-storage": "5.1.0",
     "@subsquid/borsh": "0.3.0",
+    "@subsquid/evm-normalization": "^0.0.2",
+    "@subsquid/evm-rpc": "^0.0.2",
     "@types/better-sqlite3": "7.6.13",
     "@types/express": "4.17.23",
     "@types/node": "22.14.1",
@@ -84,6 +86,8 @@
     "@google-cloud/bigquery": "8.3.0",
     "@google-cloud/bigquery-storage": "5.1.0",
     "@opentelemetry/api": "^1.9.0",
+    "@subsquid/evm-normalization": "^0.0.2",
+    "@subsquid/evm-rpc": "^0.0.2",
     "better-sqlite3": "12.4.5",
     "drizzle-orm": "0.44.7",
     "pg": "8.16.3",
@@ -91,6 +95,12 @@
   },
   "peerDependenciesMeta": {
     "@dsnp/parquetjs": {
+      "optional": true
+    },
+    "@subsquid/evm-normalization": {
+      "optional": true
+    },
+    "@subsquid/evm-rpc": {
       "optional": true
     },
     "@opentelemetry/api": {

--- a/packages/subsquid-pipes/package.json
+++ b/packages/subsquid-pipes/package.json
@@ -82,6 +82,10 @@
     "@google-cloud/bigquery": "8.3.0",
     "@google-cloud/bigquery-storage": "5.1.0",
     "@opentelemetry/api": "^1.9.0",
+    "@subsquid/evm-normalization": "^0.0.2",
+    "@subsquid/evm-rpc": "^0.0.2",
+    "@subsquid/util-internal-json": "^1.2.3",
+    "@subsquid/util-internal-processor-tools": "^4.4.0",
     "better-sqlite3": "12.4.5",
     "drizzle-orm": "0.44.7",
     "pg": "8.16.3",
@@ -89,6 +93,18 @@
   },
   "peerDependenciesMeta": {
     "@dsnp/parquetjs": {
+      "optional": true
+    },
+    "@subsquid/evm-normalization": {
+      "optional": true
+    },
+    "@subsquid/evm-rpc": {
+      "optional": true
+    },
+    "@subsquid/util-internal-json": {
+      "optional": true
+    },
+    "@subsquid/util-internal-processor-tools": {
       "optional": true
     },
     "@opentelemetry/api": {

--- a/packages/subsquid-pipes/package.json
+++ b/packages/subsquid-pipes/package.json
@@ -55,6 +55,8 @@
     "@subsquid/borsh": "0.3.0",
     "@subsquid/evm-normalization": "^0.0.2",
     "@subsquid/evm-rpc": "^0.0.2",
+    "@subsquid/http-client": "^1.8.1",
+    "@subsquid/rpc-client": "^4.15.1",
     "@types/better-sqlite3": "7.6.13",
     "@types/express": "4.17.23",
     "@types/node": "22.14.1",

--- a/packages/subsquid-pipes/package.json
+++ b/packages/subsquid-pipes/package.json
@@ -90,6 +90,8 @@
     "@opentelemetry/api": "^1.9.0",
     "@subsquid/evm-normalization": "^0.0.2",
     "@subsquid/evm-rpc": "^0.0.2",
+    "@subsquid/http-client": "^1.8.1",
+    "@subsquid/rpc-client": "^4.15.1",
     "better-sqlite3": "12.4.5",
     "drizzle-orm": "0.44.7",
     "pg": "8.16.3",
@@ -103,6 +105,12 @@
       "optional": true
     },
     "@subsquid/evm-rpc": {
+      "optional": true
+    },
+    "@subsquid/http-client": {
+      "optional": true
+    },
+    "@subsquid/rpc-client": {
       "optional": true
     },
     "@opentelemetry/api": {

--- a/packages/subsquid-pipes/package.json
+++ b/packages/subsquid-pipes/package.json
@@ -69,6 +69,8 @@
     "@subsquid/solana-stream": "0.3.1",
     "@subsquid/util-internal": "3.2.0",
     "@subsquid/util-internal-hex": "0.0.2",
+    "@subsquid/util-internal-json": "^1.2.3",
+    "@subsquid/util-internal-processor-tools": "^4.4.0",
     "@subsquid/util-internal-validation": "0.8.0",
     "@subsquid/util-timeout": "^2.3.2",
     "express": "5.1.0",
@@ -82,10 +84,6 @@
     "@google-cloud/bigquery": "8.3.0",
     "@google-cloud/bigquery-storage": "5.1.0",
     "@opentelemetry/api": "^1.9.0",
-    "@subsquid/evm-normalization": "^0.0.2",
-    "@subsquid/evm-rpc": "^0.0.2",
-    "@subsquid/util-internal-json": "^1.2.3",
-    "@subsquid/util-internal-processor-tools": "^4.4.0",
     "better-sqlite3": "12.4.5",
     "drizzle-orm": "0.44.7",
     "pg": "8.16.3",
@@ -93,18 +91,6 @@
   },
   "peerDependenciesMeta": {
     "@dsnp/parquetjs": {
-      "optional": true
-    },
-    "@subsquid/evm-normalization": {
-      "optional": true
-    },
-    "@subsquid/evm-rpc": {
-      "optional": true
-    },
-    "@subsquid/util-internal-json": {
-      "optional": true
-    },
-    "@subsquid/util-internal-processor-tools": {
       "optional": true
     },
     "@opentelemetry/api": {

--- a/packages/subsquid-pipes/src/core/fallback-async.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-async.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+
+import { safeReturn, withTimeout } from './fallback-async.js'
+
+const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+/**
+ * Run `fn` while capturing any `unhandledRejection` — the promise-hygiene edges (an abandoned
+ * timed-out promise, a rejecting `return()`) must never leak one.
+ */
+async function withoutUnhandledRejections(fn: () => Promise<void>): Promise<unknown[]> {
+  const unhandled: unknown[] = []
+  const onUnhandled = (e: unknown) => unhandled.push(e)
+  process.on('unhandledRejection', onUnhandled)
+  try {
+    await fn()
+    await wait(30) // let any abandoned promise settle
+  } finally {
+    process.off('unhandledRejection', onUnhandled)
+  }
+  return unhandled
+}
+
+describe('withTimeout', () => {
+  it('resolves with the value when it settles before the timeout', async () => {
+    await expect(withTimeout(Promise.resolve(42), 1000, () => new Error('nope'))).resolves.toBe(42)
+  })
+
+  it('rejects with makeError() when the timeout fires first', async () => {
+    const never = new Promise<never>(() => {})
+    await expect(withTimeout(never, 5, () => new Error('timed out'))).rejects.toThrow('timed out')
+  })
+
+  it('carries an arbitrary (non-Error) rejection value from makeError', async () => {
+    const cause = { reason: 'timeout' as const, code: 1 } // e.g. a classified SourceErrorInfo
+    await expect(withTimeout(new Promise<never>(() => {}), 5, () => cause)).rejects.toBe(cause)
+  })
+
+  it('returns the promise unchanged when ms is null (guard disabled)', () => {
+    const p = Promise.resolve('v')
+    expect(withTimeout(p, null, () => new Error('nope'))).toBe(p) // identity: no race wrapper
+  })
+
+  it('does not surface an unhandled rejection from the promise abandoned after a timeout', async () => {
+    const unhandled = await withoutUnhandledRejections(async () => {
+      // rejects only AFTER the timeout already fired — withTimeout must have silenced it
+      const rejectsLate = new Promise((_r, reject) => setTimeout(() => reject(new Error('late')), 5))
+      await expect(withTimeout(rejectsLate, 1, () => new Error('timed out'))).rejects.toThrow('timed out')
+    })
+    expect(unhandled).toHaveLength(0)
+  })
+})
+
+describe('safeReturn', () => {
+  it('closes an iterator via return()', async () => {
+    let closed = false
+    const it: AsyncIterator<unknown> = {
+      next: async () => ({ done: true, value: undefined }),
+      return: async () => {
+        closed = true
+        return { done: true, value: undefined }
+      },
+    }
+    safeReturn(it)
+    await wait(0)
+    expect(closed).toBe(true)
+  })
+
+  it('swallows a rejecting return() (never throws, never leaks)', async () => {
+    const unhandled = await withoutUnhandledRejections(async () => {
+      const it: AsyncIterator<unknown> = {
+        next: async () => ({ done: true, value: undefined }),
+        return: async () => {
+          throw new Error('return boom')
+        },
+      }
+      expect(() => safeReturn(it)).not.toThrow()
+    })
+    expect(unhandled).toHaveLength(0)
+  })
+
+  it('tolerates an iterator without a return() method', () => {
+    const it = { next: async () => ({ done: true, value: undefined }) } as AsyncIterator<unknown>
+    expect(() => safeReturn(it)).not.toThrow()
+  })
+})

--- a/packages/subsquid-pipes/src/core/fallback-async.ts
+++ b/packages/subsquid-pipes/src/core/fallback-async.ts
@@ -8,7 +8,11 @@
  * actually fires — and so callers can attach a classified cause (see the capability probe) rather
  * than a bare `Error`.
  */
-export function withTimeout<T>(promise: Promise<T>, ms: number | null | undefined, makeError: () => unknown): Promise<T> {
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number | null | undefined,
+  makeError: () => unknown,
+): Promise<T> {
   if (ms == null) return promise
 
   promise.catch(() => {}) // an abandoned (timed-out) promise must not surface as unhandled

--- a/packages/subsquid-pipes/src/core/fallback-async.ts
+++ b/packages/subsquid-pipes/src/core/fallback-async.ts
@@ -1,0 +1,37 @@
+/**
+ * Race `promise` against a `ms` timeout. On timeout the result rejects with `makeError()`; the
+ * abandoned `promise` is silenced so its late settlement can't surface as an unhandled rejection,
+ * and the timer is always cleared. `ms == null` disables the guard and returns `promise` unchanged,
+ * deferring to the underlying operation's own timeout.
+ *
+ * `makeError` is a thunk so the (possibly side-effecting) error value is built only if the timeout
+ * actually fires — and so callers can attach a classified cause (see the capability probe) rather
+ * than a bare `Error`.
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number | null | undefined, makeError: () => unknown): Promise<T> {
+  if (ms == null) return promise
+
+  promise.catch(() => {}) // an abandoned (timed-out) promise must not surface as unhandled
+  let timer: ReturnType<typeof setTimeout>
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(makeError()), ms)
+  })
+
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
+}
+
+/**
+ * Fire-and-forget close of an async iterator. Closing a *stalled* source's stream must neither block
+ * failover nor surface a late rejection: `return()` can itself hang on the same unresolved fetch, and
+ * its rejection (if any) is swallowed. Never awaited by design.
+ */
+export function safeReturn(it: AsyncIterator<unknown>): void {
+  try {
+    it.return?.()?.then(
+      () => {},
+      () => {},
+    )
+  } catch {
+    /* ignore */
+  }
+}

--- a/packages/subsquid-pipes/src/core/fallback-capability.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-capability.test.ts
@@ -37,33 +37,52 @@ describe('makeCapabilityProbe', () => {
     const s = source(async function* () {
       yield pbatch(100)
     })
-    expect(await makeCapabilityProbe(s)(cursor(99))).toBe(true)
+    expect(await makeCapabilityProbe(s)(cursor(99))).toEqual({ ok: true })
     expect(s.reads).toEqual([cursor(99)])
   })
 
   it('reports capable when the slice is empty (served the query, nothing matched)', async () => {
     const s = source(async function* () {})
-    expect(await makeCapabilityProbe(s)(cursor(99))).toBe(true)
+    expect(await makeCapabilityProbe(s)(cursor(99))).toEqual({ ok: true })
   })
 
-  it('reports not-capable when the source cannot serve the slice', async () => {
+  it('reports not-capable, with the classified cause, when the source cannot serve the slice', async () => {
     const s = source(async function* () {
       throw new Error('the method trace_block does not exist')
     })
-    expect(await makeCapabilityProbe(s)(cursor(99))).toBe(false)
+    const r = await makeCapabilityProbe(s)(cursor(99))
+    expect(r.ok).toBe(false)
+    expect(r.cause?.check).toBe('capability')
+    expect(r.cause?.detail).toContain('trace_block')
+  })
+
+  it('classifies a Portal HTTP 400 as an http failure carrying its status code', async () => {
+    const s = source(async function* () {
+      throw Object.assign(new Error('Got 400 from https://portal.example/q'), {
+        name: 'HttpError',
+        response: { status: 400, url: 'https://portal.example/q', body: 'not a hypothetical' },
+      })
+    })
+    const r = await makeCapabilityProbe(s)(cursor(99))
+    expect(r.ok).toBe(false)
+    expect(r.cause?.reason).toBe('http')
+    expect(r.cause?.code).toBe(400)
   })
 
   it('treats a ForkException as capable (served + reorg, not an inability to serve)', async () => {
     const s = source(async function* () {
       throw new ForkException([cursor(99)], { fromBlock: 100, parentBlockHash: '0x99' })
     })
-    expect(await makeCapabilityProbe(s)(cursor(99))).toBe(true)
+    expect(await makeCapabilityProbe(s)(cursor(99))).toEqual({ ok: true })
   })
 
   it('reports not-capable when the slice exceeds the probe timeout', async () => {
     const s = source(async function* () {
       await new Promise<void>(() => {}) // hang — never yields
     })
-    expect(await makeCapabilityProbe(s, { timeoutMs: 20 })(cursor(99))).toBe(false)
+    const r = await makeCapabilityProbe(s, { timeoutMs: 20 })(cursor(99))
+    expect(r.ok).toBe(false)
+    expect(r.cause?.reason).toBe('stale')
+    expect(r.cause?.detail).toContain('timed out')
   })
 })

--- a/packages/subsquid-pipes/src/core/fallback-capability.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-capability.test.ts
@@ -82,7 +82,7 @@ describe('makeCapabilityProbe', () => {
     })
     const r = await makeCapabilityProbe(s, { timeoutMs: 20 })(cursor(99))
     expect(r.ok).toBe(false)
-    expect(r.cause?.reason).toBe('stale')
+    expect(r.cause?.reason).toBe('timeout')
     expect(r.cause?.detail).toContain('timed out')
   })
 })

--- a/packages/subsquid-pipes/src/core/fallback-capability.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-capability.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import { ForkException } from '~/portal-client/index.js'
+
+import { makeCapabilityProbe } from './fallback-capability.js'
+import { FallbackUnderlyingSource } from './fallback-source.js'
+import { PortalBatch } from './portal-source.js'
+import { BlockCursor } from './types.js'
+
+function cursor(n: number): BlockCursor {
+  return { number: n, hash: `0x${n}` }
+}
+
+function pbatch(n: number): PortalBatch<number[]> {
+  return {
+    data: [n],
+    ctx: { stream: { state: { current: cursor(n) }, head: {} } },
+  } as unknown as PortalBatch<number[]>
+}
+
+type ReadFn = (cursor?: BlockCursor) => AsyncGenerator<PortalBatch<number[]>>
+
+function source(read: ReadFn): FallbackUnderlyingSource<number[]> & { reads: (BlockCursor | undefined)[] } {
+  const reads: (BlockCursor | undefined)[] = []
+  return {
+    name: 'mock',
+    reads,
+    read: (c) => {
+      reads.push(c)
+      return read(c)
+    },
+  }
+}
+
+describe('makeCapabilityProbe', () => {
+  it('reads a slice at the asked-for cursor and reports capable when it serves', async () => {
+    const s = source(async function* () {
+      yield pbatch(100)
+    })
+    expect(await makeCapabilityProbe(s)(cursor(99))).toBe(true)
+    expect(s.reads).toEqual([cursor(99)])
+  })
+
+  it('reports capable when the slice is empty (served the query, nothing matched)', async () => {
+    const s = source(async function* () {})
+    expect(await makeCapabilityProbe(s)(cursor(99))).toBe(true)
+  })
+
+  it('reports not-capable when the source cannot serve the slice', async () => {
+    const s = source(async function* () {
+      throw new Error('the method trace_block does not exist')
+    })
+    expect(await makeCapabilityProbe(s)(cursor(99))).toBe(false)
+  })
+
+  it('treats a ForkException as capable (served + reorg, not an inability to serve)', async () => {
+    const s = source(async function* () {
+      throw new ForkException([cursor(99)], { fromBlock: 100, parentBlockHash: '0x99' })
+    })
+    expect(await makeCapabilityProbe(s)(cursor(99))).toBe(true)
+  })
+
+  it('reports not-capable when the slice exceeds the probe timeout', async () => {
+    const s = source(async function* () {
+      await new Promise<void>(() => {}) // hang — never yields
+    })
+    expect(await makeCapabilityProbe(s, { timeoutMs: 20 })(cursor(99))).toBe(false)
+  })
+})

--- a/packages/subsquid-pipes/src/core/fallback-capability.ts
+++ b/packages/subsquid-pipes/src/core/fallback-capability.ts
@@ -1,11 +1,18 @@
 import { isForkException } from '~/portal-client/index.js'
 
+import { SourceErrorInfo, classifyError, freshnessFailure } from './fallback-diagnostics.js'
 import { FallbackUnderlyingSource } from './fallback-source.js'
 import { BlockCursor } from './types.js'
 
 export interface CapabilityProbeOptions {
   /** Report not-capable if the probe slice stays outstanding longer than this. Default 30s. */
   timeoutMs?: number
+}
+
+/** A capability probe's verdict: `ok`, plus *why* it failed (for logs + metrics) when it didn't. */
+export interface ProbeResult {
+  ok: boolean
+  cause?: SourceErrorInfo
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000
@@ -25,7 +32,8 @@ const DEFAULT_TIMEOUT_MS = 30_000
  *
  * Capable iff the slice yields a batch or the stream ends without a non-fork error. A
  * `ForkException` counts as capable — the source served data and detected a reorg, a chain event
- * rather than an inability to serve. Any other error, or exceeding `timeoutMs`, reports not-capable.
+ * rather than an inability to serve. Any other error, or exceeding `timeoutMs`, reports not-capable,
+ * with the cause (classified for logs + metrics) attached.
  *
  * (Unlike the Squid probe, which requests a one-block `{from, to}` slice, the Pipes `read` contract
  * is unbounded — so the probe takes only the first batch and closes the stream.)
@@ -33,25 +41,31 @@ const DEFAULT_TIMEOUT_MS = 30_000
 export function makeCapabilityProbe<T>(
   source: FallbackUnderlyingSource<T>,
   options: CapabilityProbeOptions = {},
-): (atCursor?: BlockCursor) => Promise<boolean> {
+): (atCursor?: BlockCursor) => Promise<ProbeResult> {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
 
-  return async (atCursor?: BlockCursor): Promise<boolean> => {
+  return async (atCursor?: BlockCursor): Promise<ProbeResult> => {
     const iterator = source.read(atCursor)[Symbol.asyncIterator]()
     let timer: ReturnType<typeof setTimeout> | undefined
     try {
       const next = iterator.next()
       next.catch(() => {}) // a late rejection after a timeout must not surface as unhandled
       const timeout = new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(() => reject(new Error('capability probe timed out')), timeoutMs)
+        timer = setTimeout(
+          () => reject(freshnessFailure('capability', 'stale', `probe timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        )
       })
 
       // One batch (or a clean stream end) is enough: it proves the source served the slice.
       await Promise.race([next, timeout])
 
-      return true
+      return { ok: true }
     } catch (e) {
-      return isForkException(e)
+      if (isForkException(e)) return { ok: true }
+      // The timeout rejects with a ready-made cause; a thrown error gets classified.
+      const cause = isErrorInfo(e) ? e : classifyError('capability', e)
+      return { ok: false, cause }
     } finally {
       if (timer) clearTimeout(timer)
       // Don't await: closing the probe stream must not block, and a stalled source's `return()`
@@ -66,4 +80,8 @@ export function makeCapabilityProbe<T>(
       }
     }
   }
+}
+
+function isErrorInfo(e: unknown): e is SourceErrorInfo {
+  return typeof e === 'object' && e != null && 'reason' in e && 'check' in e
 }

--- a/packages/subsquid-pipes/src/core/fallback-capability.ts
+++ b/packages/subsquid-pipes/src/core/fallback-capability.ts
@@ -1,0 +1,69 @@
+import { isForkException } from '~/portal-client/index.js'
+
+import { FallbackUnderlyingSource } from './fallback-source.js'
+import { BlockCursor } from './types.js'
+
+export interface CapabilityProbeOptions {
+  /** Report not-capable if the probe slice stays outstanding longer than this. Default 30s. */
+  timeoutMs?: number
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000
+
+/**
+ * Build a generic `probeCapability` for any {@link FallbackUnderlyingSource}. It pulls a single
+ * batch of *exactly the data the source is configured to serve* — the query (fields + request) is
+ * baked into the source, so one `read(cursor)` batch re-exercises the whole pipeline (logs, traces,
+ * state diffs) — starting just past the indexing frontier, and reports whether the source could
+ * serve it.
+ *
+ * This catches the reachable-but-incapable failures liveness alone misses: an RPC node with the
+ * trace/`debug_` API disabled or pruned state at that depth fails the slice, as does a Portal that
+ * answers HTTP 400 to a query that passed type-level validation. The supervisor anchors `atCursor`
+ * to the frontier, so during a backfill the probe verifies capability *at the depth the source is
+ * about to read in bulk*.
+ *
+ * Capable iff the slice yields a batch or the stream ends without a non-fork error. A
+ * `ForkException` counts as capable — the source served data and detected a reorg, a chain event
+ * rather than an inability to serve. Any other error, or exceeding `timeoutMs`, reports not-capable.
+ *
+ * (Unlike the Squid probe, which requests a one-block `{from, to}` slice, the Pipes `read` contract
+ * is unbounded — so the probe takes only the first batch and closes the stream.)
+ */
+export function makeCapabilityProbe<T>(
+  source: FallbackUnderlyingSource<T>,
+  options: CapabilityProbeOptions = {},
+): (atCursor?: BlockCursor) => Promise<boolean> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+  return async (atCursor?: BlockCursor): Promise<boolean> => {
+    const iterator = source.read(atCursor)[Symbol.asyncIterator]()
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      const next = iterator.next()
+      next.catch(() => {}) // a late rejection after a timeout must not surface as unhandled
+      const timeout = new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error('capability probe timed out')), timeoutMs)
+      })
+
+      // One batch (or a clean stream end) is enough: it proves the source served the slice.
+      await Promise.race([next, timeout])
+
+      return true
+    } catch (e) {
+      return isForkException(e)
+    } finally {
+      if (timer) clearTimeout(timer)
+      // Don't await: closing the probe stream must not block, and a stalled source's `return()`
+      // can hang on the same unresolved fetch.
+      try {
+        iterator.return?.()?.then(
+          () => {},
+          () => {},
+        )
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}

--- a/packages/subsquid-pipes/src/core/fallback-capability.ts
+++ b/packages/subsquid-pipes/src/core/fallback-capability.ts
@@ -1,5 +1,6 @@
 import { isForkException } from '~/portal-client/index.js'
 
+import { safeReturn, withTimeout } from './fallback-async.js'
 import { SourceErrorInfo, capabilityFailure, classifyError } from './fallback-diagnostics.js'
 import { FallbackUnderlyingSource } from './fallback-source.js'
 import { BlockCursor } from './types.js'
@@ -46,19 +47,12 @@ export function makeCapabilityProbe<T>(
 
   return async (atCursor?: BlockCursor): Promise<ProbeResult> => {
     const iterator = source.read(atCursor)[Symbol.asyncIterator]()
-    let timer: ReturnType<typeof setTimeout> | undefined
     try {
-      const next = iterator.next()
-      next.catch(() => {}) // a late rejection after a timeout must not surface as unhandled
-      const timeout = new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(
-          () => reject(capabilityFailure(`probe timed out after ${timeoutMs}ms`, 'timeout')),
-          timeoutMs,
-        )
-      })
-
-      // One batch (or a clean stream end) is enough: it proves the source served the slice.
-      await Promise.race([next, timeout])
+      // One batch (or a clean stream end) is enough: it proves the source served the slice. The
+      // timeout rejects with a ready-made cause (a `SourceErrorInfo`, not a bare Error).
+      await withTimeout(iterator.next(), timeoutMs, () =>
+        capabilityFailure(`probe timed out after ${timeoutMs}ms`, 'timeout'),
+      )
 
       return { ok: true }
     } catch (e) {
@@ -67,17 +61,7 @@ export function makeCapabilityProbe<T>(
       const cause = isErrorInfo(e) ? e : classifyError('capability', e)
       return { ok: false, cause }
     } finally {
-      if (timer) clearTimeout(timer)
-      // Don't await: closing the probe stream must not block, and a stalled source's `return()`
-      // can hang on the same unresolved fetch.
-      try {
-        iterator.return?.()?.then(
-          () => {},
-          () => {},
-        )
-      } catch {
-        /* ignore */
-      }
+      safeReturn(iterator)
     }
   }
 }

--- a/packages/subsquid-pipes/src/core/fallback-capability.ts
+++ b/packages/subsquid-pipes/src/core/fallback-capability.ts
@@ -1,6 +1,6 @@
 import { isForkException } from '~/portal-client/index.js'
 
-import { SourceErrorInfo, classifyError, freshnessFailure } from './fallback-diagnostics.js'
+import { SourceErrorInfo, capabilityFailure, classifyError } from './fallback-diagnostics.js'
 import { FallbackUnderlyingSource } from './fallback-source.js'
 import { BlockCursor } from './types.js'
 
@@ -52,7 +52,7 @@ export function makeCapabilityProbe<T>(
       next.catch(() => {}) // a late rejection after a timeout must not surface as unhandled
       const timeout = new Promise<never>((_resolve, reject) => {
         timer = setTimeout(
-          () => reject(freshnessFailure('capability', 'stale', `probe timed out after ${timeoutMs}ms`)),
+          () => reject(capabilityFailure(`probe timed out after ${timeoutMs}ms`, 'timeout')),
           timeoutMs,
         )
       })

--- a/packages/subsquid-pipes/src/core/fallback-diagnostics.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-diagnostics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { classifyError, redactUrl } from './fallback-diagnostics.js'
+import { capabilityFailure, classifyError, redactUrl } from './fallback-diagnostics.js'
 
 describe('redactUrl', () => {
   it('strips userinfo and query string', () => {
@@ -64,5 +64,19 @@ describe('classifyError', () => {
     expect(info.reason).toBe('unknown')
     expect(info.code).toBeUndefined()
     expect(info.detail).toContain('something odd')
+  })
+})
+
+describe('capabilityFailure', () => {
+  it('defaults to check=capability, reason=unknown (a not-capable probe is not `stale`)', () => {
+    const info = capabilityFailure('probe reported not-capable')
+    expect(info.check).toBe('capability')
+    expect(info.reason).toBe('unknown')
+    expect(info.reason).not.toBe('stale')
+    expect(info.detail).toContain('probe reported not-capable')
+  })
+
+  it('carries an explicit accurate reason, e.g. timeout', () => {
+    expect(capabilityFailure('probe timed out after 20ms', 'timeout').reason).toBe('timeout')
   })
 })

--- a/packages/subsquid-pipes/src/core/fallback-diagnostics.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-diagnostics.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
-import { capabilityFailure, classifyError, redactUrl } from './fallback-diagnostics.js'
+import { capabilityFailure, classifyError, redactText, redactUrl } from './fallback-diagnostics.js'
 
 describe('redactUrl', () => {
+  it('strips the fragment, which can also carry a token', () => {
+    expect(redactUrl('https://rpc.example.com/v1#token=secret')).toBe('https://rpc.example.com/v1')
+  })
+
+  it('redacts credentials in a ws:// endpoint too', () => {
+    expect(redactUrl('wss://user:pass@rpc.example.com/ws?apikey=secret123456')).toBe('wss://rpc.example.com/ws')
+  })
+
   it('strips userinfo and query string', () => {
     expect(redactUrl('https://user:pass@portal.example.com/v1?apikey=secret123456')).toBe(
       'https://portal.example.com/v1',
@@ -19,6 +27,18 @@ describe('redactUrl', () => {
   it('returns undefined for an unparseable value rather than leak it', () => {
     expect(redactUrl('not a url')).toBeUndefined()
     expect(redactUrl(undefined)).toBeUndefined()
+  })
+})
+
+describe('redactText', () => {
+  it('redacts an embedded https URL, fragment and all', () => {
+    expect(redactText('request to https://user:pass@rpc.example.com/v1?apikey=secret#t=x failed')).toBe(
+      'request to https://rpc.example.com/v1 failed',
+    )
+  })
+
+  it('redacts an embedded ws:// / wss:// endpoint (JSON-RPC providers quote these)', () => {
+    expect(redactText('socket wss://k3y@node.example.com/rpc dropped')).toBe('socket wss://node.example.com/rpc dropped')
   })
 })
 

--- a/packages/subsquid-pipes/src/core/fallback-diagnostics.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-diagnostics.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { classifyError, redactUrl } from './fallback-diagnostics.js'
+
+describe('redactUrl', () => {
+  it('strips userinfo and query string', () => {
+    expect(redactUrl('https://user:pass@portal.example.com/v1?apikey=secret123456')).toBe(
+      'https://portal.example.com/v1',
+    )
+  })
+
+  it('masks SQD key tokens and long opaque path segments', () => {
+    expect(redactUrl('https://rpc.example.com/sqd_abc123DEF456')).toBe('https://rpc.example.com/sqd_***')
+    expect(redactUrl('https://portal.example.com/datasets/0123456789abcdef0123456789abcdef')).toBe(
+      'https://portal.example.com/datasets/***',
+    )
+  })
+
+  it('returns undefined for an unparseable value rather than leak it', () => {
+    expect(redactUrl('not a url')).toBeUndefined()
+    expect(redactUrl(undefined)).toBeUndefined()
+  })
+})
+
+describe('classifyError', () => {
+  it('classifies a Portal HttpError by status + redacted url, keeping credentials out of detail', () => {
+    const err = Object.assign(new Error('Got 400 from https://portal.example/q?key=secret123456789'), {
+      name: 'HttpError',
+      response: { status: 400, url: 'https://portal.example/q?key=secret123456789', body: 'not a hypothetical' },
+    })
+    const info = classifyError('capability', err)
+    expect(info).toMatchObject({ check: 'capability', reason: 'http', code: 400 })
+    expect(info.endpoint).toBe('https://portal.example/q')
+    expect(info.detail).toContain('http 400')
+    expect(info.detail).not.toContain('key=secret')
+  })
+
+  it('classifies a JSON-RPC error (HTTP 200 with error body) with its code, and includes the request', () => {
+    const err = Object.assign(new Error('the method debug_traceBlockByNumber does not exist'), {
+      name: 'RpcError',
+      code: -32601,
+      rpcUrl: 'https://rpc.example/sqd_keyTOKEN1234567',
+      rpcMethod: 'debug_traceBlockByNumber',
+      rpcParams: ['0x1', { tracer: 'callTracer' }],
+    })
+    const info = classifyError('stream', err)
+    expect(info).toMatchObject({ check: 'stream', reason: 'rpc', code: -32601 })
+    expect(info.endpoint).toBe('https://rpc.example/sqd_***')
+    expect(info.detail).toContain('debug_traceBlockByNumber')
+    expect(info.detail).toContain('callTracer')
+  })
+
+  it('classifies transport timeouts and connection errors', () => {
+    expect(classifyError('liveness', Object.assign(new Error('x'), { name: 'HttpTimeoutError' })).reason).toBe(
+      'timeout',
+    )
+    expect(classifyError('liveness', Object.assign(new Error('x'), { name: 'RpcConnectionError' })).reason).toBe(
+      'connection',
+    )
+  })
+
+  it('falls back to unknown for an unrecognised error, keeping the message in detail', () => {
+    const info = classifyError('stream', new Error('something odd'))
+    expect(info.reason).toBe('unknown')
+    expect(info.code).toBeUndefined()
+    expect(info.detail).toContain('something odd')
+  })
+})

--- a/packages/subsquid-pipes/src/core/fallback-diagnostics.ts
+++ b/packages/subsquid-pipes/src/core/fallback-diagnostics.ts
@@ -122,3 +122,13 @@ export function classifyError(check: FailedCheck, err: unknown): SourceErrorInfo
 export function freshnessFailure(check: FailedCheck, reason: 'stale' | 'lag', detail: string): SourceErrorInfo {
   return { check, reason, detail: `${check} check failed: ${detail}` }
 }
+
+/**
+ * Build a {@link SourceErrorInfo} for a capability probe that reported not-capable without a thrown,
+ * classifiable error. The reason is never `stale`: a probe fails for non-freshness reasons — pruned
+ * state, disabled `trace_`/`debug_` APIs (`unknown`), or a slice that outran the probe timeout
+ * (`timeout`) — so a `stale` label would misreport it in logs and metrics.
+ */
+export function capabilityFailure(detail: string, reason: FailureReason = 'unknown'): SourceErrorInfo {
+  return { check: 'capability', reason, detail: `capability check failed: ${detail}` }
+}

--- a/packages/subsquid-pipes/src/core/fallback-diagnostics.ts
+++ b/packages/subsquid-pipes/src/core/fallback-diagnostics.ts
@@ -1,0 +1,124 @@
+/**
+ * Turning whatever a source throws into something usable by both logs and metrics. We rely on
+ * sources *throwing* to detect incapability/unreachability, so the supervisor never knows the error
+ * type up front — this normalizer duck-types the conventional fields the SDK already stamps on its
+ * errors (`@subsquid/util-internal`'s `addErrorContext` puts `rpcUrl`/`rpcMethod`/`rpcParams` on a
+ * thrown `RpcError`; `HttpError` carries `.response.{status,url,body}`; transport errors carry a
+ * `name`) rather than importing every error class. The result splits cleanly:
+ *
+ *  - `reason` + `code` + `check` are bounded enums/numbers → safe as Prometheus labels.
+ *  - `detail` (and the embedded, possibly large request) is for logs only — never a metric label.
+ *
+ * This mirrors the Squid SDK's `diagnostics.ts` (the two SDKs deliberately share no code).
+ */
+
+/** Which health check tripped — the leading "<…> failed" in the message. */
+export type FailedCheck = 'stream' | 'liveness' | 'capability'
+
+/** Coarse, bounded failure category. Kept small so it is safe as a metric label. */
+export type FailureReason = 'http' | 'rpc' | 'timeout' | 'connection' | 'stale' | 'lag' | 'fork' | 'unknown'
+
+export interface SourceErrorInfo {
+  /** Which check failed. */
+  check: FailedCheck
+  /** Bounded error category — metric label. */
+  reason: FailureReason
+  /** HTTP status or JSON-RPC error code, when known — metric label. */
+  code?: number
+  /** Endpoint URL with credentials redacted — logs only, never a metric label. */
+  endpoint?: string
+  /** Full human-readable cause, incl. the request when available — logs only. */
+  detail: string
+}
+
+/**
+ * Strip credentials from a URL before it reaches a log line: drop userinfo + query string (where
+ * `?apikey=…` lives) and mask key-like path segments (SQD `sqd_…` tokens and long opaque ids).
+ * Returns `undefined` for an unparseable value rather than risk leaking it verbatim.
+ */
+export function redactUrl(u?: string): string | undefined {
+  if (!u) return undefined
+  try {
+    const url = new URL(u)
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.pathname = url.pathname.replace(/sqd_[A-Za-z0-9]+/g, 'sqd_***').replace(/[A-Za-z0-9_-]{24,}/g, '***')
+    return url.toString()
+  } catch {
+    return undefined
+  }
+}
+
+/** Redact every URL embedded in free text — error messages routinely quote the failing URL. */
+export function redactText(s: string): string {
+  return s.replace(/https?:\/\/[^\s)'"]+/g, (m) => redactUrl(m) ?? '***')
+}
+
+function pickEndpoint(e: any): string | undefined {
+  return redactUrl(e?.rpcUrl ?? e?.response?.url ?? e?.url)
+}
+
+function requestText(e: any): string | undefined {
+  // RpcError is stamped with the offending call by `addErrorContext` (rpc-client).
+  if (e?.rpcMethod) {
+    const params = e.rpcParams === undefined ? '' : ` ${safeJson(e.rpcParams)}`
+    return `${e.rpcMethod}${params}`
+  }
+  // HttpError carries only the server's *response* body, which still localizes the failure.
+  const body = e?.response?.body
+  if (body != null) return `response body: ${typeof body === 'string' ? body : safeJson(body)}`
+  return undefined
+}
+
+function safeJson(v: unknown): string {
+  try {
+    const s = JSON.stringify(v)
+    return s.length > 1000 ? `${s.slice(0, 1000)}…` : s
+  } catch {
+    return String(v)
+  }
+}
+
+/**
+ * Classify an arbitrary thrown value into a {@link SourceErrorInfo}. `check` is supplied by the call
+ * site (the error itself doesn't know which probe ran it).
+ */
+export function classifyError(check: FailedCheck, err: unknown): SourceErrorInfo {
+  const e = err as any
+  const endpoint = pickEndpoint(e)
+  const request = requestText(e)
+  const message = typeof e?.message === 'string' ? e.message : String(e)
+
+  let reason: FailureReason = 'unknown'
+  let code: number | undefined
+
+  if (e?.name === 'HttpError' && typeof e?.response?.status === 'number') {
+    reason = 'http'
+    code = e.response.status
+  } else if (e?.name === 'HttpTimeoutError' || /timed out/i.test(message)) {
+    reason = 'timeout'
+  } else if (e?.name === 'RpcConnectionError') {
+    reason = 'connection'
+  } else if ((e?.name === 'RpcError' || e?.name === 'RpcProtocolError') && typeof e?.code === 'number') {
+    // A JSON-RPC error inside an HTTP 200 body surfaces here (e.g. trace/`debug_` disabled).
+    reason = 'rpc'
+    code = e.code
+  } else if (e?.isSqdForkException) {
+    reason = 'fork'
+  }
+
+  const head = `${check} check failed: ${reason}${code != null ? ` ${code}` : ''}`
+  const detail = [head, endpoint && `from ${endpoint}`, message && `(${message})`, request && `request: ${request}`]
+    .filter(Boolean)
+    .join(', ')
+
+  // Final safety net: the message (and, rarely, the request) can quote the failing URL verbatim,
+  // so scrub credentials from the whole detail before it reaches a log line.
+  return { check, reason, code, endpoint, detail: redactText(detail) }
+}
+
+/** Build a {@link SourceErrorInfo} for an internal freshness trip that has no thrown error. */
+export function freshnessFailure(check: FailedCheck, reason: 'stale' | 'lag', detail: string): SourceErrorInfo {
+  return { check, reason, detail: `${check} check failed: ${detail}` }
+}

--- a/packages/subsquid-pipes/src/core/fallback-diagnostics.ts
+++ b/packages/subsquid-pipes/src/core/fallback-diagnostics.ts
@@ -32,9 +32,10 @@ export interface SourceErrorInfo {
 }
 
 /**
- * Strip credentials from a URL before it reaches a log line: drop userinfo + query string (where
- * `?apikey=…` lives) and mask key-like path segments (SQD `sqd_…` tokens and long opaque ids).
- * Returns `undefined` for an unparseable value rather than risk leaking it verbatim.
+ * Strip credentials from a URL before it reaches a log line: drop userinfo, query string (where
+ * `?apikey=…` lives) and the fragment (`#…`, which can carry a token too), and mask key-like path
+ * segments (SQD `sqd_…` tokens and long opaque ids). Returns `undefined` for an unparseable value
+ * rather than risk leaking it verbatim.
  */
 export function redactUrl(u?: string): string | undefined {
   if (!u) return undefined
@@ -43,6 +44,7 @@ export function redactUrl(u?: string): string | undefined {
     url.username = ''
     url.password = ''
     url.search = ''
+    url.hash = ''
     url.pathname = url.pathname.replace(/sqd_[A-Za-z0-9]+/g, 'sqd_***').replace(/[A-Za-z0-9_-]{24,}/g, '***')
     return url.toString()
   } catch {
@@ -50,9 +52,12 @@ export function redactUrl(u?: string): string | undefined {
   }
 }
 
-/** Redact every URL embedded in free text — error messages routinely quote the failing URL. */
+/**
+ * Redact every URL embedded in free text — error messages routinely quote the failing URL. Matches
+ * both HTTP(S) and WebSocket (`ws://` / `wss://`) endpoints, since JSON-RPC providers quote either.
+ */
 export function redactText(s: string): string {
-  return s.replace(/https?:\/\/[^\s)'"]+/g, (m) => redactUrl(m) ?? '***')
+  return s.replace(/(?:https?|wss?):\/\/[^\s)'"]+/g, (m) => redactUrl(m) ?? '***')
 }
 
 function pickEndpoint(e: any): string | undefined {

--- a/packages/subsquid-pipes/src/core/fallback-health.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-health.test.ts
@@ -56,6 +56,45 @@ describe('SourceHealth', () => {
     health.onLivenessFail()
     expect(health.state).toBe('unhealthy')
   })
+
+  it('a probed source cannot recover on liveness alone after going unhealthy — capability must be re-proved', () => {
+    const { health, advance } = setup({ hasCapabilityProbe: true, cooldownMs: 1000 })
+
+    // Confirm capability once and reach healthy.
+    health.onCapability(true)
+    health.onLivenessPass()
+    health.onLivenessPass()
+    health.onLivenessPass()
+    expect(health.state).toBe('healthy')
+
+    // It fails the real query and goes unhealthy; cooldown returns it to unknown.
+    health.onStreamError()
+    advance(1000)
+    expect(health.state).toBe('unknown')
+
+    // Liveness recovers but capability is no longer confirmed — it must NOT flap back to healthy
+    // without a fresh probe, or we get the churn loop.
+    health.onLivenessPass()
+    health.onLivenessPass()
+    health.onLivenessPass()
+    expect(health.state).toBe('unknown')
+
+    // A fresh successful probe is what finally promotes it.
+    health.onCapability(true)
+    expect(health.state).toBe('healthy')
+  })
+
+  it('a probe-less source still recovers on liveness alone after cooldown', () => {
+    const { health, advance } = setup({ hasCapabilityProbe: false, cooldownMs: 1000 })
+    health.onStreamError()
+    advance(1000)
+    expect(health.state).toBe('unknown')
+
+    health.onLivenessPass()
+    health.onLivenessPass()
+    health.onLivenessPass()
+    expect(health.state).toBe('healthy')
+  })
 })
 
 describe('Selector', () => {

--- a/packages/subsquid-pipes/src/core/fallback-health.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-health.test.ts
@@ -57,6 +57,29 @@ describe('SourceHealth', () => {
     expect(health.state).toBe('unhealthy')
   })
 
+  it('a liveness pass resets the consecutive-fail counter, so non-consecutive blips do not condemn', () => {
+    const { health } = setup() // livenessFailThreshold = 2
+    health.onLivenessFail() // fail #1
+    health.onLivenessPass() // success in between must reset the counter
+    health.onLivenessFail() // this is fail #1 again, NOT #2
+    expect(health.state).toBe('unknown') // not condemned — the fails were not consecutive
+  })
+
+  it('a failed capability probe flips it unhealthy', () => {
+    const { health } = setup({ hasCapabilityProbe: true })
+    health.onCapability(false)
+    expect(health.state).toBe('unhealthy')
+  })
+
+  it('a liveness pass while unhealthy does not reset (or extend) the cooldown', () => {
+    const { health, advance } = setup({ cooldownMs: 1000 })
+    health.onStreamError() // unhealthy at t=0, cooldown ends at t=1000
+    advance(500)
+    health.onLivenessPass() // must be a no-op while unhealthy — not reset the cooldown clock
+    advance(500) // t=1000: cooldown measured from the error, so it elapses now
+    expect(health.state).toBe('unknown') // (if the pass had reset the cooldown, it'd still be unhealthy)
+  })
+
   it('exposes the cause while unhealthy and clears it on recovery', () => {
     const { health, advance } = setup({ cooldownMs: 1000 })
     const cause = { check: 'stream' as const, reason: 'http' as const, code: 400, detail: 'boom' }

--- a/packages/subsquid-pipes/src/core/fallback-health.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-health.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { Selector, SourceHealth, resolveFallbackPolicy } from './fallback-health.js'
+
+function setup(opts: { hasCapabilityProbe?: boolean; cooldownMs?: number } = {}) {
+  let now = 0
+  const policy = resolveFallbackPolicy({
+    clock: () => now,
+    cooldownMs: opts.cooldownMs ?? 1000,
+    livenessFailThreshold: 2,
+    livenessRecoverThreshold: 3,
+  })
+  const health = new SourceHealth(policy, opts.hasCapabilityProbe ?? false)
+
+  return { health, advance: (ms: number) => (now += ms) }
+}
+
+describe('SourceHealth', () => {
+  it('starts unknown', () => {
+    expect(setup().health.state).toBe('unknown')
+  })
+
+  it('a stream error flips it unhealthy until cooldown elapses', () => {
+    const { health, advance } = setup({ cooldownMs: 1000 })
+    health.onStreamError()
+    expect(health.state).toBe('unhealthy')
+    advance(999)
+    expect(health.state).toBe('unhealthy')
+    advance(1)
+    expect(health.state).toBe('unknown')
+  })
+
+  it('promotes unknown → healthy after M liveness passes (no capability probe)', () => {
+    const { health } = setup()
+    health.onLivenessPass()
+    health.onLivenessPass()
+    expect(health.state).toBe('unknown')
+    health.onLivenessPass()
+    expect(health.state).toBe('healthy')
+  })
+
+  it('with a capability probe, liveness alone is not enough', () => {
+    const { health } = setup({ hasCapabilityProbe: true })
+    health.onLivenessPass()
+    health.onLivenessPass()
+    health.onLivenessPass()
+    expect(health.state).toBe('unknown')
+    health.onCapability(true)
+    expect(health.state).toBe('healthy')
+  })
+
+  it('K consecutive liveness fails flip it unhealthy', () => {
+    const { health } = setup()
+    health.onLivenessFail()
+    expect(health.state).toBe('unknown')
+    health.onLivenessFail()
+    expect(health.state).toBe('unhealthy')
+  })
+})
+
+describe('Selector', () => {
+  it('failover picks the lowest healthy/unknown; switch-up only healthy above active', () => {
+    const policy = resolveFallbackPolicy({ livenessRecoverThreshold: 1 })
+    const health = [new SourceHealth(policy, false), new SourceHealth(policy, false), new SourceHealth(policy, false)]
+    const selector = new Selector(health)
+
+    // all unknown → failover picks index 0
+    expect(selector.pickForFailover()).toBe(0)
+    expect(selector.pickSwitchUp(2)).toBeUndefined() // none healthy yet
+
+    health[0].onStreamError() // s0 unhealthy
+    expect(selector.pickForFailover()).toBe(1)
+
+    health[0].onLivenessPass() // s0 still cooling down → stays unhealthy
+    health[1].onLivenessPass() // s1 → healthy (M=1)
+    expect(selector.pickSwitchUp(2)).toBe(1)
+  })
+})

--- a/packages/subsquid-pipes/src/core/fallback-health.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-health.test.ts
@@ -57,6 +57,18 @@ describe('SourceHealth', () => {
     expect(health.state).toBe('unhealthy')
   })
 
+  it('exposes the cause while unhealthy and clears it on recovery', () => {
+    const { health, advance } = setup({ cooldownMs: 1000 })
+    const cause = { check: 'stream' as const, reason: 'http' as const, code: 400, detail: 'boom' }
+
+    health.onStreamError(cause)
+    expect(health.cause).toEqual(cause)
+
+    advance(1000) // cooldown elapses → unknown, cause cleared
+    expect(health.state).toBe('unknown')
+    expect(health.cause).toBeUndefined()
+  })
+
   it('a probed source cannot recover on liveness alone after going unhealthy — capability must be re-proved', () => {
     const { health, advance } = setup({ hasCapabilityProbe: true, cooldownMs: 1000 })
 

--- a/packages/subsquid-pipes/src/core/fallback-health.ts
+++ b/packages/subsquid-pipes/src/core/fallback-health.ts
@@ -3,6 +3,7 @@
  * health model (the two SDKs deliberately share no code — only test scenarios), ported onto the
  * Pipes cursor model.
  */
+import { SourceErrorInfo } from './fallback-diagnostics.js'
 
 /** Trinary health (§4): `unknown` lets the first batch ship before any probe completes. */
 export type FallbackHealth = 'healthy' | 'unhealthy' | 'unknown'
@@ -90,6 +91,7 @@ export class SourceHealth {
   #hasCapabilityProbe: boolean
   #capabilityOk: boolean
   #cooldownUntil = 0
+  #cause: SourceErrorInfo | undefined
 
   constructor(
     private policy: ResolvedFallbackPolicy,
@@ -112,8 +114,13 @@ export class SourceHealth {
     return this.#capabilityOk
   }
 
-  onStreamError(): void {
-    this.#toUnhealthy()
+  /** Why the source is currently unhealthy (`undefined` unless `state === 'unhealthy'`). */
+  get cause(): SourceErrorInfo | undefined {
+    return this.state === 'unhealthy' ? this.#cause : undefined
+  }
+
+  onStreamError(cause?: SourceErrorInfo): void {
+    this.#toUnhealthy(cause)
   }
 
   onBatch(): void {
@@ -128,38 +135,40 @@ export class SourceHealth {
     this.#maybeHealthy()
   }
 
-  onLivenessFail(): void {
+  onLivenessFail(cause?: SourceErrorInfo): void {
     if (this.state === 'unhealthy') return
 
     this.#livenessPass = 0
     this.#livenessFail++
     if (this.#livenessFail >= this.policy.livenessFailThreshold) {
-      this.#toUnhealthy()
+      this.#toUnhealthy(cause)
     }
   }
 
-  onCapability(ok: boolean): void {
+  onCapability(ok: boolean, cause?: SourceErrorInfo): void {
     if (this.state === 'unhealthy') return
 
     if (ok) {
       this.#capabilityOk = true
       this.#maybeHealthy()
     } else {
-      this.#toUnhealthy()
+      this.#toUnhealthy(cause)
     }
   }
 
   #maybeHealthy(): void {
     if (this.#capabilityOk && this.#livenessPass >= this.policy.livenessRecoverThreshold) {
       this.#state = 'healthy'
+      this.#cause = undefined
     }
   }
 
-  #toUnhealthy(): void {
+  #toUnhealthy(cause?: SourceErrorInfo): void {
     this.#state = 'unhealthy'
     this.#cooldownUntil = this.policy.clock() + this.policy.cooldownMs
     this.#livenessPass = 0
     this.#livenessFail = 0
+    this.#cause = cause
     // A probed source must re-prove it can serve the query before it can recover; otherwise a node
     // that stays reachable but keeps failing the real query would flap back to healthy on liveness
     // alone, get re-promoted, and fail again — the churn loop.
@@ -170,6 +179,7 @@ export class SourceHealth {
     this.#state = 'unknown'
     this.#livenessPass = 0
     this.#livenessFail = 0
+    this.#cause = undefined
   }
 }
 

--- a/packages/subsquid-pipes/src/core/fallback-health.ts
+++ b/packages/subsquid-pipes/src/core/fallback-health.ts
@@ -40,6 +40,13 @@ export interface FallbackPolicy {
   freshnessTickMs?: number
   /** Cache an independent head poll this long, to bound the head-query rate. Default 5s. */
   headTtlMs?: number
+  /**
+   * Time-box each independent head poll. A head poll is `await`ed on the batch-critical path, so an
+   * unbounded one lets a sick standby — TCP up but not responding — stall an otherwise-healthy active
+   * source. A poll exceeding this counts as a liveness failure and returns no head. Default 500ms;
+   * `null` disables the guard and relies on the underlying client's own request timeout.
+   */
+  headPollTimeoutMs?: number | null
   /** Injectable clock (ms) for deterministic tests. Defaults to `Date.now`. */
   clock?: () => number
 }
@@ -56,6 +63,7 @@ export interface ResolvedFallbackPolicy {
   maxLagBlocks: number | null
   freshnessTickMs: number
   headTtlMs: number
+  headPollTimeoutMs: number | null
   clock: () => number
 }
 
@@ -71,6 +79,7 @@ const DEFAULTS: ResolvedFallbackPolicy = {
   maxLagBlocks: 10,
   freshnessTickMs: 1000,
   headTtlMs: 5000,
+  headPollTimeoutMs: 500,
   clock: () => Date.now(),
 }
 
@@ -91,6 +100,7 @@ export function resolveFallbackPolicy(p?: FallbackPolicy): ResolvedFallbackPolic
     maxLagBlocks: orDefault(p?.maxLagBlocks, DEFAULTS.maxLagBlocks),
     freshnessTickMs: p?.freshnessTickMs ?? DEFAULTS.freshnessTickMs,
     headTtlMs: p?.headTtlMs ?? DEFAULTS.headTtlMs,
+    headPollTimeoutMs: orDefault(p?.headPollTimeoutMs, DEFAULTS.headPollTimeoutMs),
     clock: p?.clock ?? DEFAULTS.clock,
   }
 }

--- a/packages/subsquid-pipes/src/core/fallback-health.ts
+++ b/packages/subsquid-pipes/src/core/fallback-health.ts
@@ -20,6 +20,12 @@ export interface FallbackPolicy {
   livenessFailThreshold?: number
   /** `M` — consecutive liveness passes (capability confirmed) required to become `healthy`. */
   livenessRecoverThreshold?: number
+  /**
+   * Minimum gap between capability probes of the same standby source. The probe is a full query
+   * slice (unlike Squid, Pipes has no cheap head poll, so the probe doubles as the liveness signal),
+   * so it is throttled to keep recovery from re-running it on every batch boundary. Default 5s.
+   */
+  capabilityProbeIntervalMs?: number
   /** Injectable clock (ms) for deterministic tests. Defaults to `Date.now`. */
   clock?: () => number
 }
@@ -31,6 +37,7 @@ export interface ResolvedFallbackPolicy {
   cooldownMs: number
   livenessFailThreshold: number
   livenessRecoverThreshold: number
+  capabilityProbeIntervalMs: number
   clock: () => number
 }
 
@@ -41,6 +48,7 @@ const DEFAULTS: ResolvedFallbackPolicy = {
   cooldownMs: 30_000,
   livenessFailThreshold: 2,
   livenessRecoverThreshold: 3,
+  capabilityProbeIntervalMs: 5000,
   clock: () => Date.now(),
 }
 
@@ -52,6 +60,7 @@ export function resolveFallbackPolicy(p?: FallbackPolicy): ResolvedFallbackPolic
     cooldownMs: p?.cooldownMs ?? DEFAULTS.cooldownMs,
     livenessFailThreshold: p?.livenessFailThreshold ?? DEFAULTS.livenessFailThreshold,
     livenessRecoverThreshold: p?.livenessRecoverThreshold ?? DEFAULTS.livenessRecoverThreshold,
+    capabilityProbeIntervalMs: p?.capabilityProbeIntervalMs ?? DEFAULTS.capabilityProbeIntervalMs,
     clock: p?.clock ?? DEFAULTS.clock,
   }
 }
@@ -67,11 +76,18 @@ export class AllSourcesDownError extends Error {
 /**
  * Per-source trinary health state machine. Pure and timer-free: fed signals (`onStreamError`,
  * `onBatch`, liveness/capability probe results); cooldown expiry resolves lazily on `state` read.
+ *
+ * A source without a capability probe treats capability as always-confirmed, so liveness alone
+ * promotes it. A source *with* a probe drops its confirmation whenever it goes unhealthy, so it can
+ * never return to `healthy` until a fresh probe succeeds — liveness alone cannot resurrect a node
+ * that keeps failing the real query (e.g. a Portal answering HTTP 400 to a query that passed
+ * type-level validation), which would otherwise recover, get re-promoted, and fail again (churn).
  */
 export class SourceHealth {
   #state: FallbackHealth = 'unknown'
   #livenessPass = 0
   #livenessFail = 0
+  #hasCapabilityProbe: boolean
   #capabilityOk: boolean
   #cooldownUntil = 0
 
@@ -79,6 +95,7 @@ export class SourceHealth {
     private policy: ResolvedFallbackPolicy,
     hasCapabilityProbe: boolean,
   ) {
+    this.#hasCapabilityProbe = hasCapabilityProbe
     this.#capabilityOk = !hasCapabilityProbe
   }
 
@@ -88,6 +105,11 @@ export class SourceHealth {
     }
 
     return this.#state
+  }
+
+  /** True once capability has been confirmed — or always, for a source with no capability probe. */
+  get capabilityConfirmed(): boolean {
+    return this.#capabilityOk
   }
 
   onStreamError(): void {
@@ -138,6 +160,10 @@ export class SourceHealth {
     this.#cooldownUntil = this.policy.clock() + this.policy.cooldownMs
     this.#livenessPass = 0
     this.#livenessFail = 0
+    // A probed source must re-prove it can serve the query before it can recover; otherwise a node
+    // that stays reachable but keeps failing the real query would flap back to healthy on liveness
+    // alone, get re-promoted, and fail again — the churn loop.
+    this.#capabilityOk = !this.#hasCapabilityProbe
   }
 
   #toUnknown(): void {

--- a/packages/subsquid-pipes/src/core/fallback-health.ts
+++ b/packages/subsquid-pipes/src/core/fallback-health.ts
@@ -1,0 +1,174 @@
+/**
+ * Health + selection for the {@link FallbackSource}. This mirrors the Squid SDK's fallback
+ * health model (the two SDKs deliberately share no code — only test scenarios), ported onto the
+ * Pipes cursor model.
+ */
+
+/** Trinary health (§4): `unknown` lets the first batch ship before any probe completes. */
+export type FallbackHealth = 'healthy' | 'unhealthy' | 'unknown'
+
+export interface FallbackPolicy {
+  /** `eager` (default) reclaims a recovered higher-preference source at a batch boundary. */
+  preferPrimary?: 'eager' | 'onFailureOnly'
+  /** All sources down: `null` (default) polls forever; a finite value throws after waiting. */
+  allDownTimeoutMs?: number | null
+  /** Backoff between all-down poll attempts. */
+  allDownPollMs?: number
+  /** Cooldown an `unhealthy` source waits before returning to `unknown`. */
+  cooldownMs?: number
+  /** `K` — consecutive failed liveness probes that flip a source `unhealthy`. */
+  livenessFailThreshold?: number
+  /** `M` — consecutive liveness passes (capability confirmed) required to become `healthy`. */
+  livenessRecoverThreshold?: number
+  /** Injectable clock (ms) for deterministic tests. Defaults to `Date.now`. */
+  clock?: () => number
+}
+
+export interface ResolvedFallbackPolicy {
+  preferPrimary: 'eager' | 'onFailureOnly'
+  allDownTimeoutMs: number | null
+  allDownPollMs: number
+  cooldownMs: number
+  livenessFailThreshold: number
+  livenessRecoverThreshold: number
+  clock: () => number
+}
+
+const DEFAULTS: ResolvedFallbackPolicy = {
+  preferPrimary: 'eager',
+  allDownTimeoutMs: null,
+  allDownPollMs: 1000,
+  cooldownMs: 30_000,
+  livenessFailThreshold: 2,
+  livenessRecoverThreshold: 3,
+  clock: () => Date.now(),
+}
+
+export function resolveFallbackPolicy(p?: FallbackPolicy): ResolvedFallbackPolicy {
+  return {
+    preferPrimary: p?.preferPrimary ?? DEFAULTS.preferPrimary,
+    allDownTimeoutMs: p?.allDownTimeoutMs === undefined ? DEFAULTS.allDownTimeoutMs : p.allDownTimeoutMs,
+    allDownPollMs: p?.allDownPollMs ?? DEFAULTS.allDownPollMs,
+    cooldownMs: p?.cooldownMs ?? DEFAULTS.cooldownMs,
+    livenessFailThreshold: p?.livenessFailThreshold ?? DEFAULTS.livenessFailThreshold,
+    livenessRecoverThreshold: p?.livenessRecoverThreshold ?? DEFAULTS.livenessRecoverThreshold,
+    clock: p?.clock ?? DEFAULTS.clock,
+  }
+}
+
+export class AllSourcesDownError extends Error {
+  override readonly name = 'AllSourcesDownError'
+
+  constructor() {
+    super('all fallback data sources are unavailable')
+  }
+}
+
+/**
+ * Per-source trinary health state machine. Pure and timer-free: fed signals (`onStreamError`,
+ * `onBatch`, liveness/capability probe results); cooldown expiry resolves lazily on `state` read.
+ */
+export class SourceHealth {
+  #state: FallbackHealth = 'unknown'
+  #livenessPass = 0
+  #livenessFail = 0
+  #capabilityOk: boolean
+  #cooldownUntil = 0
+
+  constructor(
+    private policy: ResolvedFallbackPolicy,
+    hasCapabilityProbe: boolean,
+  ) {
+    this.#capabilityOk = !hasCapabilityProbe
+  }
+
+  get state(): FallbackHealth {
+    if (this.#state === 'unhealthy' && this.policy.clock() >= this.#cooldownUntil) {
+      this.#toUnknown()
+    }
+
+    return this.#state
+  }
+
+  onStreamError(): void {
+    this.#toUnhealthy()
+  }
+
+  onBatch(): void {
+    this.onLivenessPass()
+  }
+
+  onLivenessPass(): void {
+    if (this.state === 'unhealthy') return
+
+    this.#livenessFail = 0
+    this.#livenessPass++
+    this.#maybeHealthy()
+  }
+
+  onLivenessFail(): void {
+    if (this.state === 'unhealthy') return
+
+    this.#livenessPass = 0
+    this.#livenessFail++
+    if (this.#livenessFail >= this.policy.livenessFailThreshold) {
+      this.#toUnhealthy()
+    }
+  }
+
+  onCapability(ok: boolean): void {
+    if (this.state === 'unhealthy') return
+
+    if (ok) {
+      this.#capabilityOk = true
+      this.#maybeHealthy()
+    } else {
+      this.#toUnhealthy()
+    }
+  }
+
+  #maybeHealthy(): void {
+    if (this.#capabilityOk && this.#livenessPass >= this.policy.livenessRecoverThreshold) {
+      this.#state = 'healthy'
+    }
+  }
+
+  #toUnhealthy(): void {
+    this.#state = 'unhealthy'
+    this.#cooldownUntil = this.policy.clock() + this.policy.cooldownMs
+    this.#livenessPass = 0
+    this.#livenessFail = 0
+  }
+
+  #toUnknown(): void {
+    this.#state = 'unknown'
+    this.#livenessPass = 0
+    this.#livenessFail = 0
+  }
+}
+
+/**
+ * Picks the active source: failover tries the lowest-index `healthy` or `unknown` source
+ * (optimistically — the stream is the fastest health test); switch-up only ever promotes to a
+ * `healthy` source of higher preference (lower index) than the active one.
+ */
+export class Selector {
+  constructor(private health: SourceHealth[]) {}
+
+  pickForFailover(): number | undefined {
+    for (let i = 0; i < this.health.length; i++) {
+      const s = this.health[i].state
+      if (s === 'healthy' || s === 'unknown') return i
+    }
+
+    return undefined
+  }
+
+  pickSwitchUp(active: number): number | undefined {
+    for (let i = 0; i < active; i++) {
+      if (this.health[i].state === 'healthy') return i
+    }
+
+    return undefined
+  }
+}

--- a/packages/subsquid-pipes/src/core/fallback-health.ts
+++ b/packages/subsquid-pipes/src/core/fallback-health.ts
@@ -23,10 +23,23 @@ export interface FallbackPolicy {
   livenessRecoverThreshold?: number
   /**
    * Minimum gap between capability probes of the same standby source. The probe is a full query
-   * slice (unlike Squid, Pipes has no cheap head poll, so the probe doubles as the liveness signal),
-   * so it is throttled to keep recovery from re-running it on every batch boundary. Default 5s.
+   * slice, so it is throttled to keep recovery from re-running it on every batch boundary. For a
+   * source with `getHead`, a cheap head poll carries liveness and the probe only confirms capability;
+   * for a source without it, the probe doubles as the liveness signal. Default 5s.
    */
   capabilityProbeIntervalMs?: number
+  /**
+   * Staleness/lag detection needs an independent chain-head reference, so it only runs for sources
+   * that implement `getHead`. `null` disables each check.
+   */
+  /** Fail a stalled source over (to a fresher one) if a batch stays outstanding this long. Default 3min. */
+  maxStalenessMs?: number | null
+  /** Fail the active over once it falls this many blocks behind the independent head. Default 10. */
+  maxLagBlocks?: number | null
+  /** How often, while a request is outstanding, to re-check staleness. Default 1s. */
+  freshnessTickMs?: number
+  /** Cache an independent head poll this long, to bound the head-query rate. Default 5s. */
+  headTtlMs?: number
   /** Injectable clock (ms) for deterministic tests. Defaults to `Date.now`. */
   clock?: () => number
 }
@@ -39,6 +52,10 @@ export interface ResolvedFallbackPolicy {
   livenessFailThreshold: number
   livenessRecoverThreshold: number
   capabilityProbeIntervalMs: number
+  maxStalenessMs: number | null
+  maxLagBlocks: number | null
+  freshnessTickMs: number
+  headTtlMs: number
   clock: () => number
 }
 
@@ -50,18 +67,30 @@ const DEFAULTS: ResolvedFallbackPolicy = {
   livenessFailThreshold: 2,
   livenessRecoverThreshold: 3,
   capabilityProbeIntervalMs: 5000,
+  maxStalenessMs: 180_000,
+  maxLagBlocks: 10,
+  freshnessTickMs: 1000,
+  headTtlMs: 5000,
   clock: () => Date.now(),
+}
+
+function orDefault<T>(value: T | undefined, fallback: T): T {
+  return value === undefined ? fallback : value
 }
 
 export function resolveFallbackPolicy(p?: FallbackPolicy): ResolvedFallbackPolicy {
   return {
     preferPrimary: p?.preferPrimary ?? DEFAULTS.preferPrimary,
-    allDownTimeoutMs: p?.allDownTimeoutMs === undefined ? DEFAULTS.allDownTimeoutMs : p.allDownTimeoutMs,
+    allDownTimeoutMs: orDefault(p?.allDownTimeoutMs, DEFAULTS.allDownTimeoutMs),
     allDownPollMs: p?.allDownPollMs ?? DEFAULTS.allDownPollMs,
     cooldownMs: p?.cooldownMs ?? DEFAULTS.cooldownMs,
     livenessFailThreshold: p?.livenessFailThreshold ?? DEFAULTS.livenessFailThreshold,
     livenessRecoverThreshold: p?.livenessRecoverThreshold ?? DEFAULTS.livenessRecoverThreshold,
     capabilityProbeIntervalMs: p?.capabilityProbeIntervalMs ?? DEFAULTS.capabilityProbeIntervalMs,
+    maxStalenessMs: orDefault(p?.maxStalenessMs, DEFAULTS.maxStalenessMs),
+    maxLagBlocks: orDefault(p?.maxLagBlocks, DEFAULTS.maxLagBlocks),
+    freshnessTickMs: p?.freshnessTickMs ?? DEFAULTS.freshnessTickMs,
+    headTtlMs: p?.headTtlMs ?? DEFAULTS.headTtlMs,
     clock: p?.clock ?? DEFAULTS.clock,
   }
 }

--- a/packages/subsquid-pipes/src/core/fallback-metrics.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-metrics.test.ts
@@ -20,7 +20,12 @@ describe('registerFallbackMetrics', () => {
       activeIndex: 1,
       switchCount: 2,
       sources: [
-        { name: 'portal', health: 'unhealthy', active: false },
+        {
+          name: 'portal',
+          health: 'unhealthy',
+          active: false,
+          cause: { check: 'capability', reason: 'http', code: 400, detail: 'capability check failed: http 400, …' },
+        },
         { name: 'rpc', health: 'unknown', active: true },
       ],
     }
@@ -35,9 +40,20 @@ describe('registerFallbackMetrics', () => {
     ])
 
     const health = captured.get('sqd_fallback_source_health')!.gauge
-    expect(health.calls).toContainEqual({ labels: { source: 'portal', state: 'unhealthy' }, value: 1 })
-    expect(health.calls).toContainEqual({ labels: { source: 'portal', state: 'healthy' }, value: 0 })
-    expect(health.calls).toContainEqual({ labels: { source: 'rpc', state: 'unknown' }, value: 1 })
+    // The unhealthy row carries the cause as bounded labels; the request detail is never a label.
+    expect(health.calls).toContainEqual({
+      labels: { source: 'portal', state: 'unhealthy', check: 'capability', reason: 'http', code: '400' },
+      value: 1,
+    })
+    expect(health.calls).toContainEqual({
+      labels: { source: 'portal', state: 'healthy', check: '', reason: '', code: '' },
+      value: 0,
+    })
+    expect(health.calls).toContainEqual({
+      labels: { source: 'rpc', state: 'unknown', check: '', reason: '', code: '' },
+      value: 1,
+    })
+    expect(health.calls.every((c) => !JSON.stringify(c).includes('capability check failed'))).toBe(true)
 
     expect(captured.get('sqd_fallback_switches_total')!.gauge.calls).toEqual([{ value: 2 }])
   })

--- a/packages/subsquid-pipes/src/core/fallback-metrics.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-metrics.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { MockGauge } from '~/testing/index.js'
+
+import { registerFallbackMetrics } from './fallback-metrics.js'
+import { FallbackMetrics } from './fallback-source.js'
+
+describe('registerFallbackMetrics', () => {
+  it('exports active source, per-source health, and switch count via collect', () => {
+    const captured = new Map<string, { collect: (this: MockGauge) => void; gauge: MockGauge }>()
+    const metrics: any = {
+      gauge(config: any) {
+        const gauge = new MockGauge()
+        captured.set(config.name, { collect: config.collect, gauge })
+        return gauge
+      },
+    }
+
+    const snapshot: FallbackMetrics = {
+      activeIndex: 1,
+      switchCount: 2,
+      sources: [
+        { name: 'portal', health: 'unhealthy', active: false },
+        { name: 'rpc', health: 'unknown', active: true },
+      ],
+    }
+    registerFallbackMetrics(metrics, { metrics: () => snapshot })
+
+    // Drive each gauge's scrape-time collect callback.
+    for (const { collect, gauge } of captured.values()) collect.call(gauge)
+
+    expect(captured.get('sqd_fallback_active')!.gauge.calls).toEqual([
+      { labels: { source: 'portal' }, value: 0 },
+      { labels: { source: 'rpc' }, value: 1 },
+    ])
+
+    const health = captured.get('sqd_fallback_source_health')!.gauge
+    expect(health.calls).toContainEqual({ labels: { source: 'portal', state: 'unhealthy' }, value: 1 })
+    expect(health.calls).toContainEqual({ labels: { source: 'portal', state: 'healthy' }, value: 0 })
+    expect(health.calls).toContainEqual({ labels: { source: 'rpc', state: 'unknown' }, value: 1 })
+
+    expect(captured.get('sqd_fallback_switches_total')!.gauge.calls).toEqual([{ value: 2 }])
+  })
+})

--- a/packages/subsquid-pipes/src/core/fallback-metrics.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-metrics.test.ts
@@ -59,7 +59,7 @@ describe('registerFallbackMetrics', () => {
     })
     expect(health.calls.every((c) => !JSON.stringify(c).includes('capability check failed'))).toBe(true)
 
-    expect(captured.get('sqd_fallback_switches_total')!.gauge.calls).toEqual([{ value: 2 }])
+    expect(captured.get('sqd_fallback_switches')!.gauge.calls).toEqual([{ value: 2 }])
     expect(captured.get('sqd_fallback_lag_blocks')!.gauge.calls).toEqual([{ value: 7 }])
     expect(captured.get('sqd_fallback_staleness_ms')!.gauge.calls).toEqual([{ value: 1500 }])
     expect(captured.get('sqd_fallback_chain_stalled')!.gauge.calls).toEqual([{ value: 1 }])

--- a/packages/subsquid-pipes/src/core/fallback-metrics.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-metrics.test.ts
@@ -19,6 +19,10 @@ describe('registerFallbackMetrics', () => {
     const snapshot: FallbackMetrics = {
       activeIndex: 1,
       switchCount: 2,
+      lag: 7,
+      staleness: 1500,
+      chainHead: 100,
+      chainStalled: true,
       sources: [
         {
           name: 'portal',
@@ -56,5 +60,8 @@ describe('registerFallbackMetrics', () => {
     expect(health.calls.every((c) => !JSON.stringify(c).includes('capability check failed'))).toBe(true)
 
     expect(captured.get('sqd_fallback_switches_total')!.gauge.calls).toEqual([{ value: 2 }])
+    expect(captured.get('sqd_fallback_lag_blocks')!.gauge.calls).toEqual([{ value: 7 }])
+    expect(captured.get('sqd_fallback_staleness_ms')!.gauge.calls).toEqual([{ value: 1500 }])
+    expect(captured.get('sqd_fallback_chain_stalled')!.gauge.calls).toEqual([{ value: 1 }])
   })
 })

--- a/packages/subsquid-pipes/src/core/fallback-metrics.ts
+++ b/packages/subsquid-pipes/src/core/fallback-metrics.ts
@@ -60,7 +60,9 @@ export function registerFallbackMetrics(
   })
 
   metrics.gauge({
-    name: `${prefix}_switches_total`,
+    // No `_total` suffix — that suffix is reserved for Counters by Prometheus convention, and this is
+    // a pull-based gauge set to the current cumulative value (matches the Squid metric name).
+    name: `${prefix}_switches`,
     help: 'Cumulative number of fallback source switches',
     collect() {
       this.set(source.metrics().switchCount)

--- a/packages/subsquid-pipes/src/core/fallback-metrics.ts
+++ b/packages/subsquid-pipes/src/core/fallback-metrics.ts
@@ -1,0 +1,52 @@
+import { FallbackMetrics } from './fallback-source.js'
+import { Metrics } from './metrics-server.js'
+
+export interface FallbackMetricsSource {
+  metrics(): FallbackMetrics
+}
+
+const HEALTH_STATES = ['healthy', 'unhealthy', 'unknown'] as const
+
+/**
+ * Register pull-based gauges that export a {@link FallbackSource}'s observable state on a metrics
+ * surface (§4 — "unhealthiness reflected in metrics"): which source is active, each source's
+ * trinary health, and the cumulative switch count. The gauges read `source.metrics()` on every
+ * scrape via the prom-style `collect` callback, so there is nothing to push.
+ */
+export function registerFallbackMetrics(
+  metrics: Metrics,
+  source: FallbackMetricsSource,
+  prefix = 'sqd_fallback',
+): void {
+  metrics.gauge<'source'>({
+    name: `${prefix}_active`,
+    help: 'Currently active fallback source (1 = active, 0 = standby)',
+    labelNames: ['source'],
+    collect() {
+      for (const s of source.metrics().sources) {
+        this.set({ source: s.name }, s.active ? 1 : 0)
+      }
+    },
+  })
+
+  metrics.gauge<'source' | 'state'>({
+    name: `${prefix}_source_health`,
+    help: 'Per-source trinary health (1 for the current state, 0 otherwise)',
+    labelNames: ['source', 'state'],
+    collect() {
+      for (const s of source.metrics().sources) {
+        for (const state of HEALTH_STATES) {
+          this.set({ source: s.name, state }, s.health === state ? 1 : 0)
+        }
+      }
+    },
+  })
+
+  metrics.gauge({
+    name: `${prefix}_switches_total`,
+    help: 'Cumulative number of fallback source switches',
+    collect() {
+      this.set(source.metrics().switchCount)
+    },
+  })
+}

--- a/packages/subsquid-pipes/src/core/fallback-metrics.ts
+++ b/packages/subsquid-pipes/src/core/fallback-metrics.ts
@@ -38,8 +38,9 @@ export function registerFallbackMetrics(
     labelNames: ['source', 'state', 'check', 'reason', 'code'],
     collect() {
       // Reset so a previous scrape's cause labels (e.g. an old `code`) don't linger as stale series
-      // once the source recovers or fails for a different reason.
-      this.reset()
+      // once the source recovers or fails for a different reason. Optional-chained: a custom
+      // MetricsServer may not implement reset() (then stale series just aren't pruned).
+      this.reset?.()
       for (const s of source.metrics().sources) {
         for (const state of HEALTH_STATES) {
           // Only the current, unhealthy state row gets cause labels.

--- a/packages/subsquid-pipes/src/core/fallback-metrics.ts
+++ b/packages/subsquid-pipes/src/core/fallback-metrics.ts
@@ -66,4 +66,28 @@ export function registerFallbackMetrics(
       this.set(source.metrics().switchCount)
     },
   })
+
+  metrics.gauge({
+    name: `${prefix}_lag_blocks`,
+    help: 'Blocks the active source is behind the independent chain-head reference',
+    collect() {
+      this.set(source.metrics().lag)
+    },
+  })
+
+  metrics.gauge({
+    name: `${prefix}_staleness_ms`,
+    help: 'Duration the active source has had a batch request outstanding (ms)',
+    collect() {
+      this.set(source.metrics().staleness)
+    },
+  })
+
+  metrics.gauge({
+    name: `${prefix}_chain_stalled`,
+    help: 'Whether every source is stuck at the same head (1 = stalled)',
+    collect() {
+      this.set(source.metrics().chainStalled ? 1 : 0)
+    },
+  })
 }

--- a/packages/subsquid-pipes/src/core/fallback-metrics.ts
+++ b/packages/subsquid-pipes/src/core/fallback-metrics.ts
@@ -29,14 +29,31 @@ export function registerFallbackMetrics(
     },
   })
 
-  metrics.gauge<'source' | 'state'>({
+  metrics.gauge<'source' | 'state' | 'check' | 'reason' | 'code'>({
     name: `${prefix}_source_health`,
-    help: 'Per-source trinary health (1 for the current state, 0 otherwise)',
-    labelNames: ['source', 'state'],
+    help:
+      'Per-source trinary health (1 for the current state, 0 otherwise). The unhealthy row carries ' +
+      'the cause as `check`/`reason`/`code` labels (empty otherwise); the full detail incl. the ' +
+      'request is in logs, never a label.',
+    labelNames: ['source', 'state', 'check', 'reason', 'code'],
     collect() {
+      // Reset so a previous scrape's cause labels (e.g. an old `code`) don't linger as stale series
+      // once the source recovers or fails for a different reason.
+      this.reset()
       for (const s of source.metrics().sources) {
         for (const state of HEALTH_STATES) {
-          this.set({ source: s.name, state }, s.health === state ? 1 : 0)
+          // Only the current, unhealthy state row gets cause labels.
+          const c = state === 'unhealthy' ? s.cause : undefined
+          this.set(
+            {
+              source: s.name,
+              state,
+              check: c?.check ?? '',
+              reason: c?.reason ?? '',
+              code: c?.code != null ? String(c.code) : '',
+            },
+            s.health === state ? 1 : 0,
+          )
         }
       }
     },

--- a/packages/subsquid-pipes/src/core/fallback-source.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+
+import { ForkException } from '~/portal-client/index.js'
+
+import { FallbackSource, FallbackUnderlyingSource } from './fallback-source.js'
+import { PortalBatch } from './portal-source.js'
+import { Target } from './target.js'
+import { BlockCursor } from './types.js'
+
+/**
+ * Unit tests for the generic fallback supervisor, using mock `read` functions (async generators
+ * yielding `PortalBatch`es) — the meta-source analog of the Squid SDK's MockSource. No HTTP is
+ * mocked here; the Portal/RPC adapters are exercised separately.
+ */
+
+function cursor(n: number, hash = `0x${n}`): BlockCursor {
+  return { number: n, hash }
+}
+
+function pbatch(n: number, hash?: string): PortalBatch<number[]> {
+  return {
+    data: [n],
+    ctx: { stream: { state: { current: cursor(n, hash) }, head: {} } },
+  } as unknown as PortalBatch<number[]>
+}
+
+type ReadFn = (cursor?: BlockCursor) => AsyncGenerator<PortalBatch<number[]>>
+
+function source(
+  name: string,
+  read: ReadFn,
+): FallbackUnderlyingSource<number[]> & { reads: (BlockCursor | undefined)[] } {
+  const reads: (BlockCursor | undefined)[] = []
+  return {
+    name,
+    reads,
+    read: (c) => {
+      reads.push(c)
+      return read(c)
+    },
+  }
+}
+
+async function collect(stream: AsyncIterable<PortalBatch<number[]>>): Promise<number[]> {
+  const out: number[] = []
+  for await (const b of stream) out.push(...b.data)
+  return out
+}
+
+describe('FallbackSource — supervisor', () => {
+  it('drives the lowest-index source; standbys are untouched', async () => {
+    const s0 = source('s0', async function* () {
+      yield pbatch(1)
+      yield pbatch(2)
+    })
+    const s1 = source('s1', async function* () {
+      yield pbatch(99)
+    })
+    const fb = new FallbackSource([s0, s1])
+
+    expect(await collect(fb.read())).toEqual([1, 2])
+    expect(s1.reads).toHaveLength(0)
+  })
+
+  it('resumes the next source from the last cursor on a non-fork error', async () => {
+    const s0 = source('s0', async function* () {
+      yield pbatch(1)
+      yield pbatch(2)
+      throw new Error('boom')
+    })
+    const s1 = source('s1', async function* (c) {
+      expect(c).toEqual(cursor(2)) // resume just after the last committed block
+      yield pbatch(3)
+    })
+    const fb = new FallbackSource([s0, s1])
+
+    expect(await collect(fb.read())).toEqual([1, 2, 3])
+    expect(s1.reads).toEqual([cursor(2)])
+  })
+
+  it('cascades through multiple failing sources', async () => {
+    const s0 = source('s0', async function* () {
+      yield pbatch(1)
+      throw new Error('e0')
+    })
+    const s1 = source('s1', async function* () {
+      throw new Error('e1')
+    })
+    const s2 = source('s2', async function* (c) {
+      expect(c).toEqual(cursor(1))
+      yield pbatch(2)
+    })
+    const fb = new FallbackSource([s0, s1, s2])
+
+    expect(await collect(fb.read())).toEqual([1, 2])
+  })
+
+  it('propagates ForkException instead of switching', async () => {
+    const s0 = source('s0', async function* () {
+      yield pbatch(1)
+      throw new ForkException([cursor(1)], { fromBlock: 2, parentBlockHash: '0x1' })
+    })
+    const s1 = source('s1', async function* () {
+      yield pbatch(99)
+    })
+    const fb = new FallbackSource([s0, s1])
+
+    const seen: number[] = []
+    await expect(
+      (async () => {
+        for await (const b of fb.read()) seen.push(...b.data)
+      })(),
+    ).rejects.toBeInstanceOf(ForkException)
+    expect(seen).toEqual([1])
+    expect(s1.reads).toHaveLength(0)
+  })
+
+  it('throws AllSourcesDown after a finite timeout', async () => {
+    const down: ReadFn = async function* () {
+      throw new Error('down')
+    }
+    const fb = new FallbackSource([source('s0', down), source('s1', down)], {
+      allDownTimeoutMs: 0,
+      allDownPollMs: 1,
+    })
+
+    await expect(collect(fb.read())).rejects.toThrowError(/all fallback data sources/)
+  })
+})
+
+describe('FallbackSource — pipeTo', () => {
+  it('rewinds via target.fork when a source forks, then resumes', async () => {
+    let forkedTo: BlockCursor | null = null
+    const s0 = source('s0', async function* (c) {
+      if (c == null) {
+        yield pbatch(1)
+        yield pbatch(2, '0x2-bad')
+        throw new ForkException([cursor(1), cursor(2, '0x2-bad')], { fromBlock: 3, parentBlockHash: '0x2-bad' })
+      }
+      // after the rewind, resume from the safe cursor
+      expect(c).toEqual(cursor(1))
+      yield pbatch(2, '0x2-good')
+    })
+
+    const written: number[] = []
+    const target: Target<number[]> = {
+      write: async ({ read }) => {
+        for await (const b of read()) written.push(...b.data)
+      },
+      fork: async (previousBlocks) => {
+        forkedTo = previousBlocks[0] // resolve to the common ancestor
+        return forkedTo
+      },
+    }
+
+    const fb = new FallbackSource([s0])
+    await fb.pipeTo(target)
+
+    expect(forkedTo).toEqual(cursor(1))
+    expect(written).toEqual([1, 2, 2]) // 2-bad yielded, rewound, 2-good re-served
+  })
+})

--- a/packages/subsquid-pipes/src/core/fallback-source.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.test.ts
@@ -545,3 +545,63 @@ describe('FallbackSource — freshness', () => {
     expect(fb.activeIndex).toBe(0) // never armed (was ahead of the reference) ⇒ no lag failover
   })
 })
+
+describe('FallbackSource — head-poll timeout (robustness)', () => {
+  // A head poll that never resolves — models a sick standby: TCP up, no response.
+  const hangHead = (): Promise<BlockCursor | undefined> => new Promise<BlockCursor | undefined>(() => {})
+
+  it('a sick standby whose getHead hangs does not stall the healthy active source', async () => {
+    const s0 = source('s0', async function* () {
+      yield pbatch(1)
+      yield pbatch(2)
+      yield pbatch(3)
+    })
+    // Its head poll hangs; without the timeout, the per-batch lag check would block s0 forever.
+    const s1 = headSource('s1', async function* () {}, hangHead)
+    const fb = new FallbackSource(
+      [s0, s1],
+      {
+        maxLagBlocks: 10,
+        maxStalenessMs: null,
+        headTtlMs: 0,
+        headPollTimeoutMs: 20,
+        livenessFailThreshold: 1, // one timed-out poll condemns the sick standby
+        cooldownMs: 60_000,
+      },
+      silent,
+    )
+
+    expect(await collect(fb)).toEqual([1, 2, 3]) // the healthy primary streamed to completion
+    expect(fb.activeIndex).toBe(0)
+    const s1health = fb.metrics().sources[1]
+    expect(s1health.health).toBe('unhealthy')
+    expect(s1health.cause).toMatchObject({ check: 'liveness', reason: 'timeout' })
+  }, 5000)
+})
+
+describe('FallbackSource — active capability confirmation', () => {
+  it('reaches healthy by serving batches, without the standby capability probe ever running', async () => {
+    let probed = 0
+    const s0 = source('s0', async function* () {
+      yield pbatch(1)
+      yield pbatch(2)
+      yield pbatch(3)
+      yield pbatch(4)
+    })
+    ;(s0 as { probeCapability?: () => Promise<{ ok: boolean }> }).probeCapability = async () => {
+      probed++
+      return { ok: true }
+    }
+    const fb = new FallbackSource(
+      [s0],
+      { livenessRecoverThreshold: 3, maxLagBlocks: null, maxStalenessMs: null },
+      silent,
+    )
+
+    expect(await collect(fb)).toEqual([1, 2, 3, 4])
+    // The active source proved capability by serving the query — the standby probe never ran for it,
+    // yet it still left `unknown` for `healthy`.
+    expect(probed).toBe(0)
+    expect(fb.metrics().sources[0].health).toBe('healthy')
+  })
+})

--- a/packages/subsquid-pipes/src/core/fallback-source.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { ForkException } from '~/portal-client/index.js'
 
 import { FallbackSource, FallbackUnderlyingSource } from './fallback-source.js'
+import { createDefaultLogger } from './logger.js'
 import { PortalBatch } from './portal-source.js'
 import { Target } from './target.js'
 import { BlockCursor } from './types.js'
@@ -12,6 +13,9 @@ import { BlockCursor } from './types.js'
  * yielding `PortalBatch`es) — the meta-source analog of the Squid SDK's MockSource. No HTTP is
  * mocked here; the Portal/RPC adapters are exercised separately.
  */
+
+/** Keep the default cause-logging (warn) out of the test output. */
+const silent = createDefaultLogger({ level: 'silent' })
 
 function cursor(n: number, hash = `0x${n}`): BlockCursor {
   return { number: n, hash }
@@ -56,7 +60,7 @@ describe('FallbackSource — supervisor', () => {
     const s1 = source('s1', async function* () {
       yield pbatch(99)
     })
-    const fb = new FallbackSource([s0, s1])
+    const fb = new FallbackSource([s0, s1], undefined, silent)
 
     expect(await collect(fb.read())).toEqual([1, 2])
     expect(s1.reads).toHaveLength(0)
@@ -72,7 +76,7 @@ describe('FallbackSource — supervisor', () => {
       expect(c).toEqual(cursor(2)) // resume just after the last committed block
       yield pbatch(3)
     })
-    const fb = new FallbackSource([s0, s1])
+    const fb = new FallbackSource([s0, s1], undefined, silent)
 
     expect(await collect(fb.read())).toEqual([1, 2, 3])
     expect(s1.reads).toEqual([cursor(2)])
@@ -90,7 +94,7 @@ describe('FallbackSource — supervisor', () => {
       expect(c).toEqual(cursor(1))
       yield pbatch(2)
     })
-    const fb = new FallbackSource([s0, s1, s2])
+    const fb = new FallbackSource([s0, s1, s2], undefined, silent)
 
     expect(await collect(fb.read())).toEqual([1, 2])
   })
@@ -103,7 +107,7 @@ describe('FallbackSource — supervisor', () => {
     const s1 = source('s1', async function* () {
       yield pbatch(99)
     })
-    const fb = new FallbackSource([s0, s1])
+    const fb = new FallbackSource([s0, s1], undefined, silent)
 
     const seen: number[] = []
     await expect(
@@ -126,7 +130,7 @@ describe('FallbackSource — supervisor', () => {
     let probes = 0
     s0.probeCapability = async () => {
       probes++
-      return true
+      return { ok: true }
     }
 
     const s1 = source('s1', async function* () {
@@ -136,12 +140,16 @@ describe('FallbackSource — supervisor', () => {
       }
     })
 
-    const fb = new FallbackSource([s0, s1], {
-      clock: () => now,
-      cooldownMs: 50,
-      capabilityProbeIntervalMs: 0,
-      livenessRecoverThreshold: 1, // one successful probe is enough to confirm + recover
-    })
+    const fb = new FallbackSource(
+      [s0, s1],
+      {
+        clock: () => now,
+        cooldownMs: 50,
+        capabilityProbeIntervalMs: 0,
+        livenessRecoverThreshold: 1, // one successful probe is enough to confirm + recover
+      },
+      silent,
+    )
 
     const out = await collect(fb.read())
 
@@ -158,7 +166,8 @@ describe('FallbackSource — supervisor', () => {
     let probes = 0
     s0.probeCapability = async () => {
       probes++
-      return false // reachable-but-incapable: never confirms
+      // reachable-but-incapable: never confirms, and reports a classified cause
+      return { ok: false, cause: { check: 'capability' as const, reason: 'http' as const, code: 400, detail: 'x' } }
     }
 
     const s1 = source('s1', async function* () {
@@ -168,12 +177,16 @@ describe('FallbackSource — supervisor', () => {
       }
     })
 
-    const fb = new FallbackSource([s0, s1], {
-      clock: () => now,
-      cooldownMs: 50,
-      capabilityProbeIntervalMs: 0,
-      livenessRecoverThreshold: 1,
-    })
+    const fb = new FallbackSource(
+      [s0, s1],
+      {
+        clock: () => now,
+        cooldownMs: 50,
+        capabilityProbeIntervalMs: 0,
+        livenessRecoverThreshold: 1,
+      },
+      silent,
+    )
 
     const out = await collect(fb.read())
 
@@ -186,10 +199,11 @@ describe('FallbackSource — supervisor', () => {
     const down: ReadFn = async function* () {
       throw new Error('down')
     }
-    const fb = new FallbackSource([source('s0', down), source('s1', down)], {
-      allDownTimeoutMs: 0,
-      allDownPollMs: 1,
-    })
+    const fb = new FallbackSource(
+      [source('s0', down), source('s1', down)],
+      { allDownTimeoutMs: 0, allDownPollMs: 1 },
+      silent,
+    )
 
     await expect(collect(fb.read())).rejects.toThrowError(/all fallback data sources/)
   })
@@ -204,17 +218,21 @@ describe('FallbackSource — metrics', () => {
     const s1 = source('s1', async function* () {
       yield pbatch(2)
     })
-    const fb = new FallbackSource([s0, s1])
+    const fb = new FallbackSource([s0, s1], undefined, silent)
 
     await collect(fb.read())
     const m = fb.metrics()
 
     expect(m.activeIndex).toBe(1)
     expect(m.switchCount).toBe(1)
-    expect(m.sources).toEqual([
+    expect(m.sources).toMatchObject([
       { name: 's0', health: 'unhealthy', active: false },
       { name: 's1', health: 'unknown', active: true },
     ])
+    // The unhealthy source carries its classified cause; the healthy/unknown one does not.
+    expect(m.sources[0].cause).toMatchObject({ check: 'stream', reason: 'unknown' })
+    expect(m.sources[0].cause?.detail).toContain('boom')
+    expect(m.sources[1].cause).toBeUndefined()
   })
 })
 
@@ -243,7 +261,7 @@ describe('FallbackSource — pipeTo', () => {
       },
     }
 
-    const fb = new FallbackSource([s0])
+    const fb = new FallbackSource([s0], undefined, silent)
     await fb.pipeTo(target)
 
     expect(forkedTo).toEqual(cursor(1))

--- a/packages/subsquid-pipes/src/core/fallback-source.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.test.ts
@@ -140,6 +140,28 @@ describe('FallbackSource — supervisor', () => {
     expect(s1.reads).toHaveLength(0)
   })
 
+  it('propagates a ForkException thrown by a source reached AFTER a switch (fork straddles the switch)', async () => {
+    const s0 = source('s0', async function* () {
+      yield pbatch(1)
+      throw new Error('s0 down') // non-fork error → fail over to s1
+    })
+    // s1 resumes at the last committed cursor and detects a reorg right there. A fork thrown by the
+    // switched-in source must propagate untouched (the target/consumer rewinds), never trigger
+    // another source switch.
+    const s1 = source('s1', async function* () {
+      throw new ForkException([cursor(1)], { fromBlock: 2, parentBlockHash: '0x1' })
+    })
+    const fb = new FallbackSource([s0, s1], undefined, silent)
+
+    const seen: number[] = []
+    await expect(
+      (async () => {
+        for await (const b of fb.read()) seen.push(...b.data)
+      })(),
+    ).rejects.toBeInstanceOf(ForkException)
+    expect(seen).toEqual([1]) // s0's block delivered; then s1's fork propagated
+  })
+
   it('reclaims a recovered higher-preference source once its capability probe confirms it', async () => {
     let now = 0
     let s0reads = 0
@@ -177,6 +199,82 @@ describe('FallbackSource — supervisor', () => {
     expect(probes).toBeGreaterThan(0) // the standby s0 was probed
     expect(out).toContain(50) // and reclaimed once healthy
     expect(fb.metrics().switchCount).toBe(2) // s0 → s1 (failover) → s0 (switch-up)
+  })
+
+  it('eager: reclaims a recovered probe-less higher-preference source via head-poll liveness alone', async () => {
+    let now = 0
+    let s0reads = 0
+    // s0 has NO capability probe — its recovery must come from head-poll liveness only (the head
+    // fetch doubles as the liveness signal that promotes a probe-less source back to healthy).
+    const s0 = headSource(
+      's0',
+      async function* () {
+        s0reads++
+        if (s0reads === 1) throw new Error('s0 down') // initial failure → fail over to s1
+        yield pbatch(50) // reclaimed once head-poll liveness promotes it
+      },
+      async () => cursor(50),
+    )
+    const s1 = source('s1', async function* () {
+      for (let n = 1; n <= 6; n++) {
+        yield pbatch(n)
+        now += 100 // advance clock so s0's cooldown elapses and it gets head-polled between batches
+      }
+    })
+
+    const fb = new FallbackSource(
+      [s0, s1],
+      {
+        clock: () => now,
+        cooldownMs: 50,
+        headTtlMs: 0,
+        livenessRecoverThreshold: 1, // one head-poll liveness pass is enough for a probe-less source
+        preferPrimary: 'eager',
+        maxLagBlocks: null,
+        maxStalenessMs: null,
+      },
+      silent,
+    )
+
+    const out = await collect(fb.read())
+
+    expect(out).toContain(50) // s0 reclaimed without ever running a capability probe
+    expect(fb.metrics().switchCount).toBe(2) // s0 → s1 (failover) → s0 (switch-up)
+  })
+
+  it('onFailureOnly: does not switch up to a recovered higher-preference source', async () => {
+    let now = 0
+    let s0reads = 0
+    const s0 = source('s0', async function* () {
+      s0reads++
+      if (s0reads === 1) throw new Error('s0 down')
+      yield pbatch(50) // would be reclaimed under 'eager' — must NOT be under 'onFailureOnly'
+    })
+    s0.probeCapability = async () => ({ ok: true })
+    const s1 = source('s1', async function* () {
+      for (let n = 1; n <= 4; n++) {
+        yield pbatch(n)
+        now += 100
+      }
+    })
+
+    const fb = new FallbackSource(
+      [s0, s1],
+      {
+        clock: () => now,
+        cooldownMs: 50,
+        capabilityProbeIntervalMs: 0,
+        livenessRecoverThreshold: 1,
+        preferPrimary: 'onFailureOnly', // sticky: only switch on failure, never reclaim
+      },
+      silent,
+    )
+
+    const out = await collect(fb.read())
+
+    expect(out).toEqual([1, 2, 3, 4]) // stayed on s1 the whole time
+    expect(out).not.toContain(50) // s0 never reclaimed
+    expect(fb.metrics().switchCount).toBe(1) // only the initial failover — no switch-up
   })
 
   it('does not switch up to a standby whose capability probe keeps failing', async () => {
@@ -425,6 +523,30 @@ describe('FallbackSource — freshness', () => {
 
     expect(await collect(fb)).toEqual([1, 2])
     expect(fb.activeIndex).toBe(1)
+  }, 5000)
+
+  it('(e) slow-handler immunity: a slow downstream consumer between yields does not mark the source stale', async () => {
+    const s0 = source('s0', async function* () {
+      yield pbatch(1)
+      yield pbatch(2)
+      yield pbatch(3)
+    })
+    // A fresher standby exists, so staleness *could* fire — but the staleness clock spans a single
+    // source `next()`, not wall-clock across yields, so time spent in a slow consumer must not count.
+    const s1 = headSource('s1', async function* () {}, async () => cursor(100))
+    const fb = new FallbackSource(
+      [s0, s1],
+      { maxStalenessMs: 30, freshnessTickMs: 5, headTtlMs: 0, maxLagBlocks: null },
+      silent,
+    )
+
+    const got: number[] = []
+    for await (const b of fb) {
+      got.push(...b.data)
+      await wait(50) // slow handler (> maxStalenessMs), but parked at yield — clock not running on s0
+    }
+    expect(got).toEqual([1, 2, 3]) // all served by s0
+    expect(fb.activeIndex).toBe(0) // never failed over
   }, 5000)
 
   it('(d) global stall: no fresher source → holds + flags chainStalled, no churn', async () => {

--- a/packages/subsquid-pipes/src/core/fallback-source.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.test.ts
@@ -115,6 +115,73 @@ describe('FallbackSource — supervisor', () => {
     expect(s1.reads).toHaveLength(0)
   })
 
+  it('reclaims a recovered higher-preference source once its capability probe confirms it', async () => {
+    let now = 0
+    let s0reads = 0
+    const s0 = source('s0', async function* () {
+      s0reads++
+      if (s0reads === 1) throw new Error('s0 down') // initial failure → fail over to s1
+      yield pbatch(50) // reclaimed after the probe confirms capability
+    })
+    let probes = 0
+    s0.probeCapability = async () => {
+      probes++
+      return true
+    }
+
+    const s1 = source('s1', async function* () {
+      for (let n = 1; n <= 6; n++) {
+        yield pbatch(n)
+        now += 100 // advance the (injected) clock so s0's cooldown elapses between batches
+      }
+    })
+
+    const fb = new FallbackSource([s0, s1], {
+      clock: () => now,
+      cooldownMs: 50,
+      capabilityProbeIntervalMs: 0,
+      livenessRecoverThreshold: 1, // one successful probe is enough to confirm + recover
+    })
+
+    const out = await collect(fb.read())
+
+    expect(probes).toBeGreaterThan(0) // the standby s0 was probed
+    expect(out).toContain(50) // and reclaimed once healthy
+    expect(fb.metrics().switchCount).toBe(2) // s0 → s1 (failover) → s0 (switch-up)
+  })
+
+  it('does not switch up to a standby whose capability probe keeps failing', async () => {
+    let now = 0
+    const s0 = source('s0', async function* () {
+      throw new Error('s0 down') // always fails the real query
+    })
+    let probes = 0
+    s0.probeCapability = async () => {
+      probes++
+      return false // reachable-but-incapable: never confirms
+    }
+
+    const s1 = source('s1', async function* () {
+      for (let n = 1; n <= 4; n++) {
+        yield pbatch(n)
+        now += 100
+      }
+    })
+
+    const fb = new FallbackSource([s0, s1], {
+      clock: () => now,
+      cooldownMs: 50,
+      capabilityProbeIntervalMs: 0,
+      livenessRecoverThreshold: 1,
+    })
+
+    const out = await collect(fb.read())
+
+    expect(probes).toBeGreaterThan(0) // s0 was probed but never confirmed
+    expect(out).toEqual([1, 2, 3, 4]) // stayed on s1 the whole time
+    expect(fb.metrics().switchCount).toBe(1) // only the initial failover — no churn back to s0
+  })
+
   it('throws AllSourcesDown after a finite timeout', async () => {
     const down: ReadFn = async function* () {
       throw new Error('down')

--- a/packages/subsquid-pipes/src/core/fallback-source.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.test.ts
@@ -228,6 +228,41 @@ describe('FallbackSource — supervisor', () => {
 
     await expect(collect(fb.read())).rejects.toThrowError(/all fallback data sources/)
   })
+
+  it('clears the active source and freshness gauges during an all-down gap', async () => {
+    // One source that global-stalls (no other source ⇒ nothing fresher) then errors. On the error
+    // there is no eligible source left, so the all-down path — not a switch — is the only thing that
+    // can clear the freshness gauges it left set.
+    const s0 = source('s0', async function* () {
+      yield pbatch(50)
+      await wait(60)
+      throw new Error('s0 down')
+    })
+    const fb = new FallbackSource(
+      [s0],
+      { maxStalenessMs: 30, freshnessTickMs: 5, allDownTimeoutMs: 0, allDownPollMs: 1, cooldownMs: 60_000 },
+      silent,
+    )
+
+    const it = fb[Symbol.asyncIterator]()
+    expect((await it.next()).value.data).toEqual([50])
+
+    // Pull the next batch so the staleness clock runs: s0 stalls past maxStalenessMs with no fresher
+    // alternative → global stall flagged on the active.
+    const pending = it.next()
+    await wait(45)
+    expect(fb.chainStalled).toBe(true)
+    expect(fb.activeIndex).toBe(0)
+
+    // s0 then errors; nothing eligible remains → all-down. The gauges must not keep reporting s0.
+    await expect(pending).rejects.toThrowError(/all fallback data sources/)
+    expect(fb.activeIndex).toBeUndefined()
+    expect(fb.metrics().sources.every((s) => !s.active)).toBe(true)
+    expect(fb.chainStalled).toBe(false)
+    expect(fb.staleness).toBe(0)
+    expect(fb.lag).toBe(0)
+    expect(fb.chainHead).toBeUndefined()
+  }, 5000)
 })
 
 describe('FallbackSource — metrics', () => {

--- a/packages/subsquid-pipes/src/core/fallback-source.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.test.ts
@@ -28,6 +28,14 @@ function pbatch(n: number, hash?: string): PortalBatch<number[]> {
   } as unknown as PortalBatch<number[]>
 }
 
+/** A batch that also reports a finalized head — for exercising the monotonic watermark clamp. */
+function pbatchF(n: number, finalizedNumber: number, hash?: string): PortalBatch<number[]> {
+  return {
+    data: [n],
+    ctx: { stream: { state: { current: cursor(n, hash) }, head: { finalized: cursor(finalizedNumber) } } },
+  } as unknown as PortalBatch<number[]>
+}
+
 type ReadFn = (cursor?: BlockCursor) => AsyncGenerator<PortalBatch<number[]>>
 
 function source(
@@ -138,6 +146,27 @@ describe('FallbackSource — supervisor', () => {
     ).rejects.toBeInstanceOf(ForkException)
     expect(seen).toEqual([1])
     expect(s1.reads).toHaveLength(0)
+  })
+
+  it('clamps a switched-in source’s finalized head monotonically (a shallower head cannot un-finalize)', async () => {
+    // Unlike the Squid supervisor (which passes finalized through — the processor owns finality), the
+    // Pipes FallbackSource owns the single monotonic watermark and clamps every batch. This guards
+    // that the clamp survives a switch: a source promoted after a failover may transiently report a
+    // shallower finalized head, and that must never un-finalize what an earlier source already did.
+    const s0 = source('s0', async function* () {
+      yield pbatchF(1, 2) // finalized head advances to 2
+      yield pbatchF(2, 2)
+      throw new Error('s0 down') // → fail over to s1
+    })
+    const s1 = source('s1', async function* () {
+      yield pbatchF(3, 1) // s1 reports a SHALLOWER finalized head (1) right after the switch
+    })
+    const fb = new FallbackSource([s0, s1], undefined, silent)
+
+    const finalizedSeen: (number | undefined)[] = []
+    for await (const b of fb.read()) finalizedSeen.push(b.ctx.stream.head.finalized?.number)
+
+    expect(finalizedSeen).toEqual([2, 2, 2]) // block 3's shallower head is clamped back up to 2
   })
 
   it('propagates a ForkException thrown by a source reached AFTER a switch (fork straddles the switch)', async () => {

--- a/packages/subsquid-pipes/src/core/fallback-source.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.test.ts
@@ -523,4 +523,25 @@ describe('FallbackSource — freshness', () => {
     expect(await collect(fb.read())).toEqual([1, 2])
     expect(fb.activeIndex).toBe(0) // stayed on s0 — no spurious failover
   })
+
+  it('(i) does not arm lag while the reference is behind us (stale standby) — no spurious failover', async () => {
+    // The standby is first *behind* the active (negative lag), then jumps to the real tip while the
+    // active is still backfilling. Arming on the negative lag would let that jump trip a spurious
+    // failover; gating arming on `lag >= 0` keeps us on the active.
+    const s1heads = [40, 1_000] // behind us at 50 (lag -10), then far ahead
+    const s0 = source('s0', async function* () {
+      yield pbatch(50)
+      yield pbatch(51)
+      yield pbatch(52)
+    })
+    const s1 = headSource(
+      's1',
+      async function* () {},
+      async () => cursor(s1heads.shift() ?? 1_000),
+    )
+    const fb = new FallbackSource([s0, s1], { maxLagBlocks: 10, maxStalenessMs: null, headTtlMs: 0 }, silent)
+
+    expect(await collect(fb.read(cursor(49)))).toEqual([50, 51, 52])
+    expect(fb.activeIndex).toBe(0) // never armed (was ahead of the reference) ⇒ no lag failover
+  })
 })

--- a/packages/subsquid-pipes/src/core/fallback-source.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.test.ts
@@ -51,6 +51,27 @@ async function collect(stream: AsyncIterable<PortalBatch<number[]>>): Promise<nu
   return out
 }
 
+/** Never resolves — models a source whose request hangs forever. */
+const hang = (): Promise<never> => new Promise<never>(() => {})
+/** Resolves after `ms` — models a slow request / a bounded delay before an error. */
+const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+type HeadFn = () => Promise<BlockCursor | undefined>
+type ProbeFn = () => Promise<{ ok: boolean }>
+
+/** A mock source with an independent head poll (and, optionally, a capability probe). */
+function headSource(
+  name: string,
+  read: ReadFn,
+  getHead: HeadFn,
+  probeCapability?: ProbeFn,
+): FallbackUnderlyingSource<number[]> & { reads: (BlockCursor | undefined)[] } {
+  return Object.assign(source(name, read), {
+    getHead,
+    ...(probeCapability ? { probeCapability: probeCapability as any } : {}),
+  })
+}
+
 describe('FallbackSource — supervisor', () => {
   it('drives the lowest-index source; standbys are untouched', async () => {
     const s0 = source('s0', async function* () {
@@ -266,5 +287,205 @@ describe('FallbackSource — pipeTo', () => {
 
     expect(forkedTo).toEqual(cursor(1))
     expect(written).toEqual([1, 2, 2]) // 2-bad yielded, rewound, 2-good re-served
+  })
+})
+
+describe('FallbackSource — freshness', () => {
+  it('(a) lag: fails over once it falls behind the independent head (after arming at the tip)', async () => {
+    const s1heads = [95, 110] // first boundary arms (lag 5), second trips (lag 19)
+    const s0 = source('s0', async function* () {
+      yield pbatch(90)
+      yield pbatch(91)
+      yield pbatch(92) // not reached
+    })
+    const s1 = headSource(
+      's1',
+      async function* () {
+        yield pbatch(92)
+        yield pbatch(93)
+      },
+      async () => cursor(s1heads.shift() ?? 110),
+    )
+    const fb = new FallbackSource([s0, s1], { maxLagBlocks: 10, maxStalenessMs: null, headTtlMs: 0 }, silent)
+
+    expect(await collect(fb)).toEqual([90, 91, 92, 93])
+    expect(fb.activeIndex).toBe(1)
+    expect(s1.reads[0]).toEqual(cursor(91)) // resumed just after the last committed block
+  })
+
+  it('(b) historical sync: a huge lag during backfill never fails over (never armed)', async () => {
+    const s0 = source('s0', async function* () {
+      yield pbatch(1)
+      yield pbatch(2)
+      yield pbatch(3)
+    })
+    const s1 = headSource(
+      's1',
+      async function* () {},
+      async () => cursor(1_000_000),
+    )
+    const fb = new FallbackSource([s0, s1], { maxLagBlocks: 10, maxStalenessMs: null, headTtlMs: 0 }, silent)
+
+    expect(await collect(fb)).toEqual([1, 2, 3])
+    expect(fb.activeIndex).toBe(0)
+  })
+
+  it('(c) staleness: fails over a stalled source when a fresher source is ahead', async () => {
+    const s0 = source('s0', async function* () {
+      yield pbatch(1)
+      await hang()
+    })
+    const s1 = headSource(
+      's1',
+      async function* () {
+        yield pbatch(2)
+      },
+      async () => cursor(100),
+    )
+    const fb = new FallbackSource(
+      [s0, s1],
+      { maxStalenessMs: 30, freshnessTickMs: 5, headTtlMs: 0, maxLagBlocks: null },
+      silent,
+    )
+
+    expect(await collect(fb)).toEqual([1, 2])
+    expect(fb.activeIndex).toBe(1)
+  }, 5000)
+
+  it('(d) global stall: no fresher source → holds + flags chainStalled, no churn', async () => {
+    const s0 = source('s0', async function* () {
+      yield pbatch(50)
+      await wait(120)
+      throw new Error('client timeout') // eventually errors, like a real client
+    })
+    const s1 = headSource(
+      's1',
+      async function* () {
+        yield pbatch(51)
+      },
+      async () => cursor(50), // same head → global stall
+    )
+    const fb = new FallbackSource(
+      [s0, s1],
+      { maxStalenessMs: 30, freshnessTickMs: 5, headTtlMs: 0, maxLagBlocks: null },
+      silent,
+    )
+
+    const it = fb[Symbol.asyncIterator]()
+    expect((await it.next()).value.data).toEqual([50])
+
+    const pending = it.next() // hangs; staleness climbs but no fresher source exists
+    await wait(80)
+    expect(fb.chainStalled).toBe(true)
+    expect(fb.activeIndex).toBe(0) // held — did NOT churn
+
+    // s0 finally errors → ordinary failover to s1
+    expect((await pending).value.data).toEqual([51])
+    expect(fb.activeIndex).toBe(1)
+    expect(fb.chainStalled).toBe(false) // cleared once progress resumed on the new source
+  }, 5000)
+
+  it('(d2) global stall: keeps probing the held source, and recovers when one becomes fresher', async () => {
+    // The active hangs forever; recovery must come from continued probing of the other source.
+    const s0 = source('s0', async function* () {
+      yield pbatch(50)
+      await hang()
+    })
+
+    const s1heads = [50, 50, 50] // global stall (same head) for a while...
+    let probedCapability = 0
+    const s1 = headSource(
+      's1',
+      async function* () {
+        yield pbatch(51)
+      },
+      async () => cursor(s1heads.shift() ?? 51), // ...then it advances to 51
+      async () => (probedCapability++, { ok: true }),
+    )
+    const fb = new FallbackSource(
+      [s0, s1],
+      { maxStalenessMs: 30, freshnessTickMs: 5, headTtlMs: 0, maxLagBlocks: null },
+      silent,
+    )
+
+    const it = fb[Symbol.asyncIterator]()
+    expect((await it.next()).value.data).toEqual([50])
+
+    // While held, the supervisor keeps polling the other source — liveness *and* capability —
+    // so it is positioned to notice recovery.
+    const next = it.next()
+    await wait(60)
+    expect(fb.chainStalled).toBe(true)
+    expect(s1heads.length).toBeLessThan(3) // s1's head was (re)polled during the hold (liveness)
+    expect(probedCapability).toBeGreaterThan(0) // capability probe fired during the hold
+
+    // s1's head advances past us → fail over to it, recovering without the active ever resolving.
+    expect((await next).value.data).toEqual([51])
+    expect(fb.activeIndex).toBe(1)
+    expect(fb.chainStalled).toBe(false)
+  }, 5000)
+
+  it('(f) thresholds disabled: neither lag nor staleness fires', async () => {
+    const s0 = source('s0', async function* () {
+      yield pbatch(1)
+      yield pbatch(2)
+    })
+    const s1 = headSource(
+      's1',
+      async function* () {},
+      async () => cursor(1_000_000),
+    )
+    const fb = new FallbackSource([s0, s1], { maxLagBlocks: null, maxStalenessMs: null, headTtlMs: 0 }, silent)
+
+    expect(await collect(fb)).toEqual([1, 2])
+    expect(fb.activeIndex).toBe(0)
+  })
+
+  it('(g) resets freshness gauges on a switch (no stale lag from the old source)', async () => {
+    const s1heads = [95, 110] // arm at lag 5, then trip at lag 19
+    const s0 = source('s0', async function* () {
+      yield pbatch(90)
+      yield pbatch(91)
+    })
+    // Empty standby: after failover the stream ends immediately, so no boundary recomputes
+    // freshness — exposing whether the switch itself cleared the old source's lag.
+    const s1 = headSource(
+      's1',
+      async function* () {},
+      async () => cursor(s1heads.shift() ?? 110),
+    )
+    const fb = new FallbackSource([s0, s1], { maxLagBlocks: 10, maxStalenessMs: null, headTtlMs: 0 }, silent)
+
+    expect(await collect(fb)).toEqual([90, 91])
+    expect(fb.activeIndex).toBe(1)
+    expect(fb.lag).toBe(0) // not the stale 19 the lag trigger recorded against s0
+  })
+
+  it('(h) re-arms lag per stream: a reused instance does not inherit "at tip" for a backfill', async () => {
+    let phase = 1
+    const s0 = source('s0', async function* () {
+      if (phase === 1) {
+        yield pbatch(100)
+      } else {
+        yield pbatch(1)
+        yield pbatch(2)
+      }
+    })
+    // Phase 1: head sits at s0 (arms the lag trigger). Phase 2: head is far ahead (backfill).
+    const s1 = headSource(
+      's1',
+      async function* () {},
+      async () => cursor(phase === 1 ? 100 : 1_000_000),
+    )
+    const fb = new FallbackSource([s0, s1], { maxLagBlocks: 10, maxStalenessMs: null, headTtlMs: 0 }, silent)
+
+    // Stream 1 reaches the tip → arms the lag trigger on the instance.
+    expect(await collect(fb.read(cursor(99)))).toEqual([100])
+
+    // Stream 2 on the SAME instance backfills far behind head. If the armed state leaked, the first
+    // boundary would trip (lag ~1e6 > 10) and fail over; a per-stream reset prevents that.
+    phase = 2
+    expect(await collect(fb.read())).toEqual([1, 2])
+    expect(fb.activeIndex).toBe(0) // stayed on s0 — no spurious failover
   })
 })

--- a/packages/subsquid-pipes/src/core/fallback-source.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.test.ts
@@ -562,7 +562,11 @@ describe('FallbackSource — freshness', () => {
     })
     // A fresher standby exists, so staleness *could* fire — but the staleness clock spans a single
     // source `next()`, not wall-clock across yields, so time spent in a slow consumer must not count.
-    const s1 = headSource('s1', async function* () {}, async () => cursor(100))
+    const s1 = headSource(
+      's1',
+      async function* () {},
+      async () => cursor(100),
+    )
     const fb = new FallbackSource(
       [s0, s1],
       { maxStalenessMs: 30, freshnessTickMs: 5, headTtlMs: 0, maxLagBlocks: null },

--- a/packages/subsquid-pipes/src/core/fallback-source.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.test.ts
@@ -128,6 +128,29 @@ describe('FallbackSource — supervisor', () => {
   })
 })
 
+describe('FallbackSource — metrics', () => {
+  it('reports the active source, switch count, and per-source health', async () => {
+    const s0 = source('s0', async function* () {
+      yield pbatch(1)
+      throw new Error('boom')
+    })
+    const s1 = source('s1', async function* () {
+      yield pbatch(2)
+    })
+    const fb = new FallbackSource([s0, s1])
+
+    await collect(fb.read())
+    const m = fb.metrics()
+
+    expect(m.activeIndex).toBe(1)
+    expect(m.switchCount).toBe(1)
+    expect(m.sources).toEqual([
+      { name: 's0', health: 'unhealthy', active: false },
+      { name: 's1', health: 'unknown', active: true },
+    ])
+  })
+})
+
 describe('FallbackSource — pipeTo', () => {
   it('rewinds via target.fork when a source forks, then resumes', async () => {
     let forkedTo: BlockCursor | null = null

--- a/packages/subsquid-pipes/src/core/fallback-source.test.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.test.ts
@@ -216,6 +216,46 @@ describe('FallbackSource — supervisor', () => {
     expect(fb.metrics().switchCount).toBe(1) // only the initial failover — no churn back to s0
   })
 
+  it('survives a capability probe that throws synchronously (fails as capability, flag not stranded)', async () => {
+    let now = 0
+    const s0 = source('s0', async function* () {
+      throw new Error('s0 down') // always fails the real query
+    })
+    let probes = 0
+    // A misbehaving custom probe that throws *synchronously*, before returning a Promise.
+    s0.probeCapability = (() => {
+      probes++
+      throw new Error('sync boom')
+    }) as any
+
+    const s1 = source('s1', async function* () {
+      for (let n = 1; n <= 4; n++) {
+        yield pbatch(n)
+        now += 100
+      }
+    })
+
+    const fb = new FallbackSource(
+      [s0, s1],
+      {
+        clock: () => now,
+        cooldownMs: 50,
+        capabilityProbeIntervalMs: 0,
+        livenessRecoverThreshold: 1,
+      },
+      silent,
+    )
+
+    const out = await collect(fb.read())
+
+    // Pre-fix, the synchronous throw escaped #maybeProbeCapability and stalled the read loop (and
+    // stranded #capabilityProbing at true). Normalizing it into a rejection keeps the supervisor
+    // streaming s1 to completion, and the probe having run proves the fire-and-forget path executed.
+    expect(probes).toBeGreaterThan(0)
+    expect(out).toEqual([1, 2, 3, 4])
+    expect(fb.metrics().switchCount).toBe(1) // never churned back to the incapable s0
+  })
+
   it('throws AllSourcesDown after a finite timeout', async () => {
     const down: ReadFn = async function* () {
       throw new Error('down')

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -357,7 +357,12 @@ export class FallbackSource<T> {
 
     this.#lastProbeAt[i] = now
     this.#capabilityProbing[i] = true
-    probe(last)
+    // `Promise.resolve().then(() => probe(last))` normalizes a *synchronously*-throwing custom probe
+    // into a rejection, so the throw can't escape this method (stranding `#capabilityProbing[i]` at
+    // `true` and blocking all future probes for the source) — it flows to the rejection handler and
+    // the `.finally` still clears the flag.
+    Promise.resolve()
+      .then(() => probe(last))
       .then(
         (r) => {
           if (r.ok) {

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -10,9 +10,10 @@ import {
   SourceHealth,
   resolveFallbackPolicy,
 } from './fallback-health.js'
+import { FinalizedWatermark } from './finalized-watermark.js'
 import { Logger, createDefaultLogger } from './logger.js'
 import { PortalBatch } from './portal-source.js'
-import { Target } from './target.js'
+import { Target, TargetState } from './target.js'
 import { BlockCursor } from './types.js'
 
 /**
@@ -43,8 +44,13 @@ export interface FallbackMetrics {
  * A meta-source over an ordered list of sources. It drives the lowest-index healthy (or
  * optimistically `unknown`) source and, on a non-fork error, resumes the next source from the
  * last committed cursor. A `ForkException` is propagated untouched so a fork straddling a switch
- * is handled by the same `pipeTo` rewind path as an ordinary reorg; `finalizedHead` rides through
- * each `PortalBatch` unchanged (the finalized high-watermark is enforced by the target).
+ * is handled by the same `pipeTo` rewind path as an ordinary reorg.
+ *
+ * Like `PortalSource`, it owns the single monotonic finalized high-watermark for the pipe (the
+ * targets no longer do): it seeds the floor from the target's persisted finalized head and clamps
+ * every batch's finalized head through it before yielding. This is what makes a source *switch*
+ * safe — a new source reporting a deeper/transiently-missing finalized head can never un-finalize
+ * already-committed data.
  *
  * Drop-in for a `PortalSource`: it exposes the same `AsyncIterable<PortalBatch<T>>` + `pipeTo`.
  */
@@ -54,6 +60,8 @@ export class FallbackSource<T> {
   readonly #health: SourceHealth[]
   readonly #selector: Selector
   readonly #logger: Logger
+  /** Single monotonic finalized high-watermark for the whole pipe, seeded from the target's floor. */
+  readonly #watermark = new FinalizedWatermark()
 
   /** Observable state (for metrics). */
   activeIndex: number | undefined
@@ -90,6 +98,13 @@ export class FallbackSource<T> {
         for await (const batch of this.#sources[active].read(last)) {
           this.#health[active].onBatch()
 
+          // Clamp the source's finalized head through the shared monotonic watermark before it
+          // reaches the target, so a source switch reporting a deeper/transiently-missing finalized
+          // head can never un-finalize already-committed data. (The rollback chain is left as the
+          // source derived it; the clamp can only raise the head, so the chain stays a safe superset
+          // of the unfinalized tail.)
+          batch.ctx.stream.head.finalized = this.#watermark.clamp(batch.ctx.stream.head.finalized)
+
           yield batch
           last = batch.ctx.stream.state.current
 
@@ -114,7 +129,13 @@ export class FallbackSource<T> {
 
     return target.write({
       logger: this.#logger,
-      read: async function* (cursor?: BlockCursor) {
+      read: async function* (state?: TargetState) {
+        // Seed the monotonic floor from the target's persisted finalized head so the watermark
+        // survives an unclean restart mid-fork (null ⇒ no floor ⇒ no-finality passthrough). The
+        // floor then persists in `self.#watermark` across fork re-invocations below.
+        self.#watermark.seed(state?.finalized ?? undefined)
+
+        let cursor = state?.latest
         while (true) {
           try {
             for await (const batch of self.read(cursor)) {

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -176,7 +176,12 @@ export class FallbackSource<T> {
             if (next.done) return // source completed (bounded stream)
             const batch = next.value
 
+            // A delivered batch proves both liveness *and* capability: the active source just served
+            // exactly the configured query (an incapable source throws rather than yields). The
+            // standby capability probe never runs for the active source, so without this a cold-start
+            // primary would serve forever yet never leave `unknown` for `healthy`.
             this.#health[active].onBatch()
+            this.#health[active].onCapability(true)
 
             // Clamp the source's finalized head through the shared monotonic watermark before it
             // reaches the target, so a source switch reporting a deeper/transiently-missing finalized
@@ -286,6 +291,25 @@ export class FallbackSource<T> {
   }
 
   /**
+   * A head poll, time-boxed by `headPollTimeoutMs`. The poll is `await`ed on the batch-critical path
+   * (lag check, staleness hold, switch-up), so a sick standby whose `getHead` hangs — TCP up, no
+   * response — must not stall the healthy active source: on timeout this rejects and `#getCachedHead`
+   * records a liveness failure. `null` defers to the underlying client's own request timeout.
+   */
+  #headWithTimeout(p: Promise<BlockCursor | undefined>): Promise<BlockCursor | undefined> {
+    const timeoutMs = this.#policy.headPollTimeoutMs
+    if (timeoutMs == null) return p
+
+    p.catch(() => {}) // an abandoned (timed-out) poll must not surface as an unhandled rejection
+    let timer: ReturnType<typeof setTimeout>
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => reject(new Error(`head poll timed out after ${timeoutMs}ms`)), timeoutMs)
+    })
+
+    return Promise.race([p, timeout]).finally(() => clearTimeout(timer))
+  }
+
+  /**
    * Poll a source's independent head (cached for `headTtlMs`). The poll doubles as a liveness probe
    * — a fresh head promotes a standby toward `healthy` — and is when we (re)fire its capability
    * probe. A source without `getHead` contributes no head, but still has its capability probe driven
@@ -303,7 +327,7 @@ export class FallbackSource<T> {
     if (cached && now - cached.at < this.#policy.headTtlMs) return cached.value
 
     try {
-      const head = await src.getHead()
+      const head = await this.#headWithTimeout(src.getHead())
       const value = head?.number
       this.#headCache[i] = { value, at: now }
       if (value != null) this.#health[i].onLivenessPass()

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -2,7 +2,7 @@ import { isForkException } from '~/portal-client/index.js'
 
 import { ForkCursorMissingError, ForkNoPreviousBlocksError, TargetForkNotSupportedError } from './errors.js'
 import type { ProbeResult } from './fallback-capability.js'
-import { SourceErrorInfo, classifyError, freshnessFailure } from './fallback-diagnostics.js'
+import { SourceErrorInfo, capabilityFailure, classifyError, freshnessFailure } from './fallback-diagnostics.js'
 import {
   AllSourcesDownError,
   FallbackHealth,
@@ -364,7 +364,7 @@ export class FallbackSource<T> {
             this.#health[i].onLivenessPass()
             this.#health[i].onCapability(true)
           } else {
-            this.#failSource(i, r.cause ?? freshnessFailure('capability', 'stale', 'probe reported not-capable'))
+            this.#failSource(i, r.cause ?? capabilityFailure('probe reported not-capable'))
           }
         },
         (e) => this.#failSource(i, classifyError('capability', e)),

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -25,8 +25,12 @@ import { BlockCursor } from './types.js'
 export interface FallbackUnderlyingSource<T> {
   name: string
   read: (cursor?: BlockCursor) => AsyncIterable<PortalBatch<T>>
-  /** Full, infrequent capability probe — verifies the source can still serve the query. */
-  probeCapability?: () => Promise<boolean>
+  /**
+   * Full, infrequent capability probe — verifies the source can still serve the query's data.
+   * `atCursor` is the indexing frontier (last committed cursor); the probe should confirm the
+   * source can serve the configured data just past it and resolve `false` if it cannot.
+   */
+  probeCapability?: (atCursor?: BlockCursor) => Promise<boolean>
 }
 
 function sleep(ms: number): Promise<void> {
@@ -66,6 +70,11 @@ export class FallbackSource<T> {
   /** Observable state (for metrics). */
   activeIndex: number | undefined
   switchCount = 0
+
+  /** Guards against firing a second capability probe for a source while one is still in flight. */
+  readonly #capabilityProbing: boolean[] = []
+  /** Clock of the last capability probe per source — throttles the (full-query) standby probe. */
+  readonly #lastProbeAt: number[] = []
 
   constructor(sources: FallbackUnderlyingSource<T>[], policy?: FallbackPolicy, logger?: Logger) {
     if (sources.length === 0) {
@@ -108,9 +117,15 @@ export class FallbackSource<T> {
           yield batch
           last = batch.ctx.stream.state.current
 
-          if (this.#policy.preferPrimary === 'eager' && this.#selector.pickSwitchUp(active) !== undefined) {
-            switchedUp = true
-            break
+          // Eager switch-up: reclaim a recovered higher-preference source at the batch boundary
+          // (never mid-batch). Probe those candidates first so a recovered one can re-prove its
+          // capability and reach `healthy` — switch-up only ever promotes to a `healthy` source.
+          if (this.#policy.preferPrimary === 'eager') {
+            this.#probeHigherPreference(active, last)
+            if (this.#selector.pickSwitchUp(active) !== undefined) {
+              switchedUp = true
+              break
+            }
           }
         }
 
@@ -167,6 +182,49 @@ export class FallbackSource<T> {
 
   async *[Symbol.asyncIterator](): AsyncIterator<PortalBatch<T>> {
     yield* this.read()
+  }
+
+  /**
+   * Drive capability (and, with it, liveness) for the not-yet-active *higher-preference* sources,
+   * so a recovered one can re-prove it can serve the query and be reclaimed by eager switch-up.
+   * When the active source is the primary (index 0) there are none, so this is a no-op on the hot
+   * path; it only does work after a failover — exactly when a recovered primary needs noticing.
+   *
+   * Fire-and-forget (a full query slice must not block the boundary) and never concurrently for the
+   * same source. Unlike Squid, Pipes has no cheap head poll, so a successful probe is the liveness
+   * signal too: it counts a liveness pass *and* confirms capability, so after `M` throttled probes
+   * the source reaches `healthy`. The probe is anchored to the frontier (`last`) so it verifies the
+   * depth the source is about to read. The gating in {@link SourceHealth} means a probe failure (or
+   * a later stream error) drops the confirmation, so the source must re-prove before recovering.
+   */
+  #probeHigherPreference(active: number, last?: BlockCursor): void {
+    for (let i = 0; i < active; i++) {
+      const probe = this.#sources[i].probeCapability
+      // Only probe a candidate that is eligible to recover: `unhealthy` is still cooling down, and
+      // `healthy` is already confirmed (the gating drops it back to `unknown`-eligible on failure).
+      if (!probe || this.#health[i].state !== 'unknown' || this.#capabilityProbing[i]) continue
+
+      const now = this.#policy.clock()
+      if (now - (this.#lastProbeAt[i] ?? 0) < this.#policy.capabilityProbeIntervalMs) continue
+
+      this.#lastProbeAt[i] = now
+      this.#capabilityProbing[i] = true
+      probe(last)
+        .then(
+          (ok) => {
+            if (ok) {
+              this.#health[i].onLivenessPass()
+              this.#health[i].onCapability(true)
+            } else {
+              this.#health[i].onCapability(false)
+            }
+          },
+          () => this.#health[i].onCapability(false),
+        )
+        .finally(() => {
+          this.#capabilityProbing[i] = false
+        })
+    }
   }
 
   /** Returns true if it waited (retry), false if the all-down timeout elapsed. */

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -3,6 +3,7 @@ import { isForkException } from '~/portal-client/index.js'
 import { ForkCursorMissingError, ForkNoPreviousBlocksError, TargetForkNotSupportedError } from './errors.js'
 import {
   AllSourcesDownError,
+  FallbackHealth,
   FallbackPolicy,
   ResolvedFallbackPolicy,
   Selector,
@@ -29,6 +30,13 @@ export interface FallbackUnderlyingSource<T> {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** A structured snapshot of the fallback's observable state, for a metrics surface (§4). */
+export interface FallbackMetrics {
+  activeIndex: number | undefined
+  switchCount: number
+  sources: { name: string; health: FallbackHealth; active: boolean }[]
 }
 
 /**
@@ -154,6 +162,19 @@ export class FallbackSource<T> {
     if (this.activeIndex !== i) {
       if (this.activeIndex !== undefined) this.switchCount++
       this.activeIndex = i
+    }
+  }
+
+  /** Snapshot of the observable state for export to a metrics surface (§4). */
+  metrics(): FallbackMetrics {
+    return {
+      activeIndex: this.activeIndex,
+      switchCount: this.switchCount,
+      sources: this.#sources.map((s, i) => ({
+        name: s.name,
+        health: this.#health[i].state,
+        active: this.activeIndex === i,
+      })),
     }
   }
 }

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -60,7 +60,6 @@ function delay(ms: number): { promise: Promise<void>; cancel: () => void } {
   return { promise, cancel: () => clearTimeout(timer) }
 }
 
-
 /** A structured snapshot of the fallback's observable state, for a metrics surface (§4). */
 export interface FallbackMetrics {
   activeIndex: number | undefined

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -1,6 +1,8 @@
 import { isForkException } from '~/portal-client/index.js'
 
 import { ForkCursorMissingError, ForkNoPreviousBlocksError, TargetForkNotSupportedError } from './errors.js'
+import type { ProbeResult } from './fallback-capability.js'
+import { SourceErrorInfo, classifyError, freshnessFailure } from './fallback-diagnostics.js'
 import {
   AllSourcesDownError,
   FallbackHealth,
@@ -28,9 +30,10 @@ export interface FallbackUnderlyingSource<T> {
   /**
    * Full, infrequent capability probe — verifies the source can still serve the query's data.
    * `atCursor` is the indexing frontier (last committed cursor); the probe should confirm the
-   * source can serve the configured data just past it and resolve `false` if it cannot.
+   * source can serve the configured data just past it and resolve not-`ok` (with a cause) if it
+   * cannot.
    */
-  probeCapability?: (atCursor?: BlockCursor) => Promise<boolean>
+  probeCapability?: (atCursor?: BlockCursor) => Promise<ProbeResult>
 }
 
 function sleep(ms: number): Promise<void> {
@@ -41,7 +44,7 @@ function sleep(ms: number): Promise<void> {
 export interface FallbackMetrics {
   activeIndex: number | undefined
   switchCount: number
-  sources: { name: string; health: FallbackHealth; active: boolean }[]
+  sources: { name: string; health: FallbackHealth; active: boolean; cause?: SourceErrorInfo }[]
 }
 
 /**
@@ -133,7 +136,7 @@ export class FallbackSource<T> {
       } catch (e) {
         if (isForkException(e)) throw e // propagate; do NOT switch
 
-        this.#health[active].onStreamError()
+        this.#failSource(active, classifyError('stream', e))
         // re-select and resume from `last` on the next iteration
       }
     }
@@ -211,19 +214,46 @@ export class FallbackSource<T> {
       this.#capabilityProbing[i] = true
       probe(last)
         .then(
-          (ok) => {
-            if (ok) {
+          (r) => {
+            if (r.ok) {
               this.#health[i].onLivenessPass()
               this.#health[i].onCapability(true)
             } else {
-              this.#health[i].onCapability(false)
+              this.#failSource(i, r.cause ?? freshnessFailure('capability', 'stale', 'probe reported not-capable'))
             }
           },
-          () => this.#health[i].onCapability(false),
+          (e) => this.#failSource(i, classifyError('capability', e)),
         )
         .finally(() => {
           this.#capabilityProbing[i] = false
         })
+    }
+  }
+
+  /**
+   * Feed a failure to a source's health (the `check` selects the signal), then log *why* — but only
+   * when it actually flips the source unhealthy, so a log line always marks a real transition
+   * (liveness fails are noisy until they trip the threshold). The bounded `reason`/`code`/`check`
+   * also reach {@link metrics}; the full `detail` (incl. the request) is logged, never a label.
+   */
+  #failSource(i: number, cause: SourceErrorInfo): void {
+    const before = this.#health[i].state
+    switch (cause.check) {
+      case 'stream':
+        this.#health[i].onStreamError(cause)
+        break
+      case 'liveness':
+        this.#health[i].onLivenessFail(cause)
+        break
+      case 'capability':
+        this.#health[i].onCapability(false, cause)
+        break
+    }
+    if (before !== 'unhealthy' && this.#health[i].state === 'unhealthy') {
+      this.#logger.warn(
+        { source: this.#sources[i].name, check: cause.check, reason: cause.reason, code: cause.code },
+        `fallback source "${this.#sources[i].name}" marked unhealthy: ${cause.detail}`,
+      )
     }
   }
 
@@ -253,6 +283,7 @@ export class FallbackSource<T> {
         name: s.name,
         health: this.#health[i].state,
         active: this.activeIndex === i,
+        cause: this.#health[i].cause,
       })),
     }
   }

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -1,6 +1,7 @@
 import { isForkException } from '~/portal-client/index.js'
 
 import { ForkCursorMissingError, ForkNoPreviousBlocksError, TargetForkNotSupportedError } from './errors.js'
+import { safeReturn, withTimeout } from './fallback-async.js'
 import type { ProbeResult } from './fallback-capability.js'
 import { SourceErrorInfo, capabilityFailure, classifyError, freshnessFailure } from './fallback-diagnostics.js'
 import {
@@ -59,18 +60,6 @@ function delay(ms: number): { promise: Promise<void>; cancel: () => void } {
   return { promise, cancel: () => clearTimeout(timer) }
 }
 
-function safeReturn(it: AsyncIterator<unknown>): void {
-  try {
-    // Don't await: closing a *stalled* source's iterator can itself hang on the same unresolved
-    // fetch, and failover must not wait on it.
-    it.return?.()?.then(
-      () => {},
-      () => {},
-    )
-  } catch {
-    /* ignore */
-  }
-}
 
 /** A structured snapshot of the fallback's observable state, for a metrics surface (§4). */
 export interface FallbackMetrics {
@@ -298,15 +287,7 @@ export class FallbackSource<T> {
    */
   #headWithTimeout(p: Promise<BlockCursor | undefined>): Promise<BlockCursor | undefined> {
     const timeoutMs = this.#policy.headPollTimeoutMs
-    if (timeoutMs == null) return p
-
-    p.catch(() => {}) // an abandoned (timed-out) poll must not surface as an unhandled rejection
-    let timer: ReturnType<typeof setTimeout>
-    const timeout = new Promise<never>((_resolve, reject) => {
-      timer = setTimeout(() => reject(new Error(`head poll timed out after ${timeoutMs}ms`)), timeoutMs)
-    })
-
-    return Promise.race([p, timeout]).finally(() => clearTimeout(timer))
+    return withTimeout(p, timeoutMs, () => new Error(`head poll timed out after ${timeoutMs}ms`))
   }
 
   /**

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -126,6 +126,8 @@ export class FallbackSource<T> {
   readonly #headCache: ({ value: number | undefined; at: number } | undefined)[] = []
   /** Lag failover arms only once the tip is first reached, so a deep backfill never trips it. */
   #lagArmed = false
+  /** The last source actually driven — survives the all-down gap so switch counting stays correct. */
+  #lastActive: number | undefined
 
   constructor(sources: FallbackUnderlyingSource<T>[], policy?: FallbackPolicy, logger?: Logger) {
     if (sources.length === 0) {
@@ -150,6 +152,7 @@ export class FallbackSource<T> {
     while (true) {
       const active = this.#selector.pickForFailover()
       if (active === undefined) {
+        this.#clearActive()
         if (await this.#waitAllDown(allDownSince ?? (allDownSince = this.#policy.clock()))) continue
 
         throw new AllSourcesDownError()
@@ -482,18 +485,31 @@ export class FallbackSource<T> {
   }
 
   #setActive(i: number): void {
-    if (this.activeIndex !== i) {
-      if (this.activeIndex !== undefined) {
-        this.switchCount++
-        // The freshness gauges describe the *active* source; on a switch the previous source's
-        // values are stale, so clear them until the new source's next batch/head poll repopulates.
-        this.lag = 0
-        this.staleness = 0
-        this.chainStalled = false
-        this.chainHead = undefined
-      }
-      this.activeIndex = i
+    // Count a switch against the last source we drove (not `activeIndex`, which is cleared to
+    // `undefined` during an all-down gap) so resuming on a *different* source after the gap still
+    // registers, and resuming on the *same* one does not.
+    if (this.#lastActive !== undefined && this.#lastActive !== i) {
+      this.switchCount++
+      // The freshness gauges describe the *active* source; on a switch the previous source's
+      // values are stale, so clear them until the new source's next batch/head poll repopulates.
+      this.lag = 0
+      this.staleness = 0
+      this.chainStalled = false
+      this.chainHead = undefined
     }
+    this.#lastActive = i
+    this.activeIndex = i
+  }
+
+  /** No source is eligible (all unhealthy): nothing is being driven, so report no active source. */
+  #clearActive(): void {
+    this.activeIndex = undefined
+    // The freshness gauges describe the active source; with none, they would otherwise keep
+    // reporting the last source's lag/staleness/stall, so clear them for the all-down gap.
+    this.lag = 0
+    this.staleness = 0
+    this.chainStalled = false
+    this.chainHead = undefined
   }
 
   /** Snapshot of the observable state for export to a metrics surface (§4). */

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -437,7 +437,11 @@ export class FallbackSource<T> {
 
     const lag = others - lastNumber
     this.lag = Math.max(0, lag)
-    if (lag <= this.#policy.maxLagBlocks) this.#lagArmed = true // arm at tip (latched)
+    // Arm only once we are genuinely at/near the tip: within the threshold *and* not ahead of the
+    // reference (`lag >= 0`). A negative lag means the independent reference is itself behind us
+    // (stale/lagging) — arming on that would let a later-recovering source's head trip a spurious
+    // failover while we are still backfilling.
+    if (lag >= 0 && lag <= this.#policy.maxLagBlocks) this.#lagArmed = true // arm at tip (latched)
 
     if (this.#lagArmed && lag > this.#policy.maxLagBlocks) {
       this.chainStalled = false

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -34,16 +34,54 @@ export interface FallbackUnderlyingSource<T> {
    * cannot.
    */
   probeCapability?: (atCursor?: BlockCursor) => Promise<ProbeResult>
+  /**
+   * Optional independent chain-head query (not tied to the stream). When present, it powers
+   * staleness/lag detection — failing a stalled or far-behind source over to one that is ahead —
+   * and serves as a cheap liveness signal for standby sources. Without it, a source still works but
+   * gets neither (a silently-stalled source can only be left once it errors). `PortalSource` and the
+   * RPC source both provide it.
+   */
+  getHead?: () => Promise<BlockCursor | undefined>
 }
+
+/** Returned by the staleness-aware fetch when the active source must be failed over. */
+const STALE = Symbol('stale')
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function delay(ms: number): { promise: Promise<void>; cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout>
+  const promise = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, ms)
+  })
+  return { promise, cancel: () => clearTimeout(timer) }
+}
+
+function safeReturn(it: AsyncIterator<unknown>): void {
+  try {
+    // Don't await: closing a *stalled* source's iterator can itself hang on the same unresolved
+    // fetch, and failover must not wait on it.
+    it.return?.()?.then(
+      () => {},
+      () => {},
+    )
+  } catch {
+    /* ignore */
+  }
 }
 
 /** A structured snapshot of the fallback's observable state, for a metrics surface (§4). */
 export interface FallbackMetrics {
   activeIndex: number | undefined
   switchCount: number
+  /** Blocks the active source is behind the independent head; ms its current request has been pending. */
+  lag: number
+  staleness: number
+  chainHead: number | undefined
+  /** Set when every source is stuck at the same head (no fresher alternative to switch to). */
+  chainStalled: boolean
   sources: { name: string; health: FallbackHealth; active: boolean; cause?: SourceErrorInfo }[]
 }
 
@@ -73,11 +111,21 @@ export class FallbackSource<T> {
   /** Observable state (for metrics). */
   activeIndex: number | undefined
   switchCount = 0
+  /** Freshness gauges (only populated for sources that implement `getHead`). */
+  lag = 0
+  staleness = 0
+  chainHead: number | undefined
+  /** Set when every source is stuck at the same head (no fresher alternative to switch to). */
+  chainStalled = false
 
   /** Guards against firing a second capability probe for a source while one is still in flight. */
   readonly #capabilityProbing: boolean[] = []
   /** Clock of the last capability probe per source — throttles the (full-query) standby probe. */
   readonly #lastProbeAt: number[] = []
+  /** Cached independent head per source, with the clock it was fetched at (TTL `headTtlMs`). */
+  readonly #headCache: ({ value: number | undefined; at: number } | undefined)[] = []
+  /** Lag failover arms only once the tip is first reached, so a deep backfill never trips it. */
+  #lagArmed = false
 
   constructor(sources: FallbackUnderlyingSource<T>[], policy?: FallbackPolicy, logger?: Logger) {
     if (sources.length === 0) {
@@ -95,6 +143,10 @@ export class FallbackSource<T> {
     let last = cursor
     let allDownSince: number | undefined
 
+    // Re-arm the lag trigger per stream: a reused instance starting a later (far-behind-head)
+    // backfill must not inherit "reached the tip" from a previous run and false-fire on lag.
+    this.#lagArmed = false
+
     while (true) {
       const active = this.#selector.pickForFailover()
       if (active === undefined) {
@@ -105,34 +157,58 @@ export class FallbackSource<T> {
       allDownSince = undefined
       this.#setActive(active)
 
-      let switchedUp = false
       try {
-        for await (const batch of this.#sources[active].read(last)) {
-          this.#health[active].onBatch()
-
-          // Clamp the source's finalized head through the shared monotonic watermark before it
-          // reaches the target, so a source switch reporting a deeper/transiently-missing finalized
-          // head can never un-finalize already-committed data. (The rollback chain is left as the
-          // source derived it; the clamp can only raise the head, so the chain stays a safe superset
-          // of the unfinalized tail.)
-          batch.ctx.stream.head.finalized = this.#watermark.clamp(batch.ctx.stream.head.finalized)
-
-          yield batch
-          last = batch.ctx.stream.state.current
-
-          // Eager switch-up: reclaim a recovered higher-preference source at the batch boundary
-          // (never mid-batch). Probe those candidates first so a recovered one can re-prove its
-          // capability and reach `healthy` — switch-up only ever promotes to a `healthy` source.
-          if (this.#policy.preferPrimary === 'eager') {
-            this.#probeHigherPreference(active, last)
-            if (this.#selector.pickSwitchUp(active) !== undefined) {
-              switchedUp = true
+        const iterator = this.#sources[active].read(last)[Symbol.asyncIterator]()
+        try {
+          while (true) {
+            const next = await this.#nextWithStaleness(iterator, active, last)
+            if (next === STALE) {
+              // Source stopped delivering while a fresher source is ahead.
+              this.#failSource(
+                active,
+                freshnessFailure('stream', 'stale', 'no batch progress while a fresher source was ahead'),
+              )
               break
             }
-          }
-        }
+            if (next.done) return // source completed (bounded stream)
+            const batch = next.value
 
-        if (!switchedUp) return // source completed (bounded stream)
+            this.#health[active].onBatch()
+
+            // Clamp the source's finalized head through the shared monotonic watermark before it
+            // reaches the target, so a source switch reporting a deeper/transiently-missing finalized
+            // head can never un-finalize already-committed data. (The rollback chain is left as the
+            // source derived it; the clamp can only raise the head, so the chain stays a safe superset
+            // of the unfinalized tail.)
+            batch.ctx.stream.head.finalized = this.#watermark.clamp(batch.ctx.stream.head.finalized)
+
+            yield batch
+            last = batch.ctx.stream.state.current
+
+            // Lag-based freshness: the active fell too far behind the independent head.
+            if (await this.#laggingTooFar(active, last)) {
+              this.#failSource(
+                active,
+                freshnessFailure(
+                  'stream',
+                  'lag',
+                  `fell behind the chain head by more than ${this.#policy.maxLagBlocks} blocks`,
+                ),
+              )
+              break
+            }
+
+            // Eager switch-up: reclaim a recovered higher-preference source at the batch boundary
+            // (never mid-batch). Probe those candidates first so a recovered one can re-prove its
+            // capability and reach `healthy` — switch-up only ever promotes to a `healthy` source.
+            if (this.#policy.preferPrimary === 'eager') {
+              await this.#probeHigherPreference(active, last)
+              if (this.#selector.pickSwitchUp(active) !== undefined) break
+            }
+          }
+        } finally {
+          safeReturn(iterator)
+        }
       } catch (e) {
         if (isForkException(e)) throw e // propagate; do NOT switch
 
@@ -188,46 +264,184 @@ export class FallbackSource<T> {
   }
 
   /**
-   * Drive capability (and, with it, liveness) for the not-yet-active *higher-preference* sources,
-   * so a recovered one can re-prove it can serve the query and be reclaimed by eager switch-up.
-   * When the active source is the primary (index 0) there are none, so this is a no-op on the hot
-   * path; it only does work after a failover — exactly when a recovered primary needs noticing.
-   *
-   * Fire-and-forget (a full query slice must not block the boundary) and never concurrently for the
-   * same source. Unlike Squid, Pipes has no cheap head poll, so a successful probe is the liveness
-   * signal too: it counts a liveness pass *and* confirms capability, so after `M` throttled probes
-   * the source reaches `healthy`. The probe is anchored to the frontier (`last`) so it verifies the
-   * depth the source is about to read. The gating in {@link SourceHealth} means a probe failure (or
-   * a later stream error) drops the confirmation, so the source must re-prove before recovering.
+   * The highest head reported by the *other* eligible sources — an independent reference that avoids
+   * the circular-lag trap (a source that stalls head and data together reads lag ≈ 0 against its own
+   * head). Excludes `unhealthy` sources so a flagged-bad one can't define the tip, and sources
+   * without `getHead` (they contribute no head). Heads are cached for `headTtlMs`.
    */
-  #probeHigherPreference(active: number, last?: BlockCursor): void {
-    for (let i = 0; i < active; i++) {
-      const probe = this.#sources[i].probeCapability
-      // Only probe a candidate that is eligible to recover: `unhealthy` is still cooling down, and
-      // `healthy` is already confirmed (the gating drops it back to `unknown`-eligible on failure).
-      if (!probe || this.#health[i].state !== 'unknown' || this.#capabilityProbing[i]) continue
+  async #chainHeadOthers(active: number, last?: BlockCursor): Promise<number | undefined> {
+    const results = await Promise.all(
+      this.#sources.map((_, i) =>
+        i === active || this.#health[i].state === 'unhealthy'
+          ? Promise.resolve(undefined)
+          : this.#getCachedHead(i, last),
+      ),
+    )
+    const vals = results.filter((h): h is number => h != null)
 
-      const now = this.#policy.clock()
-      if (now - (this.#lastProbeAt[i] ?? 0) < this.#policy.capabilityProbeIntervalMs) continue
+    return vals.length ? Math.max(...vals) : undefined
+  }
 
-      this.#lastProbeAt[i] = now
-      this.#capabilityProbing[i] = true
-      probe(last)
-        .then(
-          (r) => {
-            if (r.ok) {
-              this.#health[i].onLivenessPass()
-              this.#health[i].onCapability(true)
-            } else {
-              this.#failSource(i, r.cause ?? freshnessFailure('capability', 'stale', 'probe reported not-capable'))
-            }
-          },
-          (e) => this.#failSource(i, classifyError('capability', e)),
-        )
-        .finally(() => {
-          this.#capabilityProbing[i] = false
-        })
+  /**
+   * Poll a source's independent head (cached for `headTtlMs`). The poll doubles as a liveness probe
+   * — a fresh head promotes a standby toward `healthy` — and is when we (re)fire its capability
+   * probe. A source without `getHead` contributes no head, but still has its capability probe driven
+   * here so a probe-only source can recover (for it, the probe also carries liveness).
+   */
+  async #getCachedHead(i: number, last?: BlockCursor): Promise<number | undefined> {
+    const src = this.#sources[i]
+    if (!src.getHead) {
+      this.#maybeProbeCapability(i, last)
+      return undefined
     }
+
+    const now = this.#policy.clock()
+    const cached = this.#headCache[i]
+    if (cached && now - cached.at < this.#policy.headTtlMs) return cached.value
+
+    try {
+      const head = await src.getHead()
+      const value = head?.number
+      this.#headCache[i] = { value, at: now }
+      if (value != null) this.#health[i].onLivenessPass()
+      this.#maybeProbeCapability(i, last)
+      return value
+    } catch (e) {
+      this.#headCache[i] = { value: undefined, at: now }
+      this.#failSource(i, classifyError('liveness', e))
+      return undefined
+    }
+  }
+
+  /**
+   * Fire a source's optional capability probe once it is reachable, feeding the result into health.
+   * A source that declares a `probeCapability` cannot become `healthy` on liveness alone — capability
+   * must be confirmed — so without this it could never be switched up to. Fire-and-forget (a full
+   * query slice must not block the boundary), throttled by `capabilityProbeIntervalMs`, and never
+   * concurrent for the same source. The gating in {@link SourceHealth} drops the confirmation when a
+   * source goes unhealthy, so it must re-prove before recovering.
+   */
+  #maybeProbeCapability(i: number, last?: BlockCursor): void {
+    const probe = this.#sources[i].probeCapability
+    if (!probe || this.#health[i].capabilityConfirmed || this.#capabilityProbing[i]) return
+
+    const now = this.#policy.clock()
+    if (now - (this.#lastProbeAt[i] ?? 0) < this.#policy.capabilityProbeIntervalMs) return
+
+    this.#lastProbeAt[i] = now
+    this.#capabilityProbing[i] = true
+    probe(last)
+      .then(
+        (r) => {
+          if (r.ok) {
+            this.#health[i].onLivenessPass()
+            this.#health[i].onCapability(true)
+          } else {
+            this.#failSource(i, r.cause ?? freshnessFailure('capability', 'stale', 'probe reported not-capable'))
+          }
+        },
+        (e) => this.#failSource(i, classifyError('capability', e)),
+      )
+      .finally(() => {
+        this.#capabilityProbing[i] = false
+      })
+  }
+
+  /**
+   * Drive head/liveness/capability for the not-yet-active *higher-preference* sources, so a recovered
+   * one can reach `healthy` and be reclaimed by eager switch-up. When the active source is the primary
+   * (index 0) there are none, so this is a no-op on the hot path; it only does work after a failover —
+   * exactly when a recovered primary needs noticing.
+   */
+  async #probeHigherPreference(active: number, last?: BlockCursor): Promise<void> {
+    await Promise.all(
+      this.#sources.map((_, i) =>
+        i < active && this.#health[i].state !== 'unhealthy' ? this.#getCachedHead(i, last) : Promise.resolve(undefined),
+      ),
+    )
+  }
+
+  /**
+   * `iterator.next()` with the source-pending staleness clock. While the request is outstanding, a
+   * ticker checks how long it has been pending; past `maxStalenessMs` it fails the source over **iff**
+   * a fresher source is ahead. If every source sits at the same stale head, it is a global chain
+   * stall: hold the active source (re-arm and keep waiting + probing) and flag `chainStalled` rather
+   * than churn through sources that are all equally stuck. Disabled (plain `next()`) when
+   * `maxStalenessMs` is null.
+   */
+  async #nextWithStaleness(
+    iterator: AsyncIterator<PortalBatch<T>>,
+    active: number,
+    last?: BlockCursor,
+  ): Promise<IteratorResult<PortalBatch<T>> | typeof STALE> {
+    if (this.#policy.maxStalenessMs == null) {
+      this.staleness = 0
+      return iterator.next()
+    }
+
+    const lastNumber = last?.number ?? -1
+    let start = this.#policy.clock()
+    const nextP = iterator.next()
+    nextP.catch(() => {}) // a later abandon must not surface as an unhandled rejection
+    const settled = nextP.then(
+      (v) => ({ type: 'next' as const, v }),
+      (e) => ({ type: 'error' as const, e }),
+    )
+
+    while (true) {
+      const tick = delay(this.#policy.freshnessTickMs)
+      const r = await Promise.race([settled, tick.promise.then(() => ({ type: 'tick' as const }))])
+      tick.cancel()
+
+      if (r.type === 'next') {
+        this.staleness = 0
+        this.chainStalled = false
+        return r.v
+      }
+      if (r.type === 'error') {
+        this.staleness = 0
+        this.chainStalled = false
+        throw r.e
+      }
+
+      const elapsed = this.#policy.clock() - start
+      this.staleness = elapsed
+      if (elapsed > this.#policy.maxStalenessMs) {
+        // Re-polling the other sources both decides failover and (re)probes their liveness/capability,
+        // so a held source keeps noticing when the chain comes back.
+        const others = await this.#chainHeadOthers(active, last)
+        if (others != null && others > lastNumber) {
+          this.chainStalled = false
+          return STALE
+        }
+        this.chainStalled = true
+        start = this.#policy.clock() // hold; re-arm and keep waiting
+      }
+    }
+  }
+
+  /** Boundary-evaluated lag trigger (armed only once the tip is first reached). */
+  async #laggingTooFar(active: number, last?: BlockCursor): Promise<boolean> {
+    if (this.#policy.maxLagBlocks == null) return false
+
+    const lastNumber = last?.number ?? -1
+    const others = await this.#chainHeadOthers(active, last)
+    this.chainHead = others != null ? Math.max(others, lastNumber) : lastNumber
+    if (others == null) {
+      this.lag = 0 // no independent reference ⇒ lag is not computable; don't report a stale value
+      return false
+    }
+
+    const lag = others - lastNumber
+    this.lag = Math.max(0, lag)
+    if (lag <= this.#policy.maxLagBlocks) this.#lagArmed = true // arm at tip (latched)
+
+    if (this.#lagArmed && lag > this.#policy.maxLagBlocks) {
+      this.chainStalled = false
+      return true
+    }
+
+    return false
   }
 
   /**
@@ -269,7 +483,15 @@ export class FallbackSource<T> {
 
   #setActive(i: number): void {
     if (this.activeIndex !== i) {
-      if (this.activeIndex !== undefined) this.switchCount++
+      if (this.activeIndex !== undefined) {
+        this.switchCount++
+        // The freshness gauges describe the *active* source; on a switch the previous source's
+        // values are stale, so clear them until the new source's next batch/head poll repopulates.
+        this.lag = 0
+        this.staleness = 0
+        this.chainStalled = false
+        this.chainHead = undefined
+      }
       this.activeIndex = i
     }
   }
@@ -279,6 +501,10 @@ export class FallbackSource<T> {
     return {
       activeIndex: this.activeIndex,
       switchCount: this.switchCount,
+      lag: this.lag,
+      staleness: this.staleness,
+      chainHead: this.chainHead,
+      chainStalled: this.chainStalled,
       sources: this.#sources.map((s, i) => ({
         name: s.name,
         health: this.#health[i].state,

--- a/packages/subsquid-pipes/src/core/fallback-source.ts
+++ b/packages/subsquid-pipes/src/core/fallback-source.ts
@@ -1,0 +1,159 @@
+import { isForkException } from '~/portal-client/index.js'
+
+import { ForkCursorMissingError, ForkNoPreviousBlocksError, TargetForkNotSupportedError } from './errors.js'
+import {
+  AllSourcesDownError,
+  FallbackPolicy,
+  ResolvedFallbackPolicy,
+  Selector,
+  SourceHealth,
+  resolveFallbackPolicy,
+} from './fallback-health.js'
+import { Logger, createDefaultLogger } from './logger.js'
+import { PortalBatch } from './portal-source.js'
+import { Target } from './target.js'
+import { BlockCursor } from './types.js'
+
+/**
+ * One ranked underlying source. `read(cursor)` must yield `PortalBatch`es starting just after
+ * `cursor` and throw a `ForkException` when the chain diverges at the resume point — exactly the
+ * contract `PortalSource` already satisfies, so a Portal stream (or, later, an RPC stream) drops
+ * straight in.
+ */
+export interface FallbackUnderlyingSource<T> {
+  name: string
+  read: (cursor?: BlockCursor) => AsyncIterable<PortalBatch<T>>
+  /** Full, infrequent capability probe — verifies the source can still serve the query. */
+  probeCapability?: () => Promise<boolean>
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * A meta-source over an ordered list of sources. It drives the lowest-index healthy (or
+ * optimistically `unknown`) source and, on a non-fork error, resumes the next source from the
+ * last committed cursor. A `ForkException` is propagated untouched so a fork straddling a switch
+ * is handled by the same `pipeTo` rewind path as an ordinary reorg; `finalizedHead` rides through
+ * each `PortalBatch` unchanged (the finalized high-watermark is enforced by the target).
+ *
+ * Drop-in for a `PortalSource`: it exposes the same `AsyncIterable<PortalBatch<T>>` + `pipeTo`.
+ */
+export class FallbackSource<T> {
+  readonly #sources: FallbackUnderlyingSource<T>[]
+  readonly #policy: ResolvedFallbackPolicy
+  readonly #health: SourceHealth[]
+  readonly #selector: Selector
+  readonly #logger: Logger
+
+  /** Observable state (for metrics). */
+  activeIndex: number | undefined
+  switchCount = 0
+
+  constructor(sources: FallbackUnderlyingSource<T>[], policy?: FallbackPolicy, logger?: Logger) {
+    if (sources.length === 0) {
+      throw new Error('FallbackSource requires at least one source')
+    }
+    this.#sources = sources
+    this.#policy = resolveFallbackPolicy(policy)
+    this.#health = sources.map((s) => new SourceHealth(this.#policy, !!s.probeCapability))
+    this.#selector = new Selector(this.#health)
+    this.#logger = logger ?? createDefaultLogger({ id: 'fallback' })
+  }
+
+  /** The supervisor: switches sources internally; only `ForkException` (and completion) escape. */
+  async *read(cursor?: BlockCursor): AsyncIterable<PortalBatch<T>> {
+    let last = cursor
+    let allDownSince: number | undefined
+
+    while (true) {
+      const active = this.#selector.pickForFailover()
+      if (active === undefined) {
+        if (await this.#waitAllDown(allDownSince ?? (allDownSince = this.#policy.clock()))) continue
+
+        throw new AllSourcesDownError()
+      }
+      allDownSince = undefined
+      this.#setActive(active)
+
+      let switchedUp = false
+      try {
+        for await (const batch of this.#sources[active].read(last)) {
+          this.#health[active].onBatch()
+
+          yield batch
+          last = batch.ctx.stream.state.current
+
+          if (this.#policy.preferPrimary === 'eager' && this.#selector.pickSwitchUp(active) !== undefined) {
+            switchedUp = true
+            break
+          }
+        }
+
+        if (!switchedUp) return // source completed (bounded stream)
+      } catch (e) {
+        if (isForkException(e)) throw e // propagate; do NOT switch
+
+        this.#health[active].onStreamError()
+        // re-select and resume from `last` on the next iteration
+      }
+    }
+  }
+
+  pipeTo(target: Target<T>): Promise<void> {
+    const self = this
+
+    return target.write({
+      logger: this.#logger,
+      read: async function* (cursor?: BlockCursor) {
+        while (true) {
+          try {
+            for await (const batch of self.read(cursor)) {
+              yield batch
+            }
+
+            return
+          } catch (e) {
+            if (!isForkException(e)) throw e
+
+            if (!e.previousBlocks.length) {
+              throw new ForkNoPreviousBlocksError()
+            }
+            if (!target.fork) {
+              throw new TargetForkNotSupportedError()
+            }
+
+            const forked = await target.fork(e.previousBlocks)
+            if (!forked) {
+              throw new ForkCursorMissingError()
+            }
+
+            cursor = forked
+          }
+        }
+      },
+    })
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<PortalBatch<T>> {
+    yield* this.read()
+  }
+
+  /** Returns true if it waited (retry), false if the all-down timeout elapsed. */
+  async #waitAllDown(since: number): Promise<boolean> {
+    if (this.#policy.allDownTimeoutMs != null && this.#policy.clock() - since >= this.#policy.allDownTimeoutMs) {
+      return false
+    }
+    await sleep(this.#policy.allDownPollMs)
+
+    return true
+  }
+
+  #setActive(i: number): void {
+    if (this.activeIndex !== i) {
+      if (this.activeIndex !== undefined) this.switchCount++
+      this.activeIndex = i
+    }
+  }
+}

--- a/packages/subsquid-pipes/src/core/index.ts
+++ b/packages/subsquid-pipes/src/core/index.ts
@@ -1,6 +1,7 @@
 export * from './cursor-key.js'
 export * from './errors.js'
 export * from './fallback-health.js'
+export * from './fallback-metrics.js'
 export * from './fallback-source.js'
 export * from './finalization-buffer.js'
 // Only `coerceFinalized` is consumed across module boundaries (the target state classes). The

--- a/packages/subsquid-pipes/src/core/index.ts
+++ b/packages/subsquid-pipes/src/core/index.ts
@@ -1,5 +1,7 @@
 export * from './cursor-key.js'
 export * from './errors.js'
+export * from './fallback-health.js'
+export * from './fallback-source.js'
 export * from './finalization-buffer.js'
 // Only `coerceFinalized` is consumed across module boundaries (the target state classes). The
 // watermark class is imported directly by the source, and maxFinalized is module-internal — keep

--- a/packages/subsquid-pipes/src/core/index.ts
+++ b/packages/subsquid-pipes/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from './cursor-key.js'
 export * from './errors.js'
+export * from './fallback-capability.js'
 export * from './fallback-health.js'
 export * from './fallback-metrics.js'
 export * from './fallback-source.js'

--- a/packages/subsquid-pipes/src/core/index.ts
+++ b/packages/subsquid-pipes/src/core/index.ts
@@ -1,6 +1,7 @@
 export * from './cursor-key.js'
 export * from './errors.js'
 export * from './fallback-capability.js'
+export * from './fallback-diagnostics.js'
 export * from './fallback-health.js'
 export * from './fallback-metrics.js'
 export * from './fallback-source.js'

--- a/packages/subsquid-pipes/src/core/metrics-server.ts
+++ b/packages/subsquid-pipes/src/core/metrics-server.ts
@@ -24,6 +24,8 @@ export interface CounterConfiguration<T extends string> extends MetricConfigurat
 export interface Gauge<T extends string = string> {
   set(value: number): void
   set(labels: LabelValues<T>, value: number): void
+  /** Clear all label combinations — call before re-setting in `collect` to drop stale series. */
+  reset(): void
 }
 export interface GaugeConfiguration<T extends string> extends MetricConfiguration<T> {
   collect?: CollectFunction<Gauge<T>>
@@ -71,6 +73,7 @@ class NoopCounter<T extends string> implements Counter<T> {
 }
 class GaugeNoop<T extends string> implements Gauge<T> {
   set(): void {}
+  reset(): void {}
 }
 class HistogramNoop<T extends string> implements Histogram<T> {
   observe(): void {}

--- a/packages/subsquid-pipes/src/core/metrics-server.ts
+++ b/packages/subsquid-pipes/src/core/metrics-server.ts
@@ -24,8 +24,12 @@ export interface CounterConfiguration<T extends string> extends MetricConfigurat
 export interface Gauge<T extends string = string> {
   set(value: number): void
   set(labels: LabelValues<T>, value: number): void
-  /** Clear all label combinations — call before re-setting in `collect` to drop stale series. */
-  reset(): void
+  /**
+   * Clear all label combinations — call before re-setting in `collect` to drop stale series.
+   * Optional so a custom `MetricsServer` that predates it still satisfies the interface; callers must
+   * invoke it with optional chaining. Without it, stale label series simply aren't pruned.
+   */
+  reset?(): void
 }
 export interface GaugeConfiguration<T extends string> extends MetricConfiguration<T> {
   collect?: CollectFunction<Gauge<T>>

--- a/packages/subsquid-pipes/src/evm/browser.ts
+++ b/packages/subsquid-pipes/src/evm/browser.ts
@@ -1,5 +1,9 @@
 export * from './abi/common.js'
 export * from './evm-decoder.js'
+// The RPC-fallback EVM source. Safe to export here: evm-fallback and its import chain reference the
+// optional evm-rpc / evm-normalization peers only as erased types — the RPC stack is loaded lazily
+// (dynamic import) the first time an `rpc` source is read, so a Portal-only consumer never pulls it.
+export * from './evm-fallback.js'
 export * from './evm-portal-source.js'
 export * from './evm-query-builder.js'
 export * from './evm-rpc-latency-watcher.js'

--- a/packages/subsquid-pipes/src/evm/browser.ts
+++ b/packages/subsquid-pipes/src/evm/browser.ts
@@ -1,8 +1,11 @@
 export * from './abi/common.js'
 export * from './evm-decoder.js'
-// The RPC-fallback EVM source. Safe to export here: evm-fallback and its import chain reference the
-// optional evm-rpc / evm-normalization peers only as erased types — the RPC stack is loaded lazily
-// (dynamic import) the first time an `rpc` source is read, so a Portal-only consumer never pulls it.
+// The RPC-fallback EVM source. The RPC stack is loaded lazily (dynamic import) the first time an
+// `rpc` source is read, so a Portal-only consumer never pulls the optional evm-rpc / evm-normalization
+// peers *at runtime*. Note the exported RPC-config *types* (e.g. `EvmFallbackSourceConfig`'s
+// `rpc: Rpc`) do reference @subsquid/evm-rpc and are preserved in the emitted .d.ts, so a TS consumer
+// that references those types needs the peer installed for typechecking; Portal-only usage that never
+// touches them does not. (A separate subpath could fully TS-decouple them if that becomes a goal.)
 export * from './evm-fallback.js'
 export * from './evm-portal-source.js'
 export * from './evm-query-builder.js'

--- a/packages/subsquid-pipes/src/evm/evm-fallback.e2e.test.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.e2e.test.ts
@@ -1,0 +1,79 @@
+import { EvmRpcClient, Rpc } from '@subsquid/evm-rpc'
+import { describe, expect, it } from 'vitest'
+
+import { BlockCursor, FallbackSource, FallbackUnderlyingSource, PortalBatch } from '~/core/index.js'
+import { FieldSelection } from '~/portal-client/query/evm.js'
+
+import { createEvmFallback, evmPortalReadSource } from './evm-fallback.js'
+
+/**
+ * Live end-to-end test: drive a fallback built from a real Portal source and a real RPC source,
+ * and assert it streams correctly and fails over when the primary is unavailable.
+ * Network-gated (`RPC_E2E=1`, `RPC_URL=…`); skipped by default.
+ */
+
+const ENABLED = process.env['RPC_E2E'] === '1' && !!process.env['RPC_URL']
+const RPC_URL = process.env['RPC_URL']!
+const PORTAL_URL = process.env['PORTAL_URL'] || 'https://portal.sqd.dev/datasets/ethereum-mainnet'
+const FROM = Number(process.env['RPC_E2E_BLOCK'] || 22000000)
+const TO = FROM + 2
+
+const FIELDS = {
+  transaction: { from: true, to: true, value: true },
+  log: { address: true, topics: true },
+} satisfies FieldSelection
+
+const REQUEST = { transactions: [{}], logs: [{}] }
+
+function rpc(): Rpc {
+  return new Rpc({ client: new EvmRpcClient({ url: RPC_URL, capacity: 5 }) })
+}
+
+async function streamNumbers(source: { read(c?: BlockCursor): AsyncIterable<PortalBatch<any[]>> }): Promise<number[]> {
+  const out: number[] = []
+  for await (const batch of source.read()) {
+    out.push(...batch.data.map((b: any) => b.header.number))
+  }
+  return out
+}
+
+describe.skipIf(!ENABLED)('EVM fallback — live', () => {
+  it('streams a range through the primary (Portal)', async () => {
+    const fb = createEvmFallback({
+      fields: FIELDS,
+      request: REQUEST,
+      from: FROM,
+      to: TO,
+      sources: [
+        { type: 'portal', portal: PORTAL_URL },
+        { type: 'rpc', rpc: rpc() },
+      ],
+    })
+
+    expect(await streamNumbers(fb)).toEqual([FROM, FROM + 1, TO])
+  }, 120_000)
+
+  it('fails over to the next source when the primary is down', async () => {
+    const broken: FallbackUnderlyingSource<any[]> = {
+      name: 'broken',
+      // biome-ignore lint/correctness/useYield: intentionally throwing
+      read: async function* () {
+        throw new Error('primary down')
+      },
+    }
+    const portal = evmPortalReadSource({
+      portal: PORTAL_URL,
+      fields: FIELDS,
+      request: REQUEST,
+      from: FROM,
+      to: TO,
+    })
+
+    const fb = new FallbackSource<any[]>([broken, portal])
+
+    expect(fb.activeIndex).toBeUndefined()
+    expect(await streamNumbers(fb)).toEqual([FROM, FROM + 1, TO])
+    expect(fb.activeIndex).toBe(1) // Portal took over
+    expect(fb.switchCount).toBeGreaterThanOrEqual(1)
+  }, 120_000)
+})

--- a/packages/subsquid-pipes/src/evm/evm-fallback.test.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.test.ts
@@ -44,6 +44,19 @@ describe('translateMissingRpcPeer', () => {
     expect((out as Error).message).toContain('optional peer dependencies')
   })
 
+  it("maps evm-rpc's transitive peers (http-client / rpc-client) and names the whole stack", () => {
+    // A consumer who installed only evm-rpc + evm-normalization can still miss these; the message
+    // must name them so the guidance is complete.
+    const out = translateMissingRpcPeer(
+      moduleNotFound("Cannot find package '@subsquid/http-client' imported from /app/rpc.js"),
+    )
+    const msg = (out as Error).message
+    expect(msg).toContain('@subsquid/http-client')
+    expect(msg).toContain('@subsquid/rpc-client')
+    expect(msg).toContain('@subsquid/evm-rpc')
+    expect(msg).toContain('@subsquid/evm-normalization')
+  })
+
   it('passes through a module-not-found for an UNRELATED module unchanged', () => {
     const original = moduleNotFound("Cannot find package 'some-other-dep' imported from /app/x.js")
     expect(translateMissingRpcPeer(original)).toBe(original) // not masked as a missing peer

--- a/packages/subsquid-pipes/src/evm/evm-fallback.test.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { translateMissingRpcPeer } from './evm-fallback.js'
+
+/**
+ * The lazy RPC loader must translate a *missing optional peer* into an actionable message, while
+ * letting every other load failure surface unchanged — mirrors the Squid evm-rpc-stream
+ * load-rpc-stream tests. A blanket `catch` that always blamed the peers would misdiagnose a broken
+ * transitive dependency or an init error inside the RPC stack.
+ */
+
+function moduleNotFound(message: string, code = 'ERR_MODULE_NOT_FOUND'): NodeJS.ErrnoException {
+  const e = new Error(message) as NodeJS.ErrnoException
+  e.code = code
+  return e
+}
+
+describe('translateMissingRpcPeer', () => {
+  it('maps a missing @subsquid/evm-rpc (ESM loader) to an actionable, named error', () => {
+    const out = translateMissingRpcPeer(
+      moduleNotFound("Cannot find package '@subsquid/evm-rpc' imported from /app/evm-rpc-source.js"),
+      'rpc-1',
+    )
+    expect(out).toBeInstanceOf(Error)
+    expect((out as Error).message).toContain('rpc-1')
+    expect((out as Error).message).toContain('@subsquid/evm-rpc')
+    expect((out as Error).message).toContain('@subsquid/evm-normalization')
+  })
+
+  it('maps a missing @subsquid/evm-normalization (CJS loader code) too', () => {
+    const out = translateMissingRpcPeer(
+      moduleNotFound("Cannot find module '@subsquid/evm-normalization'", 'MODULE_NOT_FOUND'),
+    )
+    expect((out as Error).message).toContain('optional peer dependencies')
+  })
+
+  it('passes through a module-not-found for an UNRELATED module unchanged', () => {
+    const original = moduleNotFound("Cannot find package 'some-other-dep' imported from /app/x.js")
+    expect(translateMissingRpcPeer(original)).toBe(original) // not masked as a missing peer
+  })
+
+  it('passes through a non-module-not-found fault (e.g. an init/syntax error) unchanged', () => {
+    const original = new SyntaxError('Unexpected token in the RPC stack')
+    expect(translateMissingRpcPeer(original)).toBe(original)
+  })
+})

--- a/packages/subsquid-pipes/src/evm/evm-fallback.test.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest'
 
+import * as evmBarrel from './browser.js'
 import { translateMissingRpcPeer } from './evm-fallback.js'
+
+describe('public ./evm exports', () => {
+  it('surfaces the RPC-fallback source through the evm barrel (reachable by consumers)', () => {
+    // Guards the whole feature being unreachable — the barrel must re-export it, and doing so must
+    // not eagerly pull the optional evm-rpc peers (the import chain references them as types only).
+    expect(typeof evmBarrel.createEvmFallback).toBe('function')
+    expect(typeof evmBarrel.evmPortalReadSource).toBe('function')
+  })
+})
 
 /**
  * The lazy RPC loader must translate a *missing optional peer* into an actionable message, while

--- a/packages/subsquid-pipes/src/evm/evm-fallback.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.ts
@@ -1,4 +1,4 @@
-import { Rpc } from '@subsquid/evm-rpc'
+import type { Rpc } from '@subsquid/evm-rpc'
 import { cast } from '@subsquid/util-internal-validation'
 
 import {
@@ -18,7 +18,7 @@ import { ApiDataset } from '~/portal-client/client.js'
 import { PortalClient, PortalClientOptions } from '~/portal-client/index.js'
 import { Block, DataRequest, FieldSelection, getBlockSchema } from '~/portal-client/query/evm.js'
 
-import { EvmRpcSource, RpcMethodOptions } from './evm-rpc-source.js'
+import type { RpcMethodOptions } from './evm-rpc-source.js'
 import { withRequiredFields } from './rpc/decode.js'
 
 /** One EVM source in a fallback. Both kinds share the same `fields` + `request`. */
@@ -133,19 +133,54 @@ export function createEvmFallback<F extends FieldSelection>(
       })
     }
 
-    return new EvmRpcSource({
-      id: cfg.name ?? `rpc-${i}`,
-      rpc: cfg.rpc,
-      fields: options.fields,
-      request: options.request,
-      from: options.from,
-      to: options.to,
-      finalized: options.finalized,
-      method: cfg.method,
-      strideSize: cfg.strideSize,
-      strideConcurrency: cfg.strideConcurrency,
-    })
+    return lazyRpcSource(cfg.name ?? `rpc-${i}`, cfg, options)
   })
 
   return new FallbackSource(underlying, options.policy)
+}
+
+/**
+ * An RPC fallback source whose `@subsquid/evm-rpc` dependency is loaded **lazily** — only when the
+ * source is actually read (i.e. it becomes active). A multi-Portal fallback therefore never
+ * imports the RPC stack, and a misconfigured RPC source fails with a clear, actionable error
+ * instead of an opaque module-not-found at startup. (`@subsquid/evm-rpc` + `evm-normalization` are
+ * optional and currently unpublished — see EXECUTION_STATUS.md.)
+ */
+function lazyRpcSource<F extends FieldSelection>(
+  name: string,
+  cfg: Extract<EvmFallbackSourceConfig<F>, { type: 'rpc' }>,
+  options: EvmFallbackOptions<F>,
+): FallbackUnderlyingSource<Block<F>[]> {
+  let inner: { read(cursor?: BlockCursor): AsyncIterable<PortalBatch<Block<F>[]>> } | undefined
+
+  return {
+    name,
+    read: async function* (cursor?: BlockCursor): AsyncIterable<PortalBatch<Block<F>[]>> {
+      if (!inner) {
+        let mod: typeof import('./evm-rpc-source.js')
+        try {
+          mod = await import('./evm-rpc-source.js')
+        } catch {
+          throw new Error(
+            `RPC fallback source "${name}" requires the optional "@subsquid/evm-rpc" and ` +
+              `"@subsquid/evm-normalization" packages — install them to use RPC sources.`,
+          )
+        }
+        inner = new mod.EvmRpcSource({
+          id: name,
+          rpc: cfg.rpc,
+          fields: options.fields,
+          request: options.request,
+          from: options.from,
+          to: options.to,
+          finalized: options.finalized,
+          method: cfg.method,
+          strideSize: cfg.strideSize,
+          strideConcurrency: cfg.strideConcurrency,
+        })
+      }
+
+      yield* inner.read(cursor)
+    },
+  }
 }

--- a/packages/subsquid-pipes/src/evm/evm-fallback.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.ts
@@ -179,23 +179,27 @@ export function createEvmFallback<F extends FieldSelection>(
   return fallback
 }
 
-const RPC_PEERS = ['@subsquid/evm-rpc', '@subsquid/evm-normalization']
+// The full optional "RPC stack": `@subsquid/evm-rpc` + `@subsquid/evm-normalization` and evm-rpc's
+// own peers (`@subsquid/http-client`, `@subsquid/rpc-client`). A consumer installing only the first
+// two can still hit a module-not-found for the transitive peers, so all four are detected and named.
+const RPC_PEERS = ['@subsquid/evm-rpc', '@subsquid/evm-normalization', '@subsquid/http-client', '@subsquid/rpc-client']
 
 /**
- * If `e` is a module-not-found for one of the optional RPC peers, return an actionable error naming
- * both peers; otherwise return `e` unchanged. Matches the missing module by its exact quoted name,
- * so a module-not-found for a *different* module (a broken transitive dep) — and any other fault
- * thrown while loading the RPC stack (a syntax/init error) — surfaces as-is rather than being masked
- * as "peers missing". Handles both the ESM (`ERR_MODULE_NOT_FOUND`) and CJS (`MODULE_NOT_FOUND`)
- * loader codes, since the package ships both builds.
+ * If `e` is a module-not-found for one of the optional RPC-stack peers, return an actionable error
+ * naming the whole stack; otherwise return `e` unchanged. Matches the missing module by its exact
+ * quoted name, so a module-not-found for a *different* module (a broken transitive dep) — and any
+ * other fault thrown while loading the RPC stack (a syntax/init error) — surfaces as-is rather than
+ * being masked as "peers missing". Handles both the ESM (`ERR_MODULE_NOT_FOUND`) and CJS
+ * (`MODULE_NOT_FOUND`) loader codes, since the package ships both builds.
  */
 export function translateMissingRpcPeer(e: unknown, sourceName = 'rpc'): unknown {
   const err = e as NodeJS.ErrnoException
   const isModuleNotFound = err?.code === 'ERR_MODULE_NOT_FOUND' || err?.code === 'MODULE_NOT_FOUND'
   if (isModuleNotFound && RPC_PEERS.some((p) => err.message?.includes(`'${p}'`))) {
+    const list = RPC_PEERS.map((p) => `"${p}"`).join(', ')
     return new Error(
-      `RPC fallback source "${sourceName}" requires the optional peer dependencies ` +
-        `"${RPC_PEERS[0]}" and "${RPC_PEERS[1]}" — install them to use RPC sources, or use only 'portal' sources.`,
+      `RPC fallback source "${sourceName}" requires the optional peer dependencies ${list} — ` +
+        `install them to use RPC sources, or use only 'portal' sources.`,
     )
   }
   return err

--- a/packages/subsquid-pipes/src/evm/evm-fallback.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.ts
@@ -74,8 +74,15 @@ export function evmPortalReadSource<F extends FieldSelection>(
   const metrics = noopMetricsServer().metrics
   const rawQuery = { type: 'evm', fields: options.fields, ...options.request }
 
+  const finalized = options.finalized ?? true
+
   return {
     name,
+    // Independent head poll (no stream) that powers staleness/lag detection + standby liveness.
+    getHead: async (): Promise<BlockCursor | undefined> => {
+      const head = await portal.getHead({ finalized })
+      return head ? { number: head.number, hash: head.hash } : undefined
+    },
     read: async function* (cursor?: BlockCursor): AsyncIterable<PortalBatch<Block<F>[]>> {
       const from = cursor ? cursor.number + 1 : options.from
       const query: any = {
@@ -87,7 +94,7 @@ export function evmPortalReadSource<F extends FieldSelection>(
         parentBlockHash: cursor?.hash,
       }
 
-      for await (const batch of portal.getStream(query, { finalized: options.finalized ?? true })) {
+      for await (const batch of portal.getStream(query, { finalized })) {
         const data = batch.blocks.map((raw) => cast(schema, raw)) as unknown as Block<F>[]
         if (data.length === 0) continue
 
@@ -179,36 +186,46 @@ function lazyRpcSource<F extends FieldSelection>(
   cfg: Extract<EvmFallbackSourceConfig<F>, { type: 'rpc' }>,
   options: EvmFallbackOptions<F>,
 ): FallbackUnderlyingSource<Block<F>[]> {
-  let inner: { read(cursor?: BlockCursor): AsyncIterable<PortalBatch<Block<F>[]>> } | undefined
+  let inner:
+    | {
+        read(cursor?: BlockCursor): AsyncIterable<PortalBatch<Block<F>[]>>
+        getHead(): Promise<BlockCursor | undefined>
+      }
+    | undefined
+
+  const load = async () => {
+    if (inner) return inner
+    let mod: typeof import('./evm-rpc-source.js')
+    try {
+      mod = await import('./evm-rpc-source.js')
+    } catch {
+      throw new Error(
+        `RPC fallback source "${name}" requires the optional "@subsquid/evm-rpc" and ` +
+          `"@subsquid/evm-normalization" packages — install them to use RPC sources.`,
+      )
+    }
+    inner = new mod.EvmRpcSource({
+      id: name,
+      rpc: cfg.rpc,
+      fields: options.fields,
+      request: options.request,
+      from: options.from,
+      to: options.to,
+      finalized: options.finalized,
+      method: cfg.method,
+      strideSize: cfg.strideSize,
+      strideConcurrency: cfg.strideConcurrency,
+    })
+    return inner
+  }
 
   return {
     name,
+    // Head-polling a standby RPC source loads the RPC stack — that is fine/desirable: it is exactly
+    // when we want to confirm the source is loadable and viable before switching up to it.
+    getHead: async () => (await load()).getHead(),
     read: async function* (cursor?: BlockCursor): AsyncIterable<PortalBatch<Block<F>[]>> {
-      if (!inner) {
-        let mod: typeof import('./evm-rpc-source.js')
-        try {
-          mod = await import('./evm-rpc-source.js')
-        } catch {
-          throw new Error(
-            `RPC fallback source "${name}" requires the optional "@subsquid/evm-rpc" and ` +
-              `"@subsquid/evm-normalization" packages — install them to use RPC sources.`,
-          )
-        }
-        inner = new mod.EvmRpcSource({
-          id: name,
-          rpc: cfg.rpc,
-          fields: options.fields,
-          request: options.request,
-          from: options.from,
-          to: options.to,
-          finalized: options.finalized,
-          method: cfg.method,
-          strideSize: cfg.strideSize,
-          strideConcurrency: cfg.strideConcurrency,
-        })
-      }
-
-      yield* inner.read(cursor)
+      yield* (await load()).read(cursor)
     },
   }
 }

--- a/packages/subsquid-pipes/src/evm/evm-fallback.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.ts
@@ -179,7 +179,7 @@ export function createEvmFallback<F extends FieldSelection>(
  * source is actually read (i.e. it becomes active). A multi-Portal fallback therefore never
  * imports the RPC stack, and a misconfigured RPC source fails with a clear, actionable error
  * instead of an opaque module-not-found at startup. (`@subsquid/evm-rpc` + `evm-normalization` are
- * optional and currently unpublished — see EXECUTION_STATUS.md.)
+ * declared as optional peer dependencies — a Portal-only consumer never installs them.)
  */
 function lazyRpcSource<F extends FieldSelection>(
   name: string,

--- a/packages/subsquid-pipes/src/evm/evm-fallback.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.ts
@@ -1,0 +1,151 @@
+import { Rpc } from '@subsquid/evm-rpc'
+import { cast } from '@subsquid/util-internal-validation'
+
+import {
+  BatchContext,
+  BlockCursor,
+  FallbackPolicy,
+  FallbackSource,
+  FallbackUnderlyingSource,
+  PortalBatch,
+  createDefaultLogger,
+  cursorFromHeader,
+  extractRollbackChain,
+  noopMetricsServer,
+} from '~/core/index.js'
+import { Span } from '~/core/profiling.js'
+import { ApiDataset } from '~/portal-client/client.js'
+import { PortalClient, PortalClientOptions } from '~/portal-client/index.js'
+import { Block, DataRequest, FieldSelection, getBlockSchema } from '~/portal-client/query/evm.js'
+
+import { EvmRpcSource, RpcMethodOptions } from './evm-rpc-source.js'
+import { withRequiredFields } from './rpc/decode.js'
+
+/** One EVM source in a fallback. Both kinds share the same `fields` + `request`. */
+export type EvmFallbackSourceConfig<F extends FieldSelection> =
+  | { type: 'portal'; name?: string; portal: string | PortalClientOptions | PortalClient }
+  | { type: 'rpc'; name?: string; rpc: Rpc; method?: RpcMethodOptions; strideSize?: number; strideConcurrency?: number }
+
+export interface EvmFallbackOptions<F extends FieldSelection> {
+  fields: F
+  request: DataRequest
+  from: number
+  to?: number
+  finalized?: boolean
+  sources: EvmFallbackSourceConfig<F>[]
+  policy?: FallbackPolicy
+}
+
+/**
+ * A Portal source adapter that exposes the fallback's `read(cursor)` contract: it fetches raw
+ * blocks from the Portal and casts them with the same `getBlockSchema` the Portal source uses, so
+ * its output matches the RPC source's. A `ForkException` propagates from the Portal client
+ * unchanged (it is already Pipes' `ForkException`).
+ */
+export function evmPortalReadSource<F extends FieldSelection>(
+  options: { name?: string; portal: string | PortalClientOptions | PortalClient } & Omit<
+    EvmFallbackOptions<F>,
+    'sources' | 'policy'
+  >,
+): FallbackUnderlyingSource<Block<F>[]> {
+  const portal =
+    options.portal instanceof PortalClient
+      ? options.portal
+      : new PortalClient(typeof options.portal === 'string' ? { url: options.portal } : options.portal)
+
+  const fields = withRequiredFields(options.fields)
+  const schema = getBlockSchema(fields)
+  const name = options.name ?? 'portal'
+  const logger = createDefaultLogger({ id: name })
+  const metrics = noopMetricsServer().metrics
+  const rawQuery = { type: 'evm', fields: options.fields, ...options.request }
+
+  return {
+    name,
+    read: async function* (cursor?: BlockCursor): AsyncIterable<PortalBatch<Block<F>[]>> {
+      const from = cursor ? cursor.number + 1 : options.from
+      const query: any = {
+        type: 'evm',
+        fields,
+        fromBlock: from,
+        toBlock: options.to,
+        ...options.request,
+        parentBlockHash: cursor?.hash,
+      }
+
+      for await (const batch of portal.getStream(query, { finalized: options.finalized ?? true })) {
+        const data = batch.blocks.map((raw) => cast(schema, raw)) as unknown as Block<F>[]
+        if (data.length === 0) continue
+
+        const current = cursorFromHeader(data[data.length - 1] as any)
+        const finalized = batch.head.finalized
+          ? { number: batch.head.finalized.number, hash: batch.head.finalized.hash }
+          : undefined
+
+        const ctx: BatchContext = {
+          id: name,
+          profiler: Span.root('batch', false),
+          metrics,
+          logger,
+          stream: {
+            dataset: {} as ApiDataset,
+            head: { finalized, latest: current },
+            state: {
+              initial: from,
+              last: current.number,
+              current,
+              rollbackChain: extractRollbackChain({ blocks: data as any, head: finalized }),
+            },
+            query: { url: portal.getUrl?.() ?? '', hash: '', raw: rawQuery },
+          },
+          batch: {
+            blocksCount: data.length,
+            bytesSize: batch.meta.bytes,
+            requests: batch.meta.requests,
+            lastBlockReceivedAt: batch.meta.lastBlockReceivedAt,
+          },
+        }
+
+        yield { data, ctx }
+      }
+    },
+  }
+}
+
+/**
+ * Build a {@link FallbackSource} over an ordered list of EVM sources (Portal and/or RPC), all
+ * sharing one field selection + request so they produce identical output. Drop-in for a single
+ * Portal stream — same `AsyncIterable<PortalBatch> + pipeTo`.
+ */
+export function createEvmFallback<F extends FieldSelection>(
+  options: EvmFallbackOptions<F>,
+): FallbackSource<Block<F>[]> {
+  const underlying: FallbackUnderlyingSource<Block<F>[]>[] = options.sources.map((cfg, i) => {
+    if (cfg.type === 'portal') {
+      return evmPortalReadSource({
+        name: cfg.name ?? `portal-${i}`,
+        portal: cfg.portal,
+        fields: options.fields,
+        request: options.request,
+        from: options.from,
+        to: options.to,
+        finalized: options.finalized,
+      })
+    }
+
+    return new EvmRpcSource({
+      id: cfg.name ?? `rpc-${i}`,
+      rpc: cfg.rpc,
+      fields: options.fields,
+      request: options.request,
+      from: options.from,
+      to: options.to,
+      finalized: options.finalized,
+      method: cfg.method,
+      strideSize: cfg.strideSize,
+      strideConcurrency: cfg.strideConcurrency,
+    })
+  })
+
+  return new FallbackSource(underlying, options.policy)
+}

--- a/packages/subsquid-pipes/src/evm/evm-fallback.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.ts
@@ -25,9 +25,10 @@ import { Block, DataRequest, FieldSelection, getBlockSchema } from '~/portal-cli
 import type { RpcMethodOptions } from './evm-rpc-source.js'
 import { withRequiredFields } from './rpc/decode.js'
 
-// Re-export the RPC method-selection type so consumers can type an `rpc` source's `method` without
-// importing from the lazily-loaded (optional-peer) evm-rpc-source module. Type-only: erased at build,
-// so it never eagerly pulls the optional peers.
+// Re-export the RPC method-selection type so consumers can type an `rpc` source's `method`. Type-only,
+// so it's erased from the JS and never pulls the optional peers at *runtime* — but, like the `Rpc`-typed
+// config field, it is preserved in the emitted .d.ts, so a TS consumer that references the RPC-config
+// types needs @subsquid/evm-rpc installed for typechecking.
 export type { RpcMethodOptions } from './evm-rpc-source.js'
 
 /** One EVM source in a fallback. Both kinds share the same `fields` + `request`. */

--- a/packages/subsquid-pipes/src/evm/evm-fallback.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.ts
@@ -7,11 +7,13 @@ import {
   FallbackPolicy,
   FallbackSource,
   FallbackUnderlyingSource,
+  MetricsServer,
   PortalBatch,
   createDefaultLogger,
   cursorFromHeader,
   extractRollbackChain,
   noopMetricsServer,
+  registerFallbackMetrics,
 } from '~/core/index.js'
 import { Span } from '~/core/profiling.js'
 import { ApiDataset } from '~/portal-client/client.js'
@@ -34,6 +36,8 @@ export interface EvmFallbackOptions<F extends FieldSelection> {
   finalized?: boolean
   sources: EvmFallbackSourceConfig<F>[]
   policy?: FallbackPolicy
+  /** When provided, fallback health/switch gauges are registered on this metrics server (§4). */
+  metrics?: MetricsServer
 }
 
 /**
@@ -136,7 +140,12 @@ export function createEvmFallback<F extends FieldSelection>(
     return lazyRpcSource(cfg.name ?? `rpc-${i}`, cfg, options)
   })
 
-  return new FallbackSource(underlying, options.policy)
+  const fallback = new FallbackSource(underlying, options.policy)
+  if (options.metrics) {
+    registerFallbackMetrics(options.metrics.metrics, fallback)
+  }
+
+  return fallback
 }
 
 /**

--- a/packages/subsquid-pipes/src/evm/evm-fallback.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.ts
@@ -174,6 +174,28 @@ export function createEvmFallback<F extends FieldSelection>(
   return fallback
 }
 
+const RPC_PEERS = ['@subsquid/evm-rpc', '@subsquid/evm-normalization']
+
+/**
+ * If `e` is a module-not-found for one of the optional RPC peers, return an actionable error naming
+ * both peers; otherwise return `e` unchanged. Matches the missing module by its exact quoted name,
+ * so a module-not-found for a *different* module (a broken transitive dep) — and any other fault
+ * thrown while loading the RPC stack (a syntax/init error) — surfaces as-is rather than being masked
+ * as "peers missing". Handles both the ESM (`ERR_MODULE_NOT_FOUND`) and CJS (`MODULE_NOT_FOUND`)
+ * loader codes, since the package ships both builds.
+ */
+export function translateMissingRpcPeer(e: unknown, sourceName = 'rpc'): unknown {
+  const err = e as NodeJS.ErrnoException
+  const isModuleNotFound = err?.code === 'ERR_MODULE_NOT_FOUND' || err?.code === 'MODULE_NOT_FOUND'
+  if (isModuleNotFound && RPC_PEERS.some((p) => err.message?.includes(`'${p}'`))) {
+    return new Error(
+      `RPC fallback source "${sourceName}" requires the optional peer dependencies ` +
+        `"${RPC_PEERS[0]}" and "${RPC_PEERS[1]}" — install them to use RPC sources, or use only 'portal' sources.`,
+    )
+  }
+  return err
+}
+
 /**
  * An RPC fallback source whose `@subsquid/evm-rpc` dependency is loaded **lazily** — only when the
  * source is actually read (i.e. it becomes active). A multi-Portal fallback therefore never
@@ -198,11 +220,8 @@ function lazyRpcSource<F extends FieldSelection>(
     let mod: typeof import('./evm-rpc-source.js')
     try {
       mod = await import('./evm-rpc-source.js')
-    } catch {
-      throw new Error(
-        `RPC fallback source "${name}" requires the optional "@subsquid/evm-rpc" and ` +
-          `"@subsquid/evm-normalization" packages — install them to use RPC sources.`,
-      )
+    } catch (e) {
+      throw translateMissingRpcPeer(e, name)
     }
     inner = new mod.EvmRpcSource({
       id: name,

--- a/packages/subsquid-pipes/src/evm/evm-fallback.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.ts
@@ -25,6 +25,11 @@ import { Block, DataRequest, FieldSelection, getBlockSchema } from '~/portal-cli
 import type { RpcMethodOptions } from './evm-rpc-source.js'
 import { withRequiredFields } from './rpc/decode.js'
 
+// Re-export the RPC method-selection type so consumers can type an `rpc` source's `method` without
+// importing from the lazily-loaded (optional-peer) evm-rpc-source module. Type-only: erased at build,
+// so it never eagerly pulls the optional peers.
+export type { RpcMethodOptions } from './evm-rpc-source.js'
+
 /** One EVM source in a fallback. Both kinds share the same `fields` + `request`. */
 export type EvmFallbackSourceConfig<F extends FieldSelection> =
   | { type: 'portal'; name?: string; portal: string | PortalClientOptions | PortalClient }

--- a/packages/subsquid-pipes/src/evm/evm-fallback.ts
+++ b/packages/subsquid-pipes/src/evm/evm-fallback.ts
@@ -4,6 +4,7 @@ import { cast } from '@subsquid/util-internal-validation'
 import {
   BatchContext,
   BlockCursor,
+  CapabilityProbeOptions,
   FallbackPolicy,
   FallbackSource,
   FallbackUnderlyingSource,
@@ -12,6 +13,7 @@ import {
   createDefaultLogger,
   cursorFromHeader,
   extractRollbackChain,
+  makeCapabilityProbe,
   noopMetricsServer,
   registerFallbackMetrics,
 } from '~/core/index.js'
@@ -36,6 +38,14 @@ export interface EvmFallbackOptions<F extends FieldSelection> {
   finalized?: boolean
   sources: EvmFallbackSourceConfig<F>[]
   policy?: FallbackPolicy
+  /**
+   * Attach a generic capability probe to every source (default `true`): a source counts as
+   * `healthy` only once it confirms it can serve the configured data at the indexing frontier —
+   * catching a reachable-but-incapable source (trace/`debug_` disabled, pruned state, a Portal
+   * answering HTTP 400 to a type-valid query) before a switch-up promotes it. Pass `false` to govern
+   * health by liveness alone, or `{timeoutMs}` to tune the probe.
+   */
+  capabilityProbe?: boolean | CapabilityProbeOptions
   /** When provided, fallback health/switch gauges are registered on this metrics server (§4). */
   metrics?: MetricsServer
 }
@@ -125,19 +135,28 @@ export function createEvmFallback<F extends FieldSelection>(
   options: EvmFallbackOptions<F>,
 ): FallbackSource<Block<F>[]> {
   const underlying: FallbackUnderlyingSource<Block<F>[]>[] = options.sources.map((cfg, i) => {
-    if (cfg.type === 'portal') {
-      return evmPortalReadSource({
-        name: cfg.name ?? `portal-${i}`,
-        portal: cfg.portal,
-        fields: options.fields,
-        request: options.request,
-        from: options.from,
-        to: options.to,
-        finalized: options.finalized,
-      })
-    }
+    const source =
+      cfg.type === 'portal'
+        ? evmPortalReadSource({
+            name: cfg.name ?? `portal-${i}`,
+            portal: cfg.portal,
+            fields: options.fields,
+            request: options.request,
+            from: options.from,
+            to: options.to,
+            finalized: options.finalized,
+          })
+        : lazyRpcSource(cfg.name ?? `rpc-${i}`, cfg, options)
 
-    return lazyRpcSource(cfg.name ?? `rpc-${i}`, cfg, options)
+    if (options.capabilityProbe === false) return source
+
+    return {
+      ...source,
+      probeCapability: makeCapabilityProbe(
+        source,
+        options.capabilityProbe === true ? undefined : options.capabilityProbe,
+      ),
+    }
   })
 
   const fallback = new FallbackSource(underlying, options.policy)

--- a/packages/subsquid-pipes/src/evm/evm-rpc-source.parity.e2e.test.ts
+++ b/packages/subsquid-pipes/src/evm/evm-rpc-source.parity.e2e.test.ts
@@ -70,4 +70,51 @@ describe.skipIf(!ENABLED)('EvmRpcSource — Portal parity', () => {
     expect(rpc.logs).toHaveLength(portal.logs.length)
     expect(rpc).toEqual(portal)
   }, 120_000)
+
+  it(`block ${BLOCK}: filtering on an unselected field projects back to exactly F`, async () => {
+    // Filter logs by the ERC-20 Transfer topic0 but select only `data` (NOT topics): the RPC
+    // source must augment topics to filter, then project back so the output omits topics.
+    const TRANSFER = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+    const F = { log: { data: true } } satisfies FieldSelection
+
+    const schema = getBlockSchema(withRequiredFields(F))
+    const portalP = (async () => {
+      const portal = new PortalClient({ url: PORTAL_URL })
+      const query: any = {
+        type: 'evm',
+        fields: withRequiredFields(F),
+        fromBlock: BLOCK,
+        toBlock: BLOCK,
+        logs: [{ topic0: [TRANSFER] }],
+      }
+      for await (const batch of portal.getStream(query, { finalized: true })) {
+        for (const raw of batch.blocks) {
+          const block: any = cast(schema, raw)
+          if (block.header.number === BLOCK) return block
+        }
+      }
+      throw new Error('portal block not found')
+    })()
+
+    const rpcP = (async () => {
+      const source = new EvmRpcSource({
+        rpc: new Rpc({ client: new EvmRpcClient({ url: RPC_URL, capacity: 5 }) }),
+        fields: F,
+        request: { logs: [{ topic0: [TRANSFER] }] },
+        from: BLOCK,
+        to: BLOCK,
+        finalized: true,
+      })
+      for await (const batch of source.read()) {
+        for (const b of batch.data as any[]) if (b.header.number === BLOCK) return b
+      }
+      throw new Error('rpc block not found')
+    })()
+
+    const [portal, rpc] = await Promise.all([portalP, rpcP])
+
+    expect(rpc.logs.length).toBeGreaterThan(0)
+    expect(rpc.logs).toEqual(portal.logs) // filtered set; no topics field
+    expect(rpc.logs.every((l: any) => l.topics === undefined)).toBe(true)
+  }, 120_000)
 })

--- a/packages/subsquid-pipes/src/evm/evm-rpc-source.parity.e2e.test.ts
+++ b/packages/subsquid-pipes/src/evm/evm-rpc-source.parity.e2e.test.ts
@@ -1,0 +1,73 @@
+import { EvmRpcClient, Rpc } from '@subsquid/evm-rpc'
+import { cast } from '@subsquid/util-internal-validation'
+import { describe, expect, it } from 'vitest'
+
+import { PortalClient } from '~/portal-client/index.js'
+import { FieldSelection, getBlockSchema } from '~/portal-client/query/evm.js'
+
+import { EvmRpcSource } from './evm-rpc-source.js'
+import { withRequiredFields } from './rpc/decode.js'
+
+/**
+ * Live parity test: fetch the same historical block from a real RPC endpoint (through the RPC
+ * source) and from the Portal (raw + the same cast), and assert the two decode to identical
+ * blocks. Network-gated: set `RPC_E2E=1` and `RPC_URL=https://rpc.subsquid.io/eth/<key>`.
+ */
+
+const ENABLED = process.env['RPC_E2E'] === '1' && !!process.env['RPC_URL']
+const RPC_URL = process.env['RPC_URL']!
+const PORTAL_URL = process.env['PORTAL_URL'] || 'https://portal.sqd.dev/datasets/ethereum-mainnet'
+const BLOCK = Number(process.env['RPC_E2E_BLOCK'] || 22000000)
+
+const FIELDS = {
+  block: { timestamp: true, gasUsed: true, miner: true },
+  transaction: { from: true, to: true, value: true, gas: true, gasUsed: true, status: true, input: true },
+  log: { address: true, topics: true, data: true },
+} satisfies FieldSelection
+
+async function portalBlock(): Promise<any> {
+  const portal = new PortalClient({ url: PORTAL_URL })
+  const schema = getBlockSchema(withRequiredFields(FIELDS))
+  const query: any = {
+    type: 'evm',
+    fields: withRequiredFields(FIELDS),
+    fromBlock: BLOCK,
+    toBlock: BLOCK,
+    transactions: [{}],
+    logs: [{}],
+  }
+  for await (const batch of portal.getStream(query, { finalized: true })) {
+    for (const raw of batch.blocks) {
+      const block: any = cast(schema, raw)
+      if (block.header.number === BLOCK) return block
+    }
+  }
+  throw new Error(`portal: block ${BLOCK} not found`)
+}
+
+async function rpcBlock(): Promise<any> {
+  const source = new EvmRpcSource({
+    rpc: new Rpc({ client: new EvmRpcClient({ url: RPC_URL, capacity: 5 }) }),
+    fields: FIELDS,
+    request: { transactions: [{}], logs: [{}] },
+    from: BLOCK,
+    to: BLOCK,
+    finalized: true,
+  })
+  for await (const batch of source.read()) {
+    for (const b of batch.data as any[]) {
+      if (b.header.number === BLOCK) return b
+    }
+  }
+  throw new Error(`rpc: block ${BLOCK} not found`)
+}
+
+describe.skipIf(!ENABLED)('EvmRpcSource — Portal parity', () => {
+  it(`block ${BLOCK}: transactions + logs match the Portal output`, async () => {
+    const [portal, rpc] = await Promise.all([portalBlock(), rpcBlock()])
+
+    expect(rpc.transactions).toHaveLength(portal.transactions.length)
+    expect(rpc.logs).toHaveLength(portal.logs.length)
+    expect(rpc).toEqual(portal)
+  }, 120_000)
+})

--- a/packages/subsquid-pipes/src/evm/evm-rpc-source.ts
+++ b/packages/subsquid-pipes/src/evm/evm-rpc-source.ts
@@ -18,6 +18,7 @@ import { Block, DataRequest, FieldSelection } from '~/portal-client/query/evm.js
 
 import { decodeBlock, withRequiredFields } from './rpc/decode.js'
 import { Relations, filterBlock, setUpRelations } from './rpc/filter.js'
+import { augmentFields, projectKept, selectionGrew } from './rpc/project.js'
 import { toRequiredData } from './rpc/request.js'
 
 /** RPC method-selection toggles (the per-chain "C1" config) merged into the coarse fetch request. */
@@ -52,7 +53,11 @@ export interface EvmRpcSourceOptions<F extends FieldSelection> {
  */
 export class EvmRpcSource<F extends FieldSelection> {
   readonly #inner: EvmRpcDataSource
-  readonly #fields: FieldSelection
+  /** F + structural required fields — the Portal output shape; the projection target. */
+  readonly #outputFields: FieldSelection
+  /** #outputFields + the fields the request's where-clauses need to be evaluated. */
+  readonly #augmentedFields: FieldSelection
+  readonly #needsProjection: boolean
   readonly #request: DataRequest
   readonly #from: number
   readonly #to?: number
@@ -65,7 +70,9 @@ export class EvmRpcSource<F extends FieldSelection> {
   readonly #rawQuery: unknown
 
   constructor(options: EvmRpcSourceOptions<F>) {
-    this.#fields = withRequiredFields(options.fields)
+    this.#outputFields = withRequiredFields(options.fields)
+    this.#augmentedFields = augmentFields(this.#outputFields, options.request)
+    this.#needsProjection = selectionGrew(this.#augmentedFields, this.#outputFields)
     this.#request = options.request
     this.#from = options.from
     this.#to = options.to
@@ -134,12 +141,20 @@ export class EvmRpcSource<F extends FieldSelection> {
 
   #mapBlock(raw: RpcBlock): Block<F> {
     const normalized = mapRpcBlock(raw, { withTraces: this.#withTraces, withStateDiffs: this.#withStateDiffs })
-    const block = decodeBlock(normalized, this.#fields)
+    const filtered = decodeBlock(normalized, this.#augmentedFields)
 
-    const relations: Relations = setUpRelations(block as any)
-    filterBlock(block as any, this.#request, relations)
+    const relations: Relations = setUpRelations(filtered as any)
+    filterBlock(filtered as any, this.#request, relations)
 
-    return block as Block<F>
+    if (!this.#needsProjection) {
+      return filtered as Block<F>
+    }
+
+    // A where-clause referenced a field not selected for output; project back to exactly the
+    // output shape and keep only the filtered items, matched by their structural index keys.
+    const projected = decodeBlock(normalized, this.#outputFields)
+
+    return projectKept(projected as any, filtered as any) as Block<F>
   }
 
   #buildContext(

--- a/packages/subsquid-pipes/src/evm/evm-rpc-source.ts
+++ b/packages/subsquid-pipes/src/evm/evm-rpc-source.ts
@@ -18,7 +18,7 @@ import { Block, DataRequest, FieldSelection } from '~/portal-client/query/evm.js
 
 import { decodeBlock, withRequiredFields } from './rpc/decode.js'
 import { Relations, filterBlock, setUpRelations } from './rpc/filter.js'
-import { augmentFields, projectKept, selectionGrew } from './rpc/project.js'
+import { augmentFields, keptByPosition, selectionGrew } from './rpc/project.js'
 import { toRequiredData } from './rpc/request.js'
 
 /** RPC method-selection toggles (the per-chain "C1" config) merged into the coarse fetch request. */
@@ -86,7 +86,8 @@ export class EvmRpcSource<F extends FieldSelection> {
     this.#withStateDiffs = coarse.stateDiffs
 
     const req: RpcDataRequest = {
-      // mapRpcBlock always maps the block's transactions, so full tx objects must be fetched.
+      // mapRpcBlock always maps the block's transactions, so full tx objects must be fetched. This
+      // is why `RequiredData` carries no `transactions` toggle — it could never be false.
       transactions: true,
       logs: coarse.logs,
       receipts: coarse.receipts,
@@ -147,20 +148,34 @@ export class EvmRpcSource<F extends FieldSelection> {
 
   #mapBlock(raw: RpcBlock): Block<F> {
     const normalized = mapRpcBlock(raw, { withTraces: this.#withTraces, withStateDiffs: this.#withStateDiffs })
-    const filtered = decodeBlock(normalized, this.#augmentedFields)
+    const filtered: any = decodeBlock(normalized, this.#augmentedFields)
 
-    const relations: Relations = setUpRelations(filtered as any)
-    filterBlock(filtered as any, this.#request, relations)
+    // The augmented decode's item arrays align 1:1 by index with a decode at exactly the output
+    // fields of the *same* normalized block; snapshot them before filtering so the surviving
+    // positions can be recovered by object identity (used by the projection below).
+    const preLogs = filtered.logs
+    const preTransactions = filtered.transactions
+    const preTraces = filtered.traces
+    const preStateDiffs = filtered.stateDiffs
+
+    const relations: Relations = setUpRelations(filtered)
+    filterBlock(filtered, this.#request, relations)
 
     if (!this.#needsProjection) {
       return filtered as Block<F>
     }
 
-    // A where-clause referenced a field not selected for output; project back to exactly the
-    // output shape and keep only the filtered items, matched by their structural index keys.
-    const projected = decodeBlock(normalized, this.#outputFields)
+    // A where-clause referenced a field not selected for output; decode again at exactly the output
+    // shape and keep the items whose pre-filter position survived. Position/identity — not a
+    // synthesized structural key — so items that share one (block-reward traces carry no
+    // transactionIndex) can't collide and project the wrong one.
+    const projected: any = decodeBlock(normalized, this.#outputFields)
+    projected.logs = keptByPosition(projected.logs, preLogs, filtered.logs)
+    projected.transactions = keptByPosition(projected.transactions, preTransactions, filtered.transactions)
+    projected.traces = keptByPosition(projected.traces, preTraces, filtered.traces)
+    projected.stateDiffs = keptByPosition(projected.stateDiffs, preStateDiffs, filtered.stateDiffs)
 
-    return projectKept(projected as any, filtered as any) as Block<F>
+    return projected as Block<F>
   }
 
   #buildContext(

--- a/packages/subsquid-pipes/src/evm/evm-rpc-source.ts
+++ b/packages/subsquid-pipes/src/evm/evm-rpc-source.ts
@@ -1,0 +1,181 @@
+import { mapRpcBlock } from '@subsquid/evm-normalization'
+import { EvmRpcDataSource, Rpc, Block as RpcBlock, DataRequest as RpcDataRequest } from '@subsquid/evm-rpc'
+
+import {
+  BatchContext,
+  BlockCursor,
+  Logger,
+  PortalBatch,
+  createDefaultLogger,
+  cursorFromHeader,
+  extractRollbackChain,
+  noopMetricsServer,
+} from '~/core/index.js'
+import { Span } from '~/core/profiling.js'
+import { ApiDataset } from '~/portal-client/client.js'
+import { ForkException } from '~/portal-client/index.js'
+import { Block, DataRequest, FieldSelection } from '~/portal-client/query/evm.js'
+
+import { decodeBlock, withRequiredFields } from './rpc/decode.js'
+import { Relations, filterBlock, setUpRelations } from './rpc/filter.js'
+import { toRequiredData } from './rpc/request.js'
+
+/** RPC method-selection toggles (the per-chain "C1" config) merged into the coarse fetch request. */
+export interface RpcMethodOptions {
+  useTraceApi?: boolean
+  useDebugTraceBlockByNumber?: boolean
+  useDebugApiForStateDiffs?: boolean
+  debugTraceTimeout?: string
+}
+
+export interface EvmRpcSourceOptions<F extends FieldSelection> {
+  id?: string
+  rpc: Rpc
+  fields: F
+  request: DataRequest
+  from: number
+  to?: number
+  /** Stream finalized blocks only (default). Hot blocks resume-safety is the target's concern. */
+  finalized?: boolean
+  method?: RpcMethodOptions
+  strideSize?: number
+  strideConcurrency?: number
+  logger?: Logger
+}
+
+/**
+ * An RPC-backed EVM source whose output matches the Portal source's. It delegates fetching,
+ * finality, continuity and fork detection to `@subsquid/evm-rpc`'s `EvmRpcDataSource`, maps each
+ * raw block through the reused Portal decoder + the ported client-side filter, and emits
+ * `PortalBatch`es with a populated `BatchContext` — so it drops into the fallback (or a target)
+ * exactly like a `PortalSource`'s stream. evm-rpc's `ForkException` is translated to Pipes'.
+ */
+export class EvmRpcSource<F extends FieldSelection> {
+  readonly #inner: EvmRpcDataSource
+  readonly #fields: FieldSelection
+  readonly #request: DataRequest
+  readonly #from: number
+  readonly #to?: number
+  readonly #finalized: boolean
+  readonly #withTraces: boolean
+  readonly #withStateDiffs: boolean
+  readonly #id: string
+  readonly #logger: Logger
+  readonly #metrics = noopMetricsServer().metrics
+  readonly #rawQuery: unknown
+
+  constructor(options: EvmRpcSourceOptions<F>) {
+    this.#fields = withRequiredFields(options.fields)
+    this.#request = options.request
+    this.#from = options.from
+    this.#to = options.to
+    this.#finalized = options.finalized ?? true
+    this.#id = options.id ?? 'evm-rpc'
+    this.#logger = options.logger ?? createDefaultLogger({ id: this.#id })
+    this.#rawQuery = { type: 'evm', fields: options.fields, ...options.request }
+
+    const coarse = toRequiredData(options.request, options.fields)
+    this.#withTraces = coarse.traces
+    this.#withStateDiffs = coarse.stateDiffs
+
+    const req: RpcDataRequest = {
+      // mapRpcBlock always maps the block's transactions, so full tx objects must be fetched.
+      transactions: true,
+      logs: coarse.logs,
+      receipts: coarse.receipts,
+      traces: coarse.traces,
+      stateDiffs: coarse.stateDiffs,
+      useTraceApi: options.method?.useTraceApi,
+      useDebugTraceBlockByNumber: options.method?.useDebugTraceBlockByNumber,
+      useDebugApiForStateDiffs: options.method?.useDebugApiForStateDiffs,
+      debugTraceTimeout: options.method?.debugTraceTimeout,
+    }
+
+    this.#inner = new EvmRpcDataSource({
+      rpc: options.rpc,
+      req,
+      strideSize: options.strideSize,
+      strideConcurrency: options.strideConcurrency,
+    })
+  }
+
+  get name(): string {
+    return this.#id
+  }
+
+  async *read(cursor?: BlockCursor): AsyncIterable<PortalBatch<Block<F>[]>> {
+    const from = cursor ? cursor.number + 1 : this.#from
+    const streamReq = { from, to: this.#to, parentHash: cursor?.hash }
+    const initial = from
+
+    const stream = this.#finalized ? this.#inner.getFinalizedStream(streamReq) : this.#inner.getStream(streamReq)
+
+    try {
+      for await (const { blocks, finalizedHead } of stream) {
+        const data = blocks.map((raw) => this.#mapBlock(raw))
+        if (data.length === 0) continue
+
+        const current = cursorFromHeader(data[data.length - 1] as any)
+        const finalized = finalizedHead ? { number: finalizedHead.number, hash: finalizedHead.hash } : undefined
+
+        yield { data, ctx: this.#buildContext(data, current, finalized, initial) }
+      }
+    } catch (e) {
+      if (isSqdForkException(e)) {
+        throw new ForkException(
+          e.previousBlocks.map((b) => ({ number: b.number, hash: b.hash })),
+          { fromBlock: e.blockNumber, parentBlockHash: e.expectedParentHash },
+        )
+      }
+
+      throw e
+    }
+  }
+
+  #mapBlock(raw: RpcBlock): Block<F> {
+    const normalized = mapRpcBlock(raw, { withTraces: this.#withTraces, withStateDiffs: this.#withStateDiffs })
+    const block = decodeBlock(normalized, this.#fields)
+
+    const relations: Relations = setUpRelations(block as any)
+    filterBlock(block as any, this.#request, relations)
+
+    return block as Block<F>
+  }
+
+  #buildContext(
+    data: Block<F>[],
+    current: BlockCursor,
+    finalized: BlockCursor | undefined,
+    initial: number,
+  ): BatchContext {
+    return {
+      id: this.#id,
+      profiler: Span.root('batch', false),
+      metrics: this.#metrics,
+      logger: this.#logger,
+      stream: {
+        dataset: {} as ApiDataset,
+        head: { finalized, latest: current },
+        state: {
+          initial,
+          last: current.number,
+          current,
+          rollbackChain: extractRollbackChain({ blocks: data as any, head: finalized }),
+        },
+        query: { url: '', hash: '', raw: this.#rawQuery },
+      },
+      batch: { blocksCount: data.length, bytesSize: 0, requests: {}, lastBlockReceivedAt: new Date() },
+    }
+  }
+}
+
+interface SqdForkException {
+  isSqdForkException: true
+  blockNumber: number
+  expectedParentHash: string
+  previousBlocks: { number: number; hash: string }[]
+}
+
+function isSqdForkException(e: unknown): e is SqdForkException {
+  return e instanceof Error && (e as any).isSqdForkException === true
+}

--- a/packages/subsquid-pipes/src/evm/evm-rpc-source.ts
+++ b/packages/subsquid-pipes/src/evm/evm-rpc-source.ts
@@ -18,7 +18,7 @@ import { Block, DataRequest, FieldSelection } from '~/portal-client/query/evm.js
 
 import { decodeBlock, withRequiredFields } from './rpc/decode.js'
 import { Relations, filterBlock, setUpRelations } from './rpc/filter.js'
-import { augmentFields, keptByPosition, selectionGrew } from './rpc/project.js'
+import { augmentFields, dropEmptyBlocks, keptByPosition, selectionGrew } from './rpc/project.js'
 import { toRequiredData } from './rpc/request.js'
 
 /** RPC method-selection toggles (the per-chain "C1" config) merged into the coarse fetch request. */
@@ -126,7 +126,10 @@ export class EvmRpcSource<F extends FieldSelection> {
 
     try {
       for await (const { blocks, finalizedHead } of stream) {
-        const data = blocks.map((raw) => this.#mapBlock(raw))
+        const mapped = blocks.map((raw) => this.#mapBlock(raw))
+        // Match the Portal: a block left empty by filtering is dropped (boundary blocks kept). The
+        // last kept block is also the batch's progress cursor.
+        const data = dropEmptyBlocks(mapped as any, this.#request.includeAllBlocks) as typeof mapped
         if (data.length === 0) continue
 
         const current = cursorFromHeader(data[data.length - 1] as any)

--- a/packages/subsquid-pipes/src/evm/evm-rpc-source.ts
+++ b/packages/subsquid-pipes/src/evm/evm-rpc-source.ts
@@ -110,6 +110,12 @@ export class EvmRpcSource<F extends FieldSelection> {
     return this.#id
   }
 
+  /** Independent head poll (no stream) — the same commitment the stream reads toward. */
+  async getHead(): Promise<BlockCursor | undefined> {
+    const head = this.#finalized ? await this.#inner.getFinalizedHead() : await this.#inner.getHead()
+    return head ? { number: head.number, hash: head.hash } : undefined
+  }
+
   async *read(cursor?: BlockCursor): AsyncIterable<PortalBatch<Block<F>[]>> {
     const from = cursor ? cursor.number + 1 : this.#from
     const streamReq = { from, to: this.#to, parentHash: cursor?.hash }

--- a/packages/subsquid-pipes/src/evm/evm-rpc-source.ts
+++ b/packages/subsquid-pipes/src/evm/evm-rpc-source.ts
@@ -170,8 +170,8 @@ export class EvmRpcSource<F extends FieldSelection> {
 
     // A where-clause referenced a field not selected for output; decode again at exactly the output
     // shape and keep the items whose pre-filter position survived. Position/identity — not a
-    // synthesized structural key — so items that share one (block-reward traces carry no
-    // transactionIndex) can't collide and project the wrong one.
+    // synthesized structural key — so structurally identical items can't collide and project the
+    // wrong one.
     const projected: any = decodeBlock(normalized, this.#outputFields)
     projected.logs = keptByPosition(projected.logs, preLogs, filtered.logs)
     projected.transactions = keptByPosition(projected.transactions, preTransactions, filtered.transactions)

--- a/packages/subsquid-pipes/src/evm/rpc/decode.test.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/decode.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { withRequiredFields } from './decode.js'
+
+describe('withRequiredFields', () => {
+  it('forces the structural stateDiff fields, including the `kind` discriminator', () => {
+    // `kind` is the stateDiff tagged-union discriminator and must survive projection so a
+    // `stateDiffs: [{ kind: [...] }]` where-clause can still match when kind isn't selected for output.
+    expect(withRequiredFields({}).stateDiff).toMatchObject({
+      transactionIndex: true,
+      address: true,
+      key: true,
+      kind: true,
+    })
+  })
+
+  it('forces the cursor + filter fields on every item type while preserving the user selection', () => {
+    const f = withRequiredFields({ log: { data: true } })
+    expect(f.block).toMatchObject({ number: true, hash: true, parentHash: true })
+    expect(f.log).toMatchObject({ data: true, logIndex: true, transactionIndex: true })
+    expect(f.trace).toMatchObject({ transactionIndex: true, traceAddress: true })
+  })
+})

--- a/packages/subsquid-pipes/src/evm/rpc/decode.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/decode.ts
@@ -1,4 +1,4 @@
-import { Block as NormalizedBlock } from '@subsquid/evm-normalization'
+import type { Block as NormalizedBlock } from '@subsquid/evm-normalization'
 import { toJSON } from '@subsquid/util-internal-json'
 import { cast } from '@subsquid/util-internal-validation'
 
@@ -16,7 +16,10 @@ export function withRequiredFields(fields: FieldSelection): FieldSelection {
     transaction: { ...fields.transaction, transactionIndex: true },
     log: { ...fields.log, logIndex: true, transactionIndex: true },
     trace: { ...fields.trace, transactionIndex: true, traceAddress: true },
-    stateDiff: { ...fields.stateDiff, transactionIndex: true, address: true, key: true },
+    // `kind` is the stateDiff tagged-union discriminator and an always-present required field, so it
+    // must survive projection — otherwise a `stateDiffs: [{ kind: [...] }]` where-clause (which reads
+    // `kind`) never matches when the user didn't also select it for output.
+    stateDiff: { ...fields.stateDiff, transactionIndex: true, address: true, key: true, kind: true },
   }
 }
 

--- a/packages/subsquid-pipes/src/evm/rpc/decode.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/decode.ts
@@ -1,0 +1,38 @@
+import { Block as NormalizedBlock } from '@subsquid/evm-normalization'
+import { toJSON } from '@subsquid/util-internal-json'
+import { cast } from '@subsquid/util-internal-validation'
+
+import { Block, FieldSelection, getBlockSchema } from '~/portal-client/query/evm.js'
+
+import { shimWireBlock } from './shim.js'
+
+/**
+ * Force the structurally-required fields the cursor + filter engine always need (and which the
+ * Portal query always includes), so they survive `project` regardless of the user's selection.
+ */
+export function withRequiredFields(fields: FieldSelection): FieldSelection {
+  return {
+    block: { ...fields.block, number: true, hash: true, parentHash: true },
+    transaction: { ...fields.transaction, transactionIndex: true },
+    log: { ...fields.log, logIndex: true, transactionIndex: true },
+    trace: { ...fields.trace, transactionIndex: true, traceAddress: true },
+    stateDiff: { ...fields.stateDiff, transactionIndex: true, address: true, key: true },
+  }
+}
+
+/**
+ * Decode an already-serialized wire block (the `toJSON` of a normalized block) into Pipes' typed
+ * `Block<F>` by reusing the exact Portal decoder — `cast(getBlockSchema(fields), …)` — preceded by
+ * the small pre-cast shim. Reusing the Portal decoder is what makes the RPC source's output match
+ * the Portal source's.
+ */
+export function decodeWireBlock<F extends FieldSelection>(wire: unknown, fields: F): Block<F> {
+  const shaped = shimWireBlock(wire)
+
+  return cast(getBlockSchema(fields), shaped)
+}
+
+/** Decode a normalized RPC block (`mapRpcBlock` output) into Pipes' `Block<F>`. */
+export function decodeBlock<F extends FieldSelection>(block: NormalizedBlock, fields: F): Block<F> {
+  return decodeWireBlock(toJSON(block), fields)
+}

--- a/packages/subsquid-pipes/src/evm/rpc/filter.test.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/filter.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { DataRequest } from '~/portal-client/query/evm.js'
 
 import { filterBlock, setUpRelations } from './filter.js'
+import { keptByPosition } from './project.js'
 import { toRequiredData } from './request.js'
 
 /**
@@ -74,21 +75,35 @@ describe('filterBlock', () => {
 
 describe('toRequiredData', () => {
   it('derives coarse toggles incl. relation-implication and receipt upgrade', () => {
+    // No `transactions` toggle: the RPC source always fetches full transactions (mapRpcBlock needs
+    // them), so it isn't derived here.
     expect(toRequiredData({}, {})).toEqual({
-      transactions: false,
       logs: false,
       receipts: false,
       traces: false,
       stateDiffs: false,
     })
 
-    // A log filter that includes the transaction + a requested tx field forces tx fetching.
-    expect(
-      toRequiredData({ logs: [{ address: ['0xa'], transaction: true }] }, { transaction: { from: true } }).transactions,
-    ).toBe(true)
-
     const upgraded = toRequiredData({ transactions: [{ to: ['0xb'] }], logs: [{}] }, { transaction: { gasUsed: true } })
     expect(upgraded.receipts).toBe(true)
     expect(upgraded.logs).toBe(false)
+  })
+})
+
+describe('keptByPosition', () => {
+  it('projects by position/identity, so structurally identical items never collide', () => {
+    // Two pre-filter items that would share a synthesized structural key — e.g. block-reward
+    // traces, which carry no transactionIndex. A keyed projection couldn't tell them apart.
+    const preA = { tag: 'reward' }
+    const preB = { tag: 'reward' }
+    const pre = [preA, preB]
+    // The decode at exactly the output fields: distinct objects, aligned 1:1 with `pre` by position.
+    const projected = [{ n: 0 }, { n: 1 }]
+
+    // Only the *second* survived filtering — the projection must keep the second, not the first.
+    expect(keptByPosition(projected, pre, [preB])).toEqual([{ n: 1 }])
+    expect(keptByPosition(projected, pre, [preA])).toEqual([{ n: 0 }])
+    expect(keptByPosition(projected, pre, [preA, preB])).toEqual([{ n: 0 }, { n: 1 }])
+    expect(keptByPosition(projected, pre, [])).toEqual([])
   })
 })

--- a/packages/subsquid-pipes/src/evm/rpc/filter.test.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/filter.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+
+import { DataRequest } from '~/portal-client/query/evm.js'
+
+import { filterBlock, setUpRelations } from './filter.js'
+import { toRequiredData } from './request.js'
+
+/**
+ * Hand-built flat blocks + an independent expectation of Portal filter semantics (the unit
+ * oracle, not golden dumps) — mirrors the Squid evm-rpc-stream filter tests.
+ */
+
+function log(transactionIndex: number, address: string, topics: string[] = []): any {
+  return { logIndex: transactionIndex * 10, transactionIndex, address, topics }
+}
+function tx(transactionIndex: number, props: any = {}): any {
+  return { transactionIndex, ...props }
+}
+function callTrace(transactionIndex: number, traceAddress: number[], action: any = {}): any {
+  return { transactionIndex, traceAddress, type: 'call', action: { to: '0x0', from: '0x0', ...action } }
+}
+function makeBlock(parts: { transactions?: any[]; logs?: any[]; traces?: any[]; stateDiffs?: any[] } = {}): any {
+  return {
+    header: { number: 1, hash: '0x1', parentHash: '0x0' },
+    transactions: parts.transactions ?? [],
+    logs: parts.logs ?? [],
+    traces: parts.traces ?? [],
+    stateDiffs: parts.stateDiffs ?? [],
+  }
+}
+function run(block: any, req: DataRequest) {
+  filterBlock(block, req, setUpRelations(block))
+  return block
+}
+
+describe('filterBlock', () => {
+  it('matches logs by address and topic0', () => {
+    const block = makeBlock({ logs: [log(0, '0xaaa', ['0xt0']), log(1, '0xbbb', ['0xz'])] })
+    run(block, { logs: [{ address: ['0xaaa'] }] })
+    expect(block.logs.map((l: any) => l.transactionIndex)).toEqual([0])
+  })
+
+  it('matches transactions by to/from (union of requests)', () => {
+    const block = makeBlock({ transactions: [tx(0, { to: '0xto' }), tx(1, {}), tx(2, { from: '0xfrom' })] })
+    run(block, { transactions: [{ to: ['0xto'] }, { from: ['0xfrom'] }] })
+    expect(block.transactions.map((t: any) => t.transactionIndex)).toEqual([0, 2])
+  })
+
+  it('expands log → transaction and tx → logs relations', () => {
+    const block = makeBlock({
+      transactions: [tx(0, { to: '0xa' }), tx(1, { to: '0xb' })],
+      logs: [log(0, '0xaaa'), log(0, '0xbbb')],
+    })
+    run(block, { logs: [{ address: ['0xaaa'], transaction: true }] })
+    expect(block.transactions.map((t: any) => t.transactionIndex)).toEqual([0])
+    expect(block.logs).toHaveLength(1) // only the matched log (no transactionLogs)
+  })
+
+  it('expands trace subtraces to all descendants but not unrelated branches', () => {
+    const block = makeBlock({
+      traces: [callTrace(0, [0], { to: '0xroot' }), callTrace(0, [0, 0]), callTrace(0, [1]), callTrace(0, [1, 0])],
+    })
+    run(block, { traces: [{ callTo: ['0xroot'], subtraces: true }] })
+    expect(block.traces.map((t: any) => t.traceAddress)).toEqual([[0], [0, 0]])
+  })
+
+  it('drops everything when nothing is requested', () => {
+    const block = makeBlock({ logs: [log(0, '0xaaa')], transactions: [tx(0)] })
+    run(block, {})
+    expect(block.logs).toHaveLength(0)
+    expect(block.transactions).toHaveLength(0)
+  })
+})
+
+describe('toRequiredData', () => {
+  it('derives coarse toggles incl. relation-implication and receipt upgrade', () => {
+    expect(toRequiredData({}, {})).toEqual({
+      transactions: false,
+      logs: false,
+      receipts: false,
+      traces: false,
+      stateDiffs: false,
+    })
+
+    // A log filter that includes the transaction + a requested tx field forces tx fetching.
+    expect(
+      toRequiredData({ logs: [{ address: ['0xa'], transaction: true }] }, { transaction: { from: true } }).transactions,
+    ).toBe(true)
+
+    const upgraded = toRequiredData({ transactions: [{ to: ['0xb'] }], logs: [{}] }, { transaction: { gasUsed: true } })
+    expect(upgraded.receipts).toBe(true)
+    expect(upgraded.logs).toBe(false)
+  })
+})

--- a/packages/subsquid-pipes/src/evm/rpc/filter.test.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/filter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { DataRequest } from '~/portal-client/query/evm.js'
 
+import { EvmQueryBuilder } from '../evm-query-builder.js'
 import { filterBlock, setUpRelations } from './filter.js'
 import { keptByPosition } from './project.js'
 import { toRequiredData } from './request.js'
@@ -19,6 +20,12 @@ function tx(transactionIndex: number, props: any = {}): any {
 }
 function callTrace(transactionIndex: number, traceAddress: number[], action: any = {}): any {
   return { transactionIndex, traceAddress, type: 'call', action: { to: '0x0', from: '0x0', ...action } }
+}
+function rewardTrace(transactionIndex: number, traceAddress: number[] = [0], author = '0xauthor'): any {
+  return { transactionIndex, traceAddress, type: 'reward', action: { author, value: '0x1' } }
+}
+function stateDiff(transactionIndex: number, address: string, kind: string): any {
+  return { transactionIndex, address, key: 'balance', kind }
 }
 function makeBlock(parts: { transactions?: any[]; logs?: any[]; traces?: any[]; stateDiffs?: any[] } = {}): any {
   return {
@@ -71,6 +78,75 @@ describe('filterBlock', () => {
     expect(block.logs).toHaveLength(0)
     expect(block.transactions).toHaveLength(0)
   })
+
+  it('matches logs by topic0 alone (regardless of address)', () => {
+    const block = makeBlock({ logs: [log(0, '0xaaa', ['0xt0']), log(1, '0xbbb', ['0xz'])] })
+    run(block, { logs: [{ topic0: ['0xt0'] }] })
+    expect(block.logs.map((l: any) => l.transactionIndex)).toEqual([0])
+  })
+
+  it('keeps an item matched by two requests only once (Set union, no duplicates)', () => {
+    const block = makeBlock({ logs: [log(0, '0xaaa', ['0xt0'])] })
+    // the single log matches BOTH requests — it must appear once, not twice
+    run(block, { logs: [{ address: ['0xaaa'] }, { topic0: ['0xt0'] }] })
+    expect(block.logs).toHaveLength(1)
+  })
+
+  it('an empty where matches every item of that type', () => {
+    const block = makeBlock({ logs: [log(0, '0xaaa'), log(1, '0xbbb')] })
+    run(block, { logs: [{}] })
+    expect(block.logs).toHaveLength(2)
+  })
+
+  it('matches traces by type', () => {
+    const block = makeBlock({ traces: [callTrace(0, [0]), rewardTrace(1)] })
+    run(block, { traces: [{ type: ['reward'] }] })
+    expect(block.traces.map((t: any) => t.type)).toEqual(['reward'])
+  })
+
+  it('matches stateDiffs by address and, separately, by kind', () => {
+    const diffs = () => [stateDiff(0, '0xaaa', '='), stateDiff(1, '0xbbb', '+')]
+
+    const byAddress = makeBlock({ stateDiffs: diffs() })
+    run(byAddress, { stateDiffs: [{ address: ['0xaaa'] }] })
+    expect(byAddress.stateDiffs.map((d: any) => d.transactionIndex)).toEqual([0])
+
+    const byKind = makeBlock({ stateDiffs: diffs() })
+    run(byKind, { stateDiffs: [{ kind: ['+'] }] })
+    expect(byKind.stateDiffs.map((d: any) => d.transactionIndex)).toEqual([1])
+  })
+
+  it('expands transaction → logs / traces / stateDiffs siblings', () => {
+    const block = makeBlock({
+      transactions: [tx(0, { to: '0xt' })],
+      logs: [log(0, '0xaaa'), log(1, '0xbbb')],
+      traces: [callTrace(0, [0]), callTrace(1, [0])],
+      stateDiffs: [stateDiff(0, '0xaaa', '='), stateDiff(1, '0xbbb', '=')],
+    })
+    run(block, { transactions: [{ to: ['0xt'], logs: true, traces: true, stateDiffs: true }] })
+    expect(block.transactions.map((t: any) => t.transactionIndex)).toEqual([0])
+    expect(block.logs.map((l: any) => l.transactionIndex)).toEqual([0])
+    expect(block.traces.map((t: any) => t.transactionIndex)).toEqual([0])
+    expect(block.stateDiffs.map((d: any) => d.transactionIndex)).toEqual([0])
+  })
+
+  it('expands log → transactionTraces siblings', () => {
+    const block = makeBlock({
+      logs: [log(0, '0xaaa')],
+      traces: [callTrace(0, [0]), callTrace(1, [0])],
+    })
+    run(block, { logs: [{ address: ['0xaaa'], transactionTraces: true }] })
+    expect(block.traces.map((t: any) => t.transactionIndex)).toEqual([0])
+  })
+
+  it('expands trace → parents up the traceAddress chain', () => {
+    const block = makeBlock({
+      traces: [callTrace(0, [0]), callTrace(0, [0, 0]), callTrace(0, [0, 0, 0], { to: '0xdeep' })],
+    })
+    run(block, { traces: [{ callTo: ['0xdeep'], parents: true }] })
+    // the matched deep trace plus its ancestors [0,0] and [0] (original order preserved)
+    expect(block.traces.map((t: any) => t.traceAddress)).toEqual([[0], [0, 0], [0, 0, 0]])
+  })
 })
 
 describe('toRequiredData', () => {
@@ -87,6 +163,32 @@ describe('toRequiredData', () => {
     const upgraded = toRequiredData({ transactions: [{ to: ['0xb'] }], logs: [{}] }, { transaction: { gasUsed: true } })
     expect(upgraded.receipts).toBe(true)
     expect(upgraded.logs).toBe(false)
+  })
+
+  it('derives traces / stateDiffs / logs from relation includes on other item types', () => {
+    expect(toRequiredData({ logs: [{ transactionTraces: true }] }, {}).traces).toBe(true)
+    expect(toRequiredData({ logs: [{ transactionStateDiffs: true }] }, {}).stateDiffs).toBe(true)
+    expect(toRequiredData({ transactions: [{ traces: true }] }, {}).traces).toBe(true)
+    expect(toRequiredData({ transactions: [{ stateDiffs: true }] }, {}).stateDiffs).toBe(true)
+    expect(toRequiredData({ traces: [{ transactionLogs: true }] }, {}).logs).toBe(true)
+  })
+})
+
+describe('merged multi-request required-data (#510 regression)', () => {
+  it('applies the logs↔receipts dedup on the merged aggregate, not per request', () => {
+    // Two independent request items, exactly as a multi-`add*` config produces before the stream
+    // runs. `mergeDataRequests` concatenates them into one request; a single `toRequiredData` then
+    // decides the fetch toggles on the aggregate.
+    const merged = new EvmQueryBuilder().mergeDataRequests(
+      { logs: [{ address: ['0xaaa'] }] }, // wants raw logs
+      { transactions: [{ to: ['0xbbb'] }] }, // wants a tx; its receipt field upgrades to receipts
+    )
+    const required = toRequiredData(merged, { transaction: { gasUsed: true } })
+
+    // Receipts already carry the logs, so a redundant `eth_getLogs` must NOT be requested — even
+    // though one of the merged items asked for logs. Deduping per-request (the pre-#510 bug) would
+    // leave `logs: true` here.
+    expect(required).toEqual({ logs: false, receipts: true, traces: false, stateDiffs: false })
   })
 })
 

--- a/packages/subsquid-pipes/src/evm/rpc/filter.test.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/filter.test.ts
@@ -139,6 +139,33 @@ describe('filterBlock', () => {
     expect(block.traces.map((t: any) => t.transactionIndex)).toEqual([0])
   })
 
+  it('filters callSighash without crashing when a call trace has no sighash (optional field)', () => {
+    const block = makeBlock({
+      traces: [
+        { transactionIndex: 0, traceAddress: [0], type: 'call', action: { to: '0x0', from: '0x0' } }, // no sighash
+        {
+          transactionIndex: 1,
+          traceAddress: [0],
+          type: 'call',
+          action: { to: '0x0', from: '0x0', sighash: '0xdeadbeef' },
+        },
+      ],
+    })
+    run(block, { traces: [{ callSighash: ['0xdeadbeef'] }] })
+    expect(block.traces.map((t: any) => t.transactionIndex)).toEqual([1]) // the sighash-less trace is a non-match, not a crash
+  })
+
+  it('filters suicideRefundAddress without crashing when refundAddress is null (nullable field)', () => {
+    const block = makeBlock({
+      traces: [
+        { transactionIndex: 0, traceAddress: [0], type: 'suicide', action: { refundAddress: null } },
+        { transactionIndex: 1, traceAddress: [0], type: 'suicide', action: { refundAddress: '0xbene' } },
+      ],
+    })
+    run(block, { traces: [{ suicideRefundAddress: ['0xbene'] }] })
+    expect(block.traces.map((t: any) => t.transactionIndex)).toEqual([1])
+  })
+
   it('expands trace → parents up the traceAddress chain', () => {
     const block = makeBlock({
       traces: [callTrace(0, [0]), callTrace(0, [0, 0]), callTrace(0, [0, 0, 0], { to: '0xdeep' })],

--- a/packages/subsquid-pipes/src/evm/rpc/filter.test.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/filter.test.ts
@@ -221,8 +221,8 @@ describe('merged multi-request required-data (#510 regression)', () => {
 
 describe('keptByPosition', () => {
   it('projects by position/identity, so structurally identical items never collide', () => {
-    // Two pre-filter items that would share a synthesized structural key — e.g. block-reward
-    // traces, which carry no transactionIndex. A keyed projection couldn't tell them apart.
+    // Two structurally identical pre-filter items that a synthesized structural key couldn't tell
+    // apart. A keyed projection would confuse them; position + identity won't.
     const preA = { tag: 'reward' }
     const preB = { tag: 'reward' }
     const pre = [preA, preB]

--- a/packages/subsquid-pipes/src/evm/rpc/filter.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/filter.ts
@@ -147,15 +147,18 @@ function buildTraceFilter(req: TraceRequest[] = []) {
   } of req) {
     const filter = new FilterBuilder<AnyTrace>()
     filter.propIn('type' as any, type)
-    filter.getIn((t) => (t.type === 'create' ? assertNotNull((t as any).action?.from) : undefined), createFrom)
-    filter.getIn((t) => (t.type === 'call' ? assertNotNull((t as any).action?.to) : undefined), callTo)
-    filter.getIn((t) => (t.type === 'call' ? assertNotNull((t as any).action?.from) : undefined), callFrom)
-    filter.getIn((t) => (t.type === 'call' ? assertNotNull((t as any).action?.sighash) : undefined), callSighash)
+    // Read action fields nullable-safely: `getIn` treats `undefined` as a non-match, and several of
+    // these are legitimately absent on valid traces (a `call` with empty input has no `sighash`; a
+    // `suicide`'s `refundAddress` is nullable) — asserting non-null would crash the whole stream.
+    filter.getIn((t) => (t.type === 'create' ? (t as any).action?.from : undefined), createFrom)
+    filter.getIn((t) => (t.type === 'call' ? (t as any).action?.to : undefined), callTo)
+    filter.getIn((t) => (t.type === 'call' ? (t as any).action?.from : undefined), callFrom)
+    filter.getIn((t) => (t.type === 'call' ? (t as any).action?.sighash : undefined), callSighash)
     filter.getIn(
-      (t) => (t.type === 'suicide' ? assertNotNull((t as any).action?.refundAddress) : undefined),
+      (t) => (t.type === 'suicide' ? ((t as any).action?.refundAddress ?? undefined) : undefined),
       suicideRefundAddress,
     )
-    filter.getIn((t) => (t.type === 'reward' ? assertNotNull((t as any).action?.author) : undefined), rewardAuthor)
+    filter.getIn((t) => (t.type === 'reward' ? (t as any).action?.author : undefined), rewardAuthor)
     items.add(filter, relations)
   }
 

--- a/packages/subsquid-pipes/src/evm/rpc/filter.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/filter.ts
@@ -1,0 +1,276 @@
+import { assertNotNull, groupBy } from '@subsquid/util-internal'
+import { EntityFilter, FilterBuilder } from '@subsquid/util-internal-processor-tools'
+
+import {
+  Block,
+  DataRequest,
+  Log,
+  LogRequest,
+  StateDiff,
+  StateDiffRequest,
+  Trace,
+  TraceRequest,
+  Transaction,
+  TransactionRequest,
+} from '~/portal-client/query/evm.js'
+
+/**
+ * Client-side equivalent of the Portal server's filtering, for the RPC source: the Portal filters
+ * server-side, but RPC fetches full blocks, so we match items + expand relations here. Ported from
+ * the legacy `@subsquid/evm-processor` `ds-rpc/filter.ts` (and mirrors the Squid evm-rpc-stream
+ * port) onto Pipes' flat `Block`/`DataRequest` model. Relations are kept in side-maps so the
+ * yielded blocks stay plain projections.
+ */
+
+type AnyBlock = Block<any>
+type AnyLog = Log<any>
+type AnyTransaction = Transaction<any>
+type AnyTrace = Trace<any>
+type AnyStateDiff = StateDiff<any>
+
+export interface Relations {
+  txByIndex: Map<number, AnyTransaction>
+  logsByTx: Map<number, AnyLog[]>
+  tracesByTx: Map<number, AnyTrace[]>
+  stateDiffsByTx: Map<number, AnyStateDiff[]>
+  traceParent: Map<AnyTrace, AnyTrace>
+  traceChildren: Map<AnyTrace, AnyTrace[]>
+}
+
+function traceAddressOf(trace: AnyTrace): number[] {
+  return (trace as any).traceAddress ?? []
+}
+
+function traceCompare(a: AnyTrace, b: AnyTrace): number {
+  return a.transactionIndex - b.transactionIndex || addressCompare(traceAddressOf(a), traceAddressOf(b))
+}
+
+function addressCompare(a: number[], b: number[]): number {
+  for (let i = 0; i < Math.min(a.length, b.length); i++) {
+    const order = a[i] - b[i]
+    if (order) return order
+  }
+
+  return a.length - b.length
+}
+
+function isDescendent(parent: AnyTrace, child: AnyTrace): boolean {
+  const pa = traceAddressOf(parent)
+  const ca = traceAddressOf(child)
+  if (parent.transactionIndex !== child.transactionIndex) return false
+  if (pa.length >= ca.length) return false
+  for (let i = 0; i < pa.length; i++) {
+    if (pa[i] !== ca[i]) return false
+  }
+
+  return true
+}
+
+export function setUpRelations(block: AnyBlock): Relations {
+  const traces = [...block.traces].sort(traceCompare)
+
+  const relations: Relations = {
+    txByIndex: new Map(block.transactions.map((tx) => [tx.transactionIndex, tx])),
+    logsByTx: groupBy(block.logs, (log) => log.transactionIndex),
+    tracesByTx: groupBy(traces, (trace) => trace.transactionIndex),
+    stateDiffsByTx: groupBy(block.stateDiffs, (diff) => diff.transactionIndex),
+    traceParent: new Map(),
+    traceChildren: new Map(),
+  }
+
+  for (let i = 0; i < traces.length; i++) {
+    const rec = traces[i]
+    const children: AnyTrace[] = []
+    for (let j = i + 1; j < traces.length; j++) {
+      const next = traces[j]
+      if (isDescendent(rec, next)) {
+        children.push(next)
+        if (traceAddressOf(next).length === traceAddressOf(rec).length + 1) {
+          relations.traceParent.set(next, rec)
+        }
+      } else {
+        break
+      }
+    }
+    relations.traceChildren.set(rec, children)
+  }
+
+  return relations
+}
+
+function buildLogFilter(req: LogRequest[] = []) {
+  const items = new EntityFilter<
+    AnyLog,
+    { transaction?: boolean; transactionLogs?: boolean; transactionStateDiffs?: boolean; transactionTraces?: boolean }
+  >()
+  for (const { address, topic0, topic1, topic2, topic3, ...relations } of req) {
+    const filter = new FilterBuilder<AnyLog>()
+    filter.propIn('address' as any, address)
+    filter.getIn((log) => assertNotNull((log as any).topics)[0], topic0)
+    filter.getIn((log) => assertNotNull((log as any).topics)[1], topic1)
+    filter.getIn((log) => assertNotNull((log as any).topics)[2], topic2)
+    filter.getIn((log) => assertNotNull((log as any).topics)[3], topic3)
+    items.add(filter, relations)
+  }
+
+  return items
+}
+
+function buildTransactionFilter(req: TransactionRequest[] = []) {
+  const items = new EntityFilter<AnyTransaction, { logs?: boolean; traces?: boolean; stateDiffs?: boolean }>()
+  for (const { to, from, sighash, type, ...relations } of req) {
+    const filter = new FilterBuilder<AnyTransaction>()
+    filter.propIn('to' as any, to)
+    filter.propIn('from' as any, from)
+    filter.propIn('sighash' as any, sighash)
+    filter.propIn('type' as any, type)
+    items.add(filter, relations)
+  }
+
+  return items
+}
+
+function buildTraceFilter(req: TraceRequest[] = []) {
+  const items = new EntityFilter<
+    AnyTrace,
+    { transaction?: boolean; transactionLogs?: boolean; subtraces?: boolean; parents?: boolean }
+  >()
+  for (const {
+    type,
+    createFrom,
+    callTo,
+    callFrom,
+    callSighash,
+    suicideRefundAddress,
+    rewardAuthor,
+    ...relations
+  } of req) {
+    const filter = new FilterBuilder<AnyTrace>()
+    filter.propIn('type' as any, type)
+    filter.getIn((t) => (t.type === 'create' ? assertNotNull((t as any).action?.from) : undefined), createFrom)
+    filter.getIn((t) => (t.type === 'call' ? assertNotNull((t as any).action?.to) : undefined), callTo)
+    filter.getIn((t) => (t.type === 'call' ? assertNotNull((t as any).action?.from) : undefined), callFrom)
+    filter.getIn((t) => (t.type === 'call' ? assertNotNull((t as any).action?.sighash) : undefined), callSighash)
+    filter.getIn(
+      (t) => (t.type === 'suicide' ? assertNotNull((t as any).action?.refundAddress) : undefined),
+      suicideRefundAddress,
+    )
+    filter.getIn((t) => (t.type === 'reward' ? assertNotNull((t as any).action?.author) : undefined), rewardAuthor)
+    items.add(filter, relations)
+  }
+
+  return items
+}
+
+function buildStateDiffFilter(req: StateDiffRequest[] = []) {
+  const items = new EntityFilter<AnyStateDiff, { transaction?: boolean }>()
+  for (const { address, key, kind, ...relations } of req) {
+    const filter = new FilterBuilder<AnyStateDiff>()
+    filter.propIn('address' as any, address)
+    filter.propIn('key' as any, key)
+    filter.propIn('kind' as any, kind)
+    items.add(filter, relations)
+  }
+
+  return items
+}
+
+class IncludeSet {
+  logs = new Set<AnyLog>()
+  transactions = new Set<AnyTransaction>()
+  traces = new Set<AnyTrace>()
+  stateDiffs = new Set<AnyStateDiff>()
+
+  addLog(log?: AnyLog) {
+    if (log) this.logs.add(log)
+  }
+  addTransaction(tx?: AnyTransaction) {
+    if (tx) this.transactions.add(tx)
+  }
+  addTrace(trace?: AnyTrace) {
+    if (trace) this.traces.add(trace)
+  }
+  addTraceStack(relations: Relations, trace?: AnyTrace) {
+    while (trace) {
+      this.traces.add(trace)
+      trace = relations.traceParent.get(trace)
+    }
+  }
+  addStateDiff(diff?: AnyStateDiff) {
+    if (diff) this.stateDiffs.add(diff)
+  }
+}
+
+export function filterBlock(block: AnyBlock, req: DataRequest, relations: Relations): void {
+  const logFilter = buildLogFilter(req.logs)
+  const transactionFilter = buildTransactionFilter(req.transactions)
+  const traceFilter = buildTraceFilter(req.traces)
+  const stateDiffFilter = buildStateDiffFilter(req.stateDiffs)
+
+  const include = new IncludeSet()
+
+  if (logFilter.present()) {
+    for (const log of block.logs) {
+      const rel = logFilter.match(log)
+      if (rel == null) continue
+      include.addLog(log)
+      if (rel.transaction) include.addTransaction(relations.txByIndex.get(log.transactionIndex))
+      if (rel.transactionLogs) {
+        for (const sibling of relations.logsByTx.get(log.transactionIndex) ?? []) include.addLog(sibling)
+      }
+      if (rel.transactionTraces) {
+        for (const trace of relations.tracesByTx.get(log.transactionIndex) ?? []) include.addTrace(trace)
+      }
+      if (rel.transactionStateDiffs) {
+        for (const diff of relations.stateDiffsByTx.get(log.transactionIndex) ?? []) include.addStateDiff(diff)
+      }
+    }
+  }
+
+  if (transactionFilter.present()) {
+    for (const tx of block.transactions) {
+      const rel = transactionFilter.match(tx)
+      if (rel == null) continue
+      include.addTransaction(tx)
+      if (rel.logs) {
+        for (const log of relations.logsByTx.get(tx.transactionIndex) ?? []) include.addLog(log)
+      }
+      if (rel.traces) {
+        for (const trace of relations.tracesByTx.get(tx.transactionIndex) ?? []) include.addTrace(trace)
+      }
+      if (rel.stateDiffs) {
+        for (const diff of relations.stateDiffsByTx.get(tx.transactionIndex) ?? []) include.addStateDiff(diff)
+      }
+    }
+  }
+
+  if (traceFilter.present()) {
+    for (const trace of block.traces) {
+      const rel = traceFilter.match(trace)
+      if (rel == null) continue
+      include.addTrace(trace)
+      if (rel.parents) include.addTraceStack(relations, relations.traceParent.get(trace))
+      if (rel.subtraces) {
+        for (const sub of relations.traceChildren.get(trace) ?? []) include.addTrace(sub)
+      }
+      if (rel.transaction) include.addTransaction(relations.txByIndex.get(trace.transactionIndex))
+      if (rel.transactionLogs) {
+        for (const log of relations.logsByTx.get(trace.transactionIndex) ?? []) include.addLog(log)
+      }
+    }
+  }
+
+  if (stateDiffFilter.present()) {
+    for (const diff of block.stateDiffs) {
+      const rel = stateDiffFilter.match(diff)
+      if (rel == null) continue
+      include.addStateDiff(diff)
+      if (rel.transaction) include.addTransaction(relations.txByIndex.get(diff.transactionIndex))
+    }
+  }
+
+  block.logs = block.logs.filter((log) => include.logs.has(log))
+  block.transactions = block.transactions.filter((tx) => include.transactions.has(tx))
+  block.traces = block.traces.filter((trace) => include.traces.has(trace))
+  block.stateDiffs = block.stateDiffs.filter((diff) => include.stateDiffs.has(diff))
+}

--- a/packages/subsquid-pipes/src/evm/rpc/filter.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/filter.ts
@@ -54,7 +54,7 @@ function addressCompare(a: number[], b: number[]): number {
   return a.length - b.length
 }
 
-function isDescendent(parent: AnyTrace, child: AnyTrace): boolean {
+function isDescendant(parent: AnyTrace, child: AnyTrace): boolean {
   const pa = traceAddressOf(parent)
   const ca = traceAddressOf(child)
   if (parent.transactionIndex !== child.transactionIndex) return false
@@ -83,7 +83,7 @@ export function setUpRelations(block: AnyBlock): Relations {
     const children: AnyTrace[] = []
     for (let j = i + 1; j < traces.length; j++) {
       const next = traces[j]
-      if (isDescendent(rec, next)) {
+      if (isDescendant(rec, next)) {
         children.push(next)
         if (traceAddressOf(next).length === traceAddressOf(rec).length + 1) {
           relations.traceParent.set(next, rec)

--- a/packages/subsquid-pipes/src/evm/rpc/project.test.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/project.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { FieldSelection } from '~/portal-client/query/evm.js'
 
-import { augmentFields, selectionGrew } from './project.js'
+import { augmentFields, dropEmptyBlocks, selectionGrew } from './project.js'
 
 /**
  * `augmentFields` adds the fields a request's where-clauses must read to be *evaluated* client-side
@@ -55,5 +55,44 @@ describe('selectionGrew', () => {
     const fields: FieldSelection = { log: { topics: true } }
     const augmented = augmentFields(fields, { logs: [{ address: ['0xaaa'] }] })
     expect(selectionGrew(augmented, fields)).toBe(true)
+  })
+})
+
+describe('dropEmptyBlocks', () => {
+  const blk = (
+    number: number,
+    parts: { logs?: unknown[]; transactions?: unknown[]; traces?: unknown[]; stateDiffs?: unknown[] } = {},
+  ) => ({
+    header: { number },
+    logs: parts.logs ?? [],
+    transactions: parts.transactions ?? [],
+    traces: parts.traces ?? [],
+    stateDiffs: parts.stateDiffs ?? [],
+  })
+
+  it('drops empty interior blocks but keeps the boundaries', () => {
+    const blocks = [blk(1), blk(2, { logs: [{}] }), blk(3), blk(4)]
+    // 1 kept (first), 2 kept (has a log), 3 dropped (empty interior), 4 kept (last)
+    expect(dropEmptyBlocks(blocks).map((b) => b.header.number)).toEqual([1, 2, 4])
+  })
+
+  it('keeps every block when includeAllBlocks is set', () => {
+    const blocks = [blk(1), blk(2), blk(3)]
+    expect(dropEmptyBlocks(blocks, true).map((b) => b.header.number)).toEqual([1, 2, 3])
+  })
+
+  it('keeps an interior block that has any data (tx / trace / stateDiff)', () => {
+    const blocks = [
+      blk(1),
+      blk(2, { transactions: [{}] }),
+      blk(3, { traces: [{}] }),
+      blk(4, { stateDiffs: [{}] }),
+      blk(5),
+    ]
+    expect(dropEmptyBlocks(blocks).map((b) => b.header.number)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('keeps a lone empty block (it is both first and last — the progress cursor)', () => {
+    expect(dropEmptyBlocks([blk(7)]).map((b) => b.header.number)).toEqual([7])
   })
 })

--- a/packages/subsquid-pipes/src/evm/rpc/project.test.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/project.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { FieldSelection } from '~/portal-client/query/evm.js'
+
+import { augmentFields, selectionGrew } from './project.js'
+
+/**
+ * `augmentFields` adds the fields a request's where-clauses must read to be *evaluated* client-side
+ * (the RPC source filters full blocks locally), even when those fields aren't selected for output;
+ * `selectionGrew` reports whether that augmentation added anything (so the caller can project back
+ * down to the user's original selection). Mirrors the Squid evm-rpc-stream augment tests.
+ */
+
+describe('augmentFields', () => {
+  it('adds a where-only field (log address) not in the original selection', () => {
+    const fields: FieldSelection = { log: { topics: true } }
+    const augmented = augmentFields(fields, { logs: [{ address: ['0xaaa'] }] })
+    expect((augmented.log as any).address).toBe(true)
+    expect((augmented.log as any).topics).toBe(true) // original selection preserved
+  })
+
+  it('adds log.topics when a topic filter is present', () => {
+    const augmented = augmentFields({}, { logs: [{ topic0: ['0xt0'] }] })
+    expect((augmented.log as any).topics).toBe(true)
+  })
+
+  it('adds transaction where fields (to / from / sighash / type)', () => {
+    const augmented = augmentFields(
+      {},
+      { transactions: [{ to: ['0xa'], from: ['0xb'], sighash: ['0xc'], type: [2] }] },
+    )
+    expect(augmented.transaction).toMatchObject({ to: true, from: true, sighash: true, type: true })
+  })
+
+  it('maps trace where-keys to trace selection keys', () => {
+    const augmented = augmentFields({}, { traces: [{ callTo: ['0xa'], rewardAuthor: ['0xb'] }] })
+    expect(augmented.trace).toMatchObject({ callTo: true, rewardAuthor: true })
+  })
+
+  it('does not add a field that is already selected', () => {
+    const fields: FieldSelection = { log: { address: true } }
+    const augmented = augmentFields(fields, { logs: [{ address: ['0xaaa'] }] })
+    expect(selectionGrew(augmented, fields)).toBe(false)
+  })
+
+  it('does not grow when no where-clause references an unselected field', () => {
+    const fields: FieldSelection = { log: { data: true } }
+    const augmented = augmentFields(fields, { logs: [{}] }) // empty where — nothing to add
+    expect(selectionGrew(augmented, fields)).toBe(false)
+  })
+})
+
+describe('selectionGrew', () => {
+  it('is true when augmentation added a field', () => {
+    const fields: FieldSelection = { log: { topics: true } }
+    const augmented = augmentFields(fields, { logs: [{ address: ['0xaaa'] }] })
+    expect(selectionGrew(augmented, fields)).toBe(true)
+  })
+})

--- a/packages/subsquid-pipes/src/evm/rpc/project.test.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/project.test.ts
@@ -25,10 +25,7 @@ describe('augmentFields', () => {
   })
 
   it('adds transaction where fields (to / from / sighash / type)', () => {
-    const augmented = augmentFields(
-      {},
-      { transactions: [{ to: ['0xa'], from: ['0xb'], sighash: ['0xc'], type: [2] }] },
-    )
+    const augmented = augmentFields({}, { transactions: [{ to: ['0xa'], from: ['0xb'], sighash: ['0xc'], type: [2] }] })
     expect(augmented.transaction).toMatchObject({ to: true, from: true, sighash: true, type: true })
   })
 

--- a/packages/subsquid-pipes/src/evm/rpc/project.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/project.ts
@@ -60,3 +60,27 @@ export function keptByPosition<P, Q>(projected: P[], pre: Q[], kept: Q[]): P[] {
 
   return projected.filter((_, i) => survived.has(pre[i]))
 }
+
+interface FilterableBlock {
+  header: { number: number }
+  logs: unknown[]
+  transactions: unknown[]
+  traces: unknown[]
+  stateDiffs: unknown[]
+}
+
+/**
+ * Match the Portal's empty-block handling for the RPC source (which fetches full blocks, so every
+ * block in a range arrives even when filtering leaves it empty): drop a block left empty by
+ * filtering, EXCEPT the batch's boundary blocks (first + last) and — when `includeAllBlocks` is set
+ * — every block. Keeping the last block matters beyond parity: it is the batch's progress cursor, so
+ * dropping it would stall resume. Mirrors the Squid evm-rpc-stream `dropEmptyBlocks`.
+ */
+export function dropEmptyBlocks<B extends FilterableBlock>(blocks: B[], includeAllBlocks = false): B[] {
+  if (includeAllBlocks) return blocks
+
+  return blocks.filter((b, i) => {
+    if (i === 0 || i === blocks.length - 1) return true // boundary blocks: always present
+    return b.logs.length > 0 || b.transactions.length > 0 || b.traces.length > 0 || b.stateDiffs.length > 0
+  })
+}

--- a/packages/subsquid-pipes/src/evm/rpc/project.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/project.ts
@@ -1,4 +1,4 @@
-import { Block, DataRequest, FieldSelection } from '~/portal-client/query/evm.js'
+import { DataRequest, FieldSelection } from '~/portal-client/query/evm.js'
 
 /**
  * Augment a field selection with the fields a request's where-clauses need to *evaluate* — even
@@ -48,20 +48,15 @@ export function selectionGrew(augmented: FieldSelection, original: FieldSelectio
   return false
 }
 
-const traceKey = (t: any) => `${t.transactionIndex}:${(t.traceAddress ?? []).join(',')}`
-const stateDiffKey = (d: any) => `${d.transactionIndex}:${d.address}:${d.key}`
+/**
+ * Keep the items of `projected` whose positionally-aligned item in `pre` (the pre-filter decode of
+ * the same block) survived filtering into `kept`. `projected[i]` and `pre[i]` are the same on-chain
+ * item decoded at two field selections, so a surviving `pre[i]` means keep `projected[i]`. Position
+ * + identity — not a synthesized structural key — so items that would share such a key (block-reward
+ * traces carry no `transactionIndex`) can't collide. Mirrors the Squid evm-rpc-stream projection.
+ */
+export function keptByPosition<P, Q>(projected: P[], pre: Q[], kept: Q[]): P[] {
+  const survived = new Set(kept)
 
-/** Keep only the items of `projected` whose structural index appears in the `filtered` block. */
-export function projectKept(projected: Block<any>, filtered: Block<any>): Block<any> {
-  const logs = new Set(filtered.logs.map((l: any) => l.logIndex))
-  const transactions = new Set(filtered.transactions.map((t: any) => t.transactionIndex))
-  const traces = new Set(filtered.traces.map(traceKey))
-  const stateDiffs = new Set(filtered.stateDiffs.map(stateDiffKey))
-
-  projected.logs = projected.logs.filter((l: any) => logs.has(l.logIndex))
-  projected.transactions = projected.transactions.filter((t: any) => transactions.has(t.transactionIndex))
-  projected.traces = projected.traces.filter((t: any) => traces.has(traceKey(t)))
-  projected.stateDiffs = projected.stateDiffs.filter((d: any) => stateDiffs.has(stateDiffKey(d)))
-
-  return projected
+  return projected.filter((_, i) => survived.has(pre[i]))
 }

--- a/packages/subsquid-pipes/src/evm/rpc/project.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/project.ts
@@ -51,9 +51,9 @@ export function selectionGrew(augmented: FieldSelection, original: FieldSelectio
 /**
  * Keep the items of `projected` whose positionally-aligned item in `pre` (the pre-filter decode of
  * the same block) survived filtering into `kept`. `projected[i]` and `pre[i]` are the same on-chain
- * item decoded at two field selections, so a surviving `pre[i]` means keep `projected[i]`. Position
- * + identity — not a synthesized structural key — so items that would share such a key (block-reward
- * traces carry no `transactionIndex`) can't collide. Mirrors the Squid evm-rpc-stream projection.
+ * item decoded at two field selections, so a surviving `pre[i]` means keep `projected[i]`. Alignment
+ * is by position + object identity — never a synthesized structural key — so structurally identical
+ * items can't be confused by a shared/ambiguous key. Mirrors the Squid evm-rpc-stream projection.
  */
 export function keptByPosition<P, Q>(projected: P[], pre: Q[], kept: Q[]): P[] {
   const survived = new Set(kept)

--- a/packages/subsquid-pipes/src/evm/rpc/project.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/project.ts
@@ -1,0 +1,67 @@
+import { Block, DataRequest, FieldSelection } from '~/portal-client/query/evm.js'
+
+/**
+ * Augment a field selection with the fields a request's where-clauses need to *evaluate* — even
+ * when not selected for output — so the filter engine can match on them (otherwise it sees
+ * `undefined` and throws). Trace where-keys map 1:1 to trace field-selection keys; stateDiff
+ * address/key/kind are always-present required fields. Mirrors the Squid evm-rpc-stream augment.
+ */
+export function augmentFields(fields: FieldSelection, req: DataRequest): FieldSelection {
+  const log: any = { ...fields.log }
+  const transaction: any = { ...fields.transaction }
+  const trace: any = { ...fields.trace }
+
+  for (const it of req.logs ?? []) {
+    if (it.address) log.address = true
+    if (it.topic0 || it.topic1 || it.topic2 || it.topic3) log.topics = true
+  }
+  for (const it of req.transactions ?? []) {
+    if (it.to) transaction.to = true
+    if (it.from) transaction.from = true
+    if (it.sighash) transaction.sighash = true
+    if (it.type) transaction.type = true
+  }
+  for (const it of req.traces ?? []) {
+    if (it.createFrom) trace.createFrom = true
+    if (it.callTo) trace.callTo = true
+    if (it.callFrom) trace.callFrom = true
+    if (it.callSighash) trace.callSighash = true
+    if (it.suicideRefundAddress) trace.suicideRefundAddress = true
+    if (it.rewardAuthor) trace.rewardAuthor = true
+  }
+
+  return { ...fields, log, transaction, trace }
+}
+
+const SELECTION_TYPES = ['block', 'transaction', 'log', 'trace', 'stateDiff'] as const
+
+/** True if `augmented` selects any field that `original` does not (augmentation only adds). */
+export function selectionGrew(augmented: FieldSelection, original: FieldSelection): boolean {
+  for (const t of SELECTION_TYPES) {
+    const aug = (augmented as any)[t] ?? {}
+    const orig = (original as any)[t] ?? {}
+    for (const k in aug) {
+      if (aug[k] && !orig[k]) return true
+    }
+  }
+
+  return false
+}
+
+const traceKey = (t: any) => `${t.transactionIndex}:${(t.traceAddress ?? []).join(',')}`
+const stateDiffKey = (d: any) => `${d.transactionIndex}:${d.address}:${d.key}`
+
+/** Keep only the items of `projected` whose structural index appears in the `filtered` block. */
+export function projectKept(projected: Block<any>, filtered: Block<any>): Block<any> {
+  const logs = new Set(filtered.logs.map((l: any) => l.logIndex))
+  const transactions = new Set(filtered.transactions.map((t: any) => t.transactionIndex))
+  const traces = new Set(filtered.traces.map(traceKey))
+  const stateDiffs = new Set(filtered.stateDiffs.map(stateDiffKey))
+
+  projected.logs = projected.logs.filter((l: any) => logs.has(l.logIndex))
+  projected.transactions = projected.transactions.filter((t: any) => transactions.has(t.transactionIndex))
+  projected.traces = projected.traces.filter((t: any) => traces.has(traceKey(t)))
+  projected.stateDiffs = projected.stateDiffs.filter((d: any) => stateDiffs.has(stateDiffKey(d)))
+
+  return projected
+}

--- a/packages/subsquid-pipes/src/evm/rpc/request.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/request.ts
@@ -1,0 +1,121 @@
+import { DataRequest, FieldSelection } from '~/portal-client/query/evm.js'
+
+/**
+ * The coarse data types an RPC source must fetch to satisfy a request — drives both the evm-rpc
+ * fetch toggles and the capability a health probe must verify. Ported from
+ * `@subsquid/evm-processor` `ds-rpc/request.ts`; Pipes' `DataRequest` is already flat, so it is
+ * consumed directly.
+ */
+export interface RequiredData {
+  transactions: boolean
+  logs: boolean
+  receipts: boolean
+  traces: boolean
+  stateDiffs: boolean
+}
+
+export function toRequiredData(req: DataRequest, fields: FieldSelection): RequiredData {
+  const txs = transactionsRequested(req)
+  const logs = logsRequested(req)
+  const receipts = txs && isRequested(TX_RECEIPT_FIELDS, fields.transaction)
+
+  return {
+    transactions: !!req.transactions?.length || (txs && isRequested(TX_FIELDS, fields.transaction)),
+    logs: logs && !receipts,
+    receipts,
+    traces: tracesRequested(req),
+    stateDiffs: stateDiffsRequested(req),
+  }
+}
+
+function transactionsRequested(req: DataRequest): boolean {
+  if (req.transactions?.length) return true
+  for (const items of [req.logs, req.traces, req.stateDiffs]) {
+    if (items) {
+      for (const it of items) {
+        if (it.transaction) return true
+      }
+    }
+  }
+
+  return false
+}
+
+function logsRequested(req: DataRequest): boolean {
+  if (req.logs?.length) return true
+  if (req.transactions) {
+    for (const tx of req.transactions) if (tx.logs) return true
+  }
+  if (req.traces) {
+    for (const trace of req.traces) if (trace.transactionLogs) return true
+  }
+
+  return false
+}
+
+function tracesRequested(req: DataRequest): boolean {
+  if (req.traces?.length) return true
+  if (req.transactions) {
+    for (const tx of req.transactions) if (tx.traces) return true
+  }
+  if (req.logs) {
+    for (const log of req.logs) if (log.transactionTraces) return true
+  }
+
+  return false
+}
+
+function stateDiffsRequested(req: DataRequest): boolean {
+  if (req.stateDiffs?.length) return true
+  if (req.transactions) {
+    for (const tx of req.transactions) if (tx.stateDiffs) return true
+  }
+  if (req.logs) {
+    for (const log of req.logs) if (log.transactionStateDiffs) return true
+  }
+
+  return false
+}
+
+const TX_FIELDS: Record<string, true> = {
+  from: true,
+  to: true,
+  gas: true,
+  gasPrice: true,
+  maxFeePerGas: true,
+  maxPriorityFeePerGas: true,
+  input: true,
+  nonce: true,
+  value: true,
+  v: true,
+  r: true,
+  s: true,
+  yParity: true,
+  chainId: true,
+  authorizationList: true,
+}
+
+const TX_RECEIPT_FIELDS: Record<string, true> = {
+  gasUsed: true,
+  cumulativeGasUsed: true,
+  effectiveGasPrice: true,
+  contractAddress: true,
+  type: true,
+  status: true,
+  l1Fee: true,
+  l1FeeScalar: true,
+  l1GasPrice: true,
+  l1GasUsed: true,
+  l1BaseFeeScalar: true,
+  l1BlobBaseFee: true,
+  l1BlobBaseFeeScalar: true,
+}
+
+function isRequested(set: Record<string, boolean>, selection?: Record<string, boolean>): boolean {
+  if (selection == null) return false
+  for (const key in selection) {
+    if (set[key] && selection[key]) return true
+  }
+
+  return false
+}

--- a/packages/subsquid-pipes/src/evm/rpc/request.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/request.ts
@@ -7,7 +7,6 @@ import { DataRequest, FieldSelection } from '~/portal-client/query/evm.js'
  * consumed directly.
  */
 export interface RequiredData {
-  transactions: boolean
   logs: boolean
   receipts: boolean
   traces: boolean
@@ -19,8 +18,11 @@ export function toRequiredData(req: DataRequest, fields: FieldSelection): Requir
   const logs = logsRequested(req)
   const receipts = txs && isRequested(TX_RECEIPT_FIELDS, fields.transaction)
 
+  // No `transactions` toggle: the RPC source always fetches full transactions (mapRpcBlock needs
+  // them to normalize a block — see `EvmRpcSource`), so deriving whether they're required would be
+  // dead — the fetch can't be turned off. `txs` is still needed to decide whether requested
+  // *receipt* fields upgrade the fetch to receipts.
   return {
-    transactions: !!req.transactions?.length || (txs && isRequested(TX_FIELDS, fields.transaction)),
     logs: logs && !receipts,
     receipts,
     traces: tracesRequested(req),
@@ -75,24 +77,6 @@ function stateDiffsRequested(req: DataRequest): boolean {
   }
 
   return false
-}
-
-const TX_FIELDS: Record<string, true> = {
-  from: true,
-  to: true,
-  gas: true,
-  gasPrice: true,
-  maxFeePerGas: true,
-  maxPriorityFeePerGas: true,
-  input: true,
-  nonce: true,
-  value: true,
-  v: true,
-  r: true,
-  s: true,
-  yParity: true,
-  chainId: true,
-  authorizationList: true,
 }
 
 const TX_RECEIPT_FIELDS: Record<string, true> = {

--- a/packages/subsquid-pipes/src/evm/rpc/shim.test.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/shim.test.ts
@@ -37,4 +37,12 @@ describe('shimWireBlock', () => {
     expect(() => shimWireBlock({ header: {} })).not.toThrow()
     expect(() => shimWireBlock({})).not.toThrow()
   })
+
+  it('does not throw on malformed wire JSON (non-object action) — leaves it for schema validation', () => {
+    // A reward trace whose `action` is a truthy non-object must not make the `in` check throw before
+    // the downstream `cast()` can report a proper validation error.
+    const block = { traces: [{ type: 'reward', action: 'not-an-object' }] }
+    expect(() => shimWireBlock(block)).not.toThrow()
+    expect(block.traces[0].action).toBe('not-an-object') // left untouched for the schema to reject
+  })
 })

--- a/packages/subsquid-pipes/src/evm/rpc/shim.test.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/shim.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import { shimWireBlock } from './shim.js'
+
+/**
+ * `shimWireBlock` reconciles the two enumerable trace-level differences between the normalized model
+ * (`@subsquid/evm-normalization` `toJSON`) and the Portal wire schema. Mirrors the Squid
+ * evm-rpc-stream shim tests.
+ */
+
+describe('shimWireBlock', () => {
+  it('rewrites the selfdestruct trace tag to suicide', () => {
+    const block = { traces: [{ type: 'selfdestruct', action: { refundAddress: '0xa' } }] }
+    shimWireBlock(block)
+    expect(block.traces[0].type).toBe('suicide')
+  })
+
+  it('renames a reward action rewardType to type', () => {
+    const block = { traces: [{ type: 'reward', action: { author: '0xa', rewardType: 'block' } }] }
+    shimWireBlock(block)
+    expect(block.traces[0].action).toEqual({ author: '0xa', type: 'block' })
+    expect('rewardType' in block.traces[0].action).toBe(false)
+  })
+
+  it('leaves create / call traces and trace-less blocks untouched', () => {
+    const block = {
+      traces: [
+        { type: 'call', action: { to: '0xa', from: '0xb' } },
+        { type: 'create', action: { from: '0xc' } },
+      ],
+    }
+    shimWireBlock(block)
+    expect(block.traces[0]).toEqual({ type: 'call', action: { to: '0xa', from: '0xb' } })
+    expect(block.traces[1]).toEqual({ type: 'create', action: { from: '0xc' } })
+
+    // no traces at all — must not throw
+    expect(() => shimWireBlock({ header: {} })).not.toThrow()
+    expect(() => shimWireBlock({})).not.toThrow()
+  })
+})

--- a/packages/subsquid-pipes/src/evm/rpc/shim.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/shim.ts
@@ -13,7 +13,12 @@ export function shimWireBlock(block: any): any {
     for (const trace of traces) {
       if (trace.type === 'selfdestruct') {
         trace.type = 'suicide'
-      } else if (trace.type === 'reward' && trace.action && 'rewardType' in trace.action) {
+      } else if (
+        trace.type === 'reward' &&
+        typeof trace.action === 'object' &&
+        trace.action !== null &&
+        'rewardType' in trace.action
+      ) {
         trace.action.type = trace.action.rewardType
         delete trace.action.rewardType
       }

--- a/packages/subsquid-pipes/src/evm/rpc/shim.ts
+++ b/packages/subsquid-pipes/src/evm/rpc/shim.ts
@@ -1,0 +1,24 @@
+/**
+ * Reshape `toJSON(normalized)` wire JSON so Pipes' `getBlockSchema` tagged-union accepts it. The
+ * normalized model (`@subsquid/evm-normalization`) and the Portal wire schema are the same SQD EVM
+ * schema except for two enumerable trace-level differences (the same shim the Squid RPC source
+ * applies):
+ *  - the suicide trace tag: normalized `'selfdestruct'` → schema `'suicide'`;
+ *  - the reward action field: normalized `action.rewardType` → schema `action.type`.
+ * Mutates in place (runs on fresh `toJSON` output).
+ */
+export function shimWireBlock(block: any): any {
+  const traces = block?.traces
+  if (Array.isArray(traces)) {
+    for (const trace of traces) {
+      if (trace.type === 'selfdestruct') {
+        trace.type = 'suicide'
+      } else if (trace.type === 'reward' && trace.action && 'rewardType' in trace.action) {
+        trace.action.type = trace.action.rewardType
+        delete trace.action.rewardType
+      }
+    }
+  }
+
+  return block
+}

--- a/packages/subsquid-pipes/src/testing/test-metrics-server.ts
+++ b/packages/subsquid-pipes/src/testing/test-metrics-server.ts
@@ -40,6 +40,10 @@ export class MockGauge<T extends string = string> implements Gauge<T> {
     }
   }
 
+  reset(): void {
+    this.calls = []
+  }
+
   get lastValue(): number | undefined {
     return this.calls[this.calls.length - 1]?.value
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,10 +335,16 @@ importers:
         version: 0.3.0
       '@subsquid/evm-normalization':
         specifier: ^0.0.2
-        version: 0.0.2(@subsquid/http-client@1.8.0)(@subsquid/logger@1.6.0)(@subsquid/rpc-client@4.14.0)
+        version: 0.0.2(@subsquid/http-client@1.8.1)(@subsquid/logger@1.6.0)(@subsquid/rpc-client@4.15.1)
       '@subsquid/evm-rpc':
         specifier: ^0.0.2
-        version: 0.0.2(@subsquid/http-client@1.8.0)(@subsquid/rpc-client@4.14.0)
+        version: 0.0.2(@subsquid/http-client@1.8.1)(@subsquid/rpc-client@4.15.1)
+      '@subsquid/http-client':
+        specifier: ^1.8.1
+        version: 1.8.1
+      '@subsquid/rpc-client':
+        specifier: ^4.15.1
+        version: 4.15.1
       '@types/better-sqlite3':
         specifier: 7.6.13
         version: 7.6.13
@@ -2450,6 +2456,9 @@ packages:
   '@subsquid/http-client@1.8.0':
     resolution: {integrity: sha512-HEwKjxBWoFdOT+BeC8j0aKCsNsNq8M4YO8peGlqAAYFw2Uhaztd5bWtygOhOYNrku9E8xm1mnH9p4ciKdyIK/Q==}
 
+  '@subsquid/http-client@1.8.1':
+    resolution: {integrity: sha512-JDOqZ2DxhOfmZaoeo0+l3MOseTbbhVAz+3VkNBAhfOdenHTKHTYrywjC1AbqtzFZCswW7ErSFsEsIk+y5GsbGQ==}
+
   '@subsquid/logger@1.4.0':
     resolution: {integrity: sha512-Yep4hzpLfmm4pJMXuTnd3n7Hlo18Dce8vwKZduGE9n/p56cHq4BTbAuaXLK50vYKWx7Lyt2obVbJ4otVMWkyYg==}
 
@@ -2461,6 +2470,9 @@ packages:
 
   '@subsquid/rpc-client@4.14.0':
     resolution: {integrity: sha512-YquFxFWc517A3G2peQYvSyK3ksmGYvlErOCMyREEGQTb9GwUl4DBaTi/+NO9ioy6Hk9Acg5hTeZzKxGnzqhBdQ==}
+
+  '@subsquid/rpc-client@4.15.1':
+    resolution: {integrity: sha512-hJpHwSkdMZjOk2POi5uz7PNV9ia7k+LsHGlwqXST89zjE/CvNslKFRL3mqBsIce8SWKdru0hta5YEScNjEjEYQ==}
 
   '@subsquid/solana-normalization@0.1.3':
     resolution: {integrity: sha512-6DuK0AsjoSdY3fKrbLwyCzbseDX91E/BYTPDGeoHJV1K8HIs9DWiuG0E1nsFXowiuQK7gSp0T3/QJep8IFfiAw==}
@@ -7754,9 +7766,9 @@ snapshots:
     dependencies:
       '@subsquid/util-internal-hex': 1.2.2
 
-  '@subsquid/evm-normalization@0.0.2(@subsquid/http-client@1.8.0)(@subsquid/logger@1.6.0)(@subsquid/rpc-client@4.14.0)':
+  '@subsquid/evm-normalization@0.0.2(@subsquid/http-client@1.8.1)(@subsquid/logger@1.6.0)(@subsquid/rpc-client@4.15.1)':
     dependencies:
-      '@subsquid/evm-rpc': 0.0.2(@subsquid/http-client@1.8.0)(@subsquid/rpc-client@4.14.0)
+      '@subsquid/evm-rpc': 0.0.2(@subsquid/http-client@1.8.1)(@subsquid/rpc-client@4.15.1)
       '@subsquid/util-internal': 3.3.1
       '@subsquid/util-internal-validation': 0.9.0(@subsquid/logger@1.6.0)
     transitivePeerDependencies:
@@ -7765,14 +7777,14 @@ snapshots:
       - '@subsquid/rpc-client'
       - supports-color
 
-  '@subsquid/evm-rpc@0.0.2(@subsquid/http-client@1.8.0)(@subsquid/rpc-client@4.14.0)':
+  '@subsquid/evm-rpc@0.0.2(@subsquid/http-client@1.8.1)(@subsquid/rpc-client@4.15.1)':
     dependencies:
       '@ethereumjs/mpt': 10.0.0
       '@ethereumjs/rlp': 10.0.0
       '@ethereumjs/util': 10.0.0
-      '@subsquid/http-client': 1.8.0
+      '@subsquid/http-client': 1.8.1
       '@subsquid/logger': 1.6.0
-      '@subsquid/rpc-client': 4.14.0
+      '@subsquid/rpc-client': 4.15.1
       '@subsquid/util-internal': 3.3.1
       '@subsquid/util-internal-data-source': 0.0.0
       '@subsquid/util-internal-hex': 1.2.3
@@ -7795,6 +7807,12 @@ snapshots:
       '@subsquid/util-internal': 3.2.0
       node-fetch: 3.3.2
 
+  '@subsquid/http-client@1.8.1':
+    dependencies:
+      '@subsquid/logger': 1.6.0
+      '@subsquid/util-internal': 3.3.1
+      node-fetch: 3.3.2
+
   '@subsquid/logger@1.4.0':
     dependencies:
       '@subsquid/util-internal-hex': 1.2.2
@@ -7809,7 +7827,7 @@ snapshots:
 
   '@subsquid/rpc-client@4.13.0':
     dependencies:
-      '@subsquid/http-client': 1.7.0
+      '@subsquid/http-client': 1.8.1
       '@subsquid/logger': 1.4.0
       '@subsquid/util-internal': 3.2.0
       '@subsquid/util-internal-binary-heap': 1.0.0
@@ -7824,6 +7842,18 @@ snapshots:
       '@subsquid/http-client': 1.8.0
       '@subsquid/logger': 1.4.0
       '@subsquid/util-internal': 3.2.0
+      '@subsquid/util-internal-binary-heap': 1.0.0
+      '@subsquid/util-internal-counters': 1.3.2
+      '@subsquid/util-internal-json-fix-unsafe-integers': 0.0.0
+      websocket: 1.0.35
+    transitivePeerDependencies:
+      - supports-color
+
+  '@subsquid/rpc-client@4.15.1':
+    dependencies:
+      '@subsquid/http-client': 1.8.1
+      '@subsquid/logger': 1.6.0
+      '@subsquid/util-internal': 3.3.1
       '@subsquid/util-internal-binary-heap': 1.0.0
       '@subsquid/util-internal-counters': 1.3.2
       '@subsquid/util-internal-json-fix-unsafe-integers': 0.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,12 @@ importers:
       '@subsquid/borsh':
         specifier: 0.3.0
         version: 0.3.0
+      '@subsquid/evm-normalization':
+        specifier: ^0.0.2
+        version: 0.0.2(@subsquid/http-client@1.8.0)(@subsquid/logger@1.6.0)(@subsquid/rpc-client@4.14.0)
+      '@subsquid/evm-rpc':
+        specifier: ^0.0.2
+        version: 0.0.2(@subsquid/http-client@1.8.0)(@subsquid/rpc-client@4.14.0)
       '@types/better-sqlite3':
         specifier: 7.6.13
         version: 7.6.13
@@ -1136,6 +1142,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ethereumjs/mpt@10.0.0':
+    resolution: {integrity: sha512-WpIWAyWhe/veG6bvBEQUdEGPyDTID0clFy4yMy+wRs5Tr7UHeDbsG4bAeXzLCEkhIgarSFok+9P5XO6r1q4tpw==}
+    engines: {node: '>=18'}
+
+  '@ethereumjs/rlp@10.0.0':
+    resolution: {integrity: sha512-h2SK6RxFBfN5ZGykbw8LTNNLckSXZeuUZ6xqnmtF22CzZbHflFMcIOyfVGdvyCVQqIoSbGMHtvyxMCWnOyB9RA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@ethereumjs/util@10.0.0':
+    resolution: {integrity: sha512-lO23alM4uQsv8dp6/yEm4Xw4328+wIRjSeuBO1mRTToUWRcByEMTk87yzBpXgpixpgHrl+9LTn9KB2vvKKtOQQ==}
+    engines: {node: '>=18'}
+
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
 
@@ -1579,6 +1598,10 @@ packages:
 
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.0':
+    resolution: {integrity: sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/curves@1.9.1':
@@ -2412,6 +2435,15 @@ packages:
   '@subsquid/evm-codec@0.3.0':
     resolution: {integrity: sha512-W6EIiC7MJN2oWdbgzpUSDop+UtROdFAlvsrzc10g3AnCAaK31nH59tkTjylRxgECewWFCFWZrwsVp+a+lwvXMA==}
 
+  '@subsquid/evm-normalization@0.0.2':
+    resolution: {integrity: sha512-Aays6fkgicKmX8FFHDtFcRMlGMkuMvAzEDW1Jm7/y/jcKTJO87tv1Bj2BL+uUEt5IlPE4wbsp5o34k+w/ThsQA==}
+
+  '@subsquid/evm-rpc@0.0.2':
+    resolution: {integrity: sha512-KS/of2cKLcVFc7P2egSVPPnKN7rEA48Ib5ABJFtHGCDDsOBOqa4ykXxlL7e/1LF67KC1WIKNHW24OtISRqdIBg==}
+    peerDependencies:
+      '@subsquid/http-client': ^1.8.1
+      '@subsquid/rpc-client': ^4.15.1
+
   '@subsquid/http-client@1.7.0':
     resolution: {integrity: sha512-dx5rGkBhip0zgjLQuY0x6ZaLIoartmb5RXziKPleVQCO5PpKors8C2utWWSDqDNaM8xxGQhRxfTzd83XL+F1FA==}
 
@@ -2473,6 +2505,9 @@ packages:
   '@subsquid/util-internal-counters@1.3.2':
     resolution: {integrity: sha512-GxpOIL36JXSo0KdOT7k6CsI4DY804rn/X7pTdfKhych0ReHaDghnwNyvgb7Njv9euEHWUt4MxXbfQ9YrbpPDng==}
 
+  '@subsquid/util-internal-data-source@0.0.0':
+    resolution: {integrity: sha512-3J4FtZy3fl2VQJqYR0ZQU9LsSbpboRsAT49Tf1NDAqYyWbtjDkflMvAkRxq4l1PJR6MQY73nwRDK+0Fv06SizQ==}
+
   '@subsquid/util-internal-hex@0.0.2':
     resolution: {integrity: sha512-EgqYmZjJ6ox885tXBObEAZQZImpRc5pFzQeOLEh78gGPTc39IH3VI4BG0zaomStvgBx+e25M7Y2cc+ae+ttuXQ==}
 
@@ -2521,8 +2556,19 @@ packages:
       '@subsquid/logger':
         optional: true
 
+  '@subsquid/util-internal-validation@0.9.0':
+    resolution: {integrity: sha512-S9j/o1gmKz4qTf0O8B9mpGV6Z+WhIe6xDLhKvpzJ7IaMqkDUHTu386Hx8IXyTJf/RY9ABunfGLI9q9uJln9wSA==}
+    peerDependencies:
+      '@subsquid/logger': ^1.6.0
+    peerDependenciesMeta:
+      '@subsquid/logger':
+        optional: true
+
   '@subsquid/util-internal@3.2.0':
     resolution: {integrity: sha512-foNCjOmZaP8MKMa9sNe2GXTjFSDM9UqA0I0C0/ZvCxM1lCmG3mxZb70f8Wyi7TePXC/eV8eARbIqFyz0GjQmzA==}
+
+  '@subsquid/util-internal@3.3.1':
+    resolution: {integrity: sha512-Q8C19KnbI9V3WhEcb5H/r6WHeHiTvBSUBvBZ6W7k7G2G6x5OojtT6CELMb1Yy34PH9DVe0ew7wtd9nM5ZLJ6qg==}
 
   '@subsquid/util-naming@1.3.0':
     resolution: {integrity: sha512-PfYg1uFHwb7e6egbkzIbQTWf7DVlZIQr2gHy4VE35ZNiA15R9wkJLo/Mym6OkwLQyjJwhhq7pCFhkz6tm19m+A==}
@@ -3011,6 +3057,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  bn.js@4.12.4:
+    resolution: {integrity: sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g==}
+
   bn.js@5.2.2:
     resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
 
@@ -3030,6 +3079,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  brorand@1.1.0:
+    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
 
   brotli-wasm@3.0.1:
     resolution: {integrity: sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==}
@@ -3532,6 +3584,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -3630,6 +3685,10 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  ethereum-cryptography@3.2.0:
+    resolution: {integrity: sha512-Urr5YVsalH+Jo0sYkTkv1MyI9bLYZwW8BENZCeE1QYaTHETEYx0Nv/SVsWkSqpYrzweg6d8KMY1wTjH/1m/BIg==}
+    engines: {node: ^14.21.3 || >=16, npm: '>=9'}
 
   event-emitter@0.3.5:
     resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
@@ -3900,6 +3959,9 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -3918,6 +3980,9 @@ packages:
 
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
+
+  hmac-drbg@1.0.1:
+    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
@@ -4250,6 +4315,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.0.2:
+    resolution: {integrity: sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==}
+    engines: {node: 20 || >=22}
+
   lru-cache@11.2.2:
     resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
     engines: {node: 20 || >=22}
@@ -4318,6 +4387,12 @@ packages:
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
+  minimalistic-crypto-utils@1.0.1:
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
@@ -4425,6 +4500,9 @@ packages:
 
   node-addon-api@2.0.2:
     resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
+
+  node-addon-api@5.1.0:
+    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -4934,6 +5012,10 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  secp256k1@5.0.1:
+    resolution: {integrity: sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==}
+    engines: {node: '>=18.0.0'}
 
   secure-json-parse@4.0.0:
     resolution: {integrity: sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==}
@@ -6415,6 +6497,23 @@ snapshots:
   '@esbuild/win32-x64@0.25.11':
     optional: true
 
+  '@ethereumjs/mpt@10.0.0':
+    dependencies:
+      '@ethereumjs/rlp': 10.0.0
+      '@ethereumjs/util': 10.0.0
+      debug: 4.4.3
+      ethereum-cryptography: 3.2.0
+      lru-cache: 11.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@ethereumjs/rlp@10.0.0': {}
+
+  '@ethereumjs/util@10.0.0':
+    dependencies:
+      '@ethereumjs/rlp': 10.0.0
+      ethereum-cryptography: 3.2.0
+
   '@floating-ui/core@1.7.4':
     dependencies:
       '@floating-ui/utils': 0.2.10
@@ -6810,6 +6909,10 @@ snapshots:
     optional: true
 
   '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@noble/curves@1.9.1':
     dependencies:
@@ -7651,6 +7754,35 @@ snapshots:
     dependencies:
       '@subsquid/util-internal-hex': 1.2.2
 
+  '@subsquid/evm-normalization@0.0.2(@subsquid/http-client@1.8.0)(@subsquid/logger@1.6.0)(@subsquid/rpc-client@4.14.0)':
+    dependencies:
+      '@subsquid/evm-rpc': 0.0.2(@subsquid/http-client@1.8.0)(@subsquid/rpc-client@4.14.0)
+      '@subsquid/util-internal': 3.3.1
+      '@subsquid/util-internal-validation': 0.9.0(@subsquid/logger@1.6.0)
+    transitivePeerDependencies:
+      - '@subsquid/http-client'
+      - '@subsquid/logger'
+      - '@subsquid/rpc-client'
+      - supports-color
+
+  '@subsquid/evm-rpc@0.0.2(@subsquid/http-client@1.8.0)(@subsquid/rpc-client@4.14.0)':
+    dependencies:
+      '@ethereumjs/mpt': 10.0.0
+      '@ethereumjs/rlp': 10.0.0
+      '@ethereumjs/util': 10.0.0
+      '@subsquid/http-client': 1.8.0
+      '@subsquid/logger': 1.6.0
+      '@subsquid/rpc-client': 4.14.0
+      '@subsquid/util-internal': 3.3.1
+      '@subsquid/util-internal-data-source': 0.0.0
+      '@subsquid/util-internal-hex': 1.2.3
+      '@subsquid/util-internal-range': 0.3.0
+      '@subsquid/util-internal-validation': 0.9.0(@subsquid/logger@1.6.0)
+      ethereum-cryptography: 3.2.0
+      secp256k1: 5.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@subsquid/http-client@1.7.0':
     dependencies:
       '@subsquid/logger': 1.4.0
@@ -7780,6 +7912,10 @@ snapshots:
 
   '@subsquid/util-internal-counters@1.3.2': {}
 
+  '@subsquid/util-internal-data-source@0.0.0':
+    dependencies:
+      '@subsquid/util-internal-range': 0.3.0
+
   '@subsquid/util-internal-hex@0.0.2': {}
 
   '@subsquid/util-internal-hex@1.2.2': {}
@@ -7835,7 +7971,13 @@ snapshots:
     optionalDependencies:
       '@subsquid/logger': 1.6.0
 
+  '@subsquid/util-internal-validation@0.9.0(@subsquid/logger@1.6.0)':
+    optionalDependencies:
+      '@subsquid/logger': 1.6.0
+
   '@subsquid/util-internal@3.2.0': {}
+
+  '@subsquid/util-internal@3.3.1': {}
 
   '@subsquid/util-naming@1.3.0':
     dependencies:
@@ -8347,6 +8489,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  bn.js@4.12.4: {}
+
   bn.js@5.2.2: {}
 
   body-parser@2.2.0:
@@ -8378,6 +8522,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  brorand@1.1.0: {}
 
   brotli-wasm@3.0.1: {}
 
@@ -8749,6 +8895,16 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  elliptic@6.6.1:
+    dependencies:
+      bn.js: 4.12.4
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -8915,6 +9071,14 @@ snapshots:
       '@types/estree': 1.0.8
 
   etag@1.8.1: {}
+
+  ethereum-cryptography@3.2.0:
+    dependencies:
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.0
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
 
   event-emitter@0.3.5:
     dependencies:
@@ -9220,6 +9384,11 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -9239,6 +9408,12 @@ snapshots:
   highlight.js@10.7.3: {}
 
   highlightjs-vue@1.0.0: {}
+
+  hmac-drbg@1.0.1:
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
 
   html-entities@2.6.0: {}
 
@@ -9555,6 +9730,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.0.2: {}
+
   lru-cache@11.2.2: {}
 
   lucide-react@0.544.0(react@19.2.5):
@@ -9609,6 +9786,10 @@ snapshots:
   mimic-function@5.0.1: {}
 
   mimic-response@3.1.0: {}
+
+  minimalistic-assert@1.0.1: {}
+
+  minimalistic-crypto-utils@1.0.1: {}
 
   minimatch@10.0.3:
     dependencies:
@@ -9703,6 +9884,8 @@ snapshots:
       semver: 7.7.4
 
   node-addon-api@2.0.2: {}
+
+  node-addon-api@5.1.0: {}
 
   node-domexception@1.0.0: {}
 
@@ -10318,6 +10501,12 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
+
+  secp256k1@5.0.1:
+    dependencies:
+      elliptic: 6.6.1
+      node-addon-api: 5.1.0
+      node-gyp-build: 4.8.4
 
   secure-json-parse@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,9 +287,15 @@ importers:
       '@subsquid/util-internal-hex':
         specifier: 0.0.2
         version: 0.0.2
+      '@subsquid/util-internal-json':
+        specifier: ^1.2.3
+        version: 1.2.3
+      '@subsquid/util-internal-processor-tools':
+        specifier: ^4.4.0
+        version: 4.4.0
       '@subsquid/util-internal-validation':
         specifier: 0.8.0
-        version: 0.8.0(@subsquid/logger@1.4.0)
+        version: 0.8.0(@subsquid/logger@1.6.0)
       '@subsquid/util-timeout':
         specifier: ^2.3.2
         version: 2.3.2
@@ -2415,6 +2421,9 @@ packages:
   '@subsquid/logger@1.4.0':
     resolution: {integrity: sha512-Yep4hzpLfmm4pJMXuTnd3n7Hlo18Dce8vwKZduGE9n/p56cHq4BTbAuaXLK50vYKWx7Lyt2obVbJ4otVMWkyYg==}
 
+  '@subsquid/logger@1.6.0':
+    resolution: {integrity: sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==}
+
   '@subsquid/rpc-client@4.13.0':
     resolution: {integrity: sha512-61lY/aaopNyDIaHmwjXH+HW02D1c1LbWQnfY0G/BkCy1sHhhI/4pUX6UyhvZAxMuy09sMep8+tib3a+VJcIAcA==}
 
@@ -2470,6 +2479,9 @@ packages:
   '@subsquid/util-internal-hex@1.2.2':
     resolution: {integrity: sha512-E43HVqf23jP5hvtWF9GsiN8luANjnJ1daR2SVTwaIUAYU/uNjv1Bi6tHz2uexlflBhyxAgBDmHgunXZ45wQTIw==}
 
+  '@subsquid/util-internal-hex@1.2.3':
+    resolution: {integrity: sha512-rGIQKHP+RpriJR56oL/AD43H/KX1EQwsvUy8nP6IHnk/vmaLyC2ECTp5n0jB7kq4NYK4C2VotP3lXHR0vWpa0A==}
+
   '@subsquid/util-internal-http-server@2.0.0':
     resolution: {integrity: sha512-MUAJGMuDjbA3B+KQFZmMkm9FuWVx067pINt+EWuq3fSZqYPr1kRkTCTSJK7uT6Q8omqJtJFRWveyOWlXmixvfg==}
 
@@ -2487,8 +2499,8 @@ packages:
   '@subsquid/util-internal-json@1.2.3':
     resolution: {integrity: sha512-H5qW5kG20IzVMpb7GhPbVRxGuACEf1DPIXE1+LNXYxt8t/GX4zQREQWHRvCB3lck+RORLJD3WJbQUtxN5UYB3Q==}
 
-  '@subsquid/util-internal-processor-tools@4.2.1':
-    resolution: {integrity: sha512-+iNmKZ9u69TsPdF96UlPSUIEYyALcY1SAVlM+tY/e+x5ZPCnZLOFF9jCYRnqDnYLmBtAw4hSEobMFv6d8S5z2g==}
+  '@subsquid/util-internal-processor-tools@4.4.0':
+    resolution: {integrity: sha512-Ov2gFOcaGr7qVhYoqx+EIUjskGLRJRImQaEal5e0uNjX1sLG1bKfz+rXh1YMYCIUFwKd86fAGyLjVWwvnG0V8w==}
 
   '@subsquid/util-internal-prometheus-server@1.3.0':
     resolution: {integrity: sha512-E/ch5mxBg1CIGPsuAqUAQ7vVln2oTPm+Rl+0WYweH8JeZ81rD01XAmxhDuZzZnMMMzfZd9W4NlE4mCXbhSY1Ug==}
@@ -7657,6 +7669,12 @@ snapshots:
       '@subsquid/util-internal-json': 1.2.3
       supports-color: 8.1.1
 
+  '@subsquid/logger@1.6.0':
+    dependencies:
+      '@subsquid/util-internal-hex': 1.2.3
+      '@subsquid/util-internal-json': 1.2.3
+      supports-color: 8.1.1
+
   '@subsquid/rpc-client@4.13.0':
     dependencies:
       '@subsquid/http-client': 1.7.0
@@ -7714,7 +7732,7 @@ snapshots:
       '@subsquid/util-internal-archive-client': 0.1.2(@subsquid/http-client@1.7.0)(@subsquid/logger@1.4.0)
       '@subsquid/util-internal-hex': 1.2.2
       '@subsquid/util-internal-ingest-tools': 1.1.4(@subsquid/util-internal-archive-client@0.1.2(@subsquid/http-client@1.7.0)(@subsquid/logger@1.4.0))
-      '@subsquid/util-internal-processor-tools': 4.2.1
+      '@subsquid/util-internal-processor-tools': 4.4.0
       '@subsquid/util-internal-range': 0.3.0
       '@subsquid/util-internal-validation': 0.8.0(@subsquid/logger@1.4.0)
       bs58: 5.0.0
@@ -7766,9 +7784,11 @@ snapshots:
 
   '@subsquid/util-internal-hex@1.2.2': {}
 
+  '@subsquid/util-internal-hex@1.2.3': {}
+
   '@subsquid/util-internal-http-server@2.0.0':
     dependencies:
-      '@subsquid/logger': 1.4.0
+      '@subsquid/logger': 1.6.0
       stoppable: 1.1.0
 
   '@subsquid/util-internal-ingest-tools@1.1.4(@subsquid/util-internal-archive-client@0.1.2(@subsquid/http-client@1.7.0)(@subsquid/logger@1.4.0))':
@@ -7785,9 +7805,9 @@ snapshots:
     dependencies:
       '@subsquid/util-internal-hex': 1.2.2
 
-  '@subsquid/util-internal-processor-tools@4.2.1':
+  '@subsquid/util-internal-processor-tools@4.4.0':
     dependencies:
-      '@subsquid/logger': 1.4.0
+      '@subsquid/logger': 1.6.0
       '@subsquid/util-internal': 3.2.0
       '@subsquid/util-internal-counters': 1.3.2
       '@subsquid/util-internal-prometheus-server': 1.3.0(prom-client@14.2.0)
@@ -7810,6 +7830,10 @@ snapshots:
   '@subsquid/util-internal-validation@0.8.0(@subsquid/logger@1.4.0)':
     optionalDependencies:
       '@subsquid/logger': 1.4.0
+
+  '@subsquid/util-internal-validation@0.8.0(@subsquid/logger@1.6.0)':
+    optionalDependencies:
+      '@subsquid/logger': 1.6.0
 
   '@subsquid/util-internal@3.2.0': {}
 


### PR DESCRIPTION
## RPC-fallback data source for Pipes

Adds an **RPC-backed EVM source** and a generic **fallback supervisor** to Pipes, mirroring the feature landed in `subsquid/squid-sdk` (PR #510). A pipe can now be fed by an ordered list of Portal and/or RPC sources; the supervisor drives the most-preferred healthy one, fails over on error/lag/staleness, and reclaims a recovered higher-preference source — all behind the same `AsyncIterable<PortalBatch> + pipeTo` a single Portal stream exposes, so it drops into an existing pipe unchanged.

### What's here
- **`FallbackSource`** — the supervisor: cascade-on-failure, resume-from-committed, `ForkException` pass-through, lag/staleness failover, global-stall hold, eager vs `onFailureOnly` reclaim, health + capability probing, and the single **monotonic finalized watermark** for the pipe (clamps every batch so a source switch can never un-finalize committed data).
- **`EvmRpcSource`** — an RPC EVM source whose output matches the Portal source's: delegates fetch/finality/continuity/fork detection to `@subsquid/evm-rpc`, then reuses the Portal decoder + a ported client-side filter (where-clause matching, relation expansion, augment/project-back of where-only fields, and **empty-block dropping** to match Portal output).
- **`createEvmFallback`** — builds a `FallbackSource` over Portal + RPC EVM sources sharing one field selection.
- **Metrics** — fallback health/switch/freshness gauges registered on the Pipes metrics server.
- **Dep hygiene** — `@subsquid/evm-rpc` + `@subsquid/evm-normalization` are **optional peer dependencies**, loaded lazily only when an `rpc` source becomes active; a Portal-only consumer never installs or imports the RPC stack.

### Feature parity with squid-sdk (this rebase)
Rebased onto current `main` (design/sdk1 merged) and audited against squid-sdk `master` in two passes — a test-scenario diff and a code-level feature diff. The two SDKs share no code, only scenarios.

**Ported test scenarios that had no Pipes counterpart** (all covered behavior that already existed but was untested):
- Supervisor: `onFailureOnly` never switches up; a `ForkException` from a source reached *after* a switch propagates; a slow downstream consumer between yields doesn't mark a source stale; probe-less eager reclaim via head-poll liveness alone.
- `SourceHealth`: a liveness pass resets the consecutive-fail counter; a failed capability probe flips unhealthy; a liveness pass while unhealthy doesn't reset the cooldown.
- evm/rpc filter: match traces by type, stateDiffs by address/kind, topic0-only logs, empty-where-matches-all, two-requests-kept-once, tx→siblings, log→transactionTraces, trace→parents; `toRequiredData` relation derivation; the **#510 merged-aggregate logs↔receipts dedup** regression; new `project.test.ts` (augment/selectionGrew) and `shim.test.ts`.
- Extracted the inline `withTimeout` + `safeReturn` into `core/fallback-async.ts` (mirrors squid's `fallback/async.ts`) with its edge-case unit tests.

**Behavioral fixes found during the audit:**
- **Empty-block parity** — the RPC source now drops interior blocks left empty by filtering (keeping batch boundaries / the progress cursor), matching Portal output. Previously it emitted every fetched block.
- **Missing-peer diagnostics** — the lazy RPC loader now discriminates a missing optional peer (ESM `ERR_MODULE_NOT_FOUND` / CJS `MODULE_NOT_FOUND` naming a peer) from any other load failure, which now surfaces unchanged instead of being masked as "peers missing".
- Added a supervisor-level guard that the finalized watermark clamp survives a source switch.

### Deliberately not ported (documented decisions)
- **Per-network presets** (squid ships 7-chain presets + a resolver + an `evmRpcStream` builder). This is a **public-API / product decision** for Pipes — it needs a URL→`Rpc` builder surface (squid's builder constructs the `Rpc` incl. validation config from a preset, whereas Pipes has the user construct `Rpc` and pass it). Left as a focused follow-up rather than guessing the API surface here. The underlying knobs (`RpcMethodOptions`, evm-rpc validation) are already exposed.
- **Capability-probe anchoring** (squid probes at `committed + lookahead` clamped to `head − tipMargin`). Pipes anchors the probe at the committed **finalized** cursor, which is already below the reorg-prone tip and in the same pruning regime it's about to read — achieving both goals squid's `lookahead`/`tipMargin` target, more simply, and without de-hashing the probe read. Kept as-is intentionally.

### Not applicable to Pipes (by design)
`getHead` delegation suite (Pipes' `FallbackSource` exposes no public `getHead`), `flattenRequest`/`unionRequiredData`/`streamBoundedRanges` (Pipes merges requests upstream and delegates streaming to `@subsquid/evm-rpc`), squid's megapackage packaging guard, and the LFS golden decode (covered by the gated parity e2e).

### Tests
501 non-service unit tests pass; `tsc --noEmit` clean. Live RPC/Portal parity remains behind the `RPC_E2E` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
