### PR TITLE
fix(parquet): name files for the block range they cover

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -435,3 +435,42 @@ non-object column declaration, or nesting too deep (possibly cyclic).
 
 **Fix** — a `STRUCT` needs at least one field and a `LIST` needs an `element`; correct the
 declaration.
+
+### E2316 · Invalid segment coverage range
+
+Files are named `<from>-<to>.parquet` for the block window they cover, and a segment was about to be
+named for a range that could not be formed — inverted (`from` above `to`), or with no coverage start
+recorded for the table. This is an internal invariant; it should not be reachable from user code.
+
+**Fix** — not user-serviceable. Please report it with the surrounding logs.
+
+### E2317 · State file disagrees with the data files
+
+The data files were written by a run that committed further than the state file records — typically a
+restored older state file, or a cursor rewound by hand. A published `<from>-<to>.parquet` file
+straddles the committed cursor (`from <= cursor < to`) *and* does not start where the persisted
+coverage says that table was next due to publish from. Such a file holds committed data (blocks at or
+below the cursor) that a resume would never re-fetch, so deleting it as an incomplete-checkpoint
+remnant would lose data. The refusal happens **before** anything is deleted or published, so the data
+files are intact.
+
+A straddling file whose `from` *does* match the table's persisted coverage start is not this error:
+that is the file an interrupted checkpoint was publishing, and a sparse table's stretched file
+straddles the cursor as a matter of course. It is deleted and re-derived like any other remnant.
+
+**Fix** — restore the state file that matches the data files, or delete both the state file and the
+affected table directories to re-index that range from scratch.
+
+**Upgrading from a version that kept no coverage record**: if the previous version's last run
+crashed, its checkpoint remnant can itself straddle the cursor (a row keyed below the cursor puts a
+row-min/max name's `from` at or below it), and with no coverage to explain the straddle this error
+fires on the first post-upgrade start. That remnant is an ordinary incomplete-checkpoint leftover:
+deleting just that file and restarting is enough — recovery re-fetches and regenerates it. To avoid
+the manual step entirely, restart the pipe once on the old version (letting its own recovery run)
+before upgrading.
+
+A related condition is *not* fatal: if the persisted coverage for a table starts ahead of the
+furthest block a file could consistently cover from for the resume cursor, it is clamped back to
+that block and logged as a warning. The usual cause is an edit to the configured query ranges
+(a gap the recorded start referred to no longer exists), and clamping keeps the blocks after the
+cursor claimed by a file.

--- a/docs/examples/evm/17.parquet.example.ts
+++ b/docs/examples/evm/17.parquet.example.ts
@@ -2,9 +2,9 @@
  * Parquet target — write a stream to rotating, finalized-only Parquet files.
  *
  * Indexes ERC20 Transfer + Approval events from Ethereum mainnet into local Parquet files
- * under `<OUT>/transfers/` and `<OUT>/approvals/`. Each file is named by its block range
- * (`<min>-<max>.parquet`) and is immutable once published — the standard columnar format read
- * directly by DuckDB, Spark, Athena and ClickHouse `s3()` (no import step).
+ * under `<OUT>/transfers/` and `<OUT>/approvals/`. Each file is named for the block range it
+ * covers (`<from>-<to>.parquet`) and is immutable once published — the standard columnar format
+ * read directly by DuckDB, Spark, Athena and ClickHouse `s3()` (no import step).
  *
  * Why this target:
  *   - **Finalized-only.** A row is written only once its block is at/below the portal's
@@ -16,6 +16,10 @@
  *     bounds the writer's in-memory buffer.
  *   - **Crash-safe.** A durable cursor (`<OUT>/_sqd_parquet_state.json`) advances only at a
  *     checkpoint; on restart, any file above the cursor is dropped and re-fetched.
+ *   - **Coverage you can read off the filename.** `<from>-<to>` is the window the file covers,
+ *     not the min/max block of the rows in it, so a table that goes quiet for a stretch still
+ *     names those blocks in whatever it writes next. A missing range means "not indexed", never
+ *     "indexed, no data" — and the files of one table are contiguous.
  *
  * Note: `onData` must be a pure function of the batch for finalized blocks (no wall-clock / RNG
  * affecting a row's identity) — recovery re-processes finalized blocks and relies on

--- a/packages/pipes/src/core/index.ts
+++ b/packages/pipes/src/core/index.ts
@@ -14,6 +14,8 @@ export * from './output.js'
 export * from './portal-range.js'
 export * from './portal-source.js'
 export type { Profiler, ProfilerOptions, SpanHooks } from './profiling.js'
+// `StreamInfo.state.ranges` is typed with it, so the name has to be reachable by consumers.
+export type { Range } from './query-builder.js'
 export * from './target.js'
 export * from './transformer.js'
 export * from './types.js'

--- a/packages/pipes/src/core/portal-source.ts
+++ b/packages/pipes/src/core/portal-source.ts
@@ -15,7 +15,7 @@ import { LogLevel, Logger, defaultLogger, formatWarning } from './logger.js'
 import { Metrics, MetricsServer, noopMetricsServer } from './metrics-server.js'
 import { Profiler, Span, SpanHooks } from './profiling.js'
 import { ProgressEvent, StartEvent } from './progress-tracker.js'
-import { QueryBuilder, hashQuery } from './query-builder.js'
+import { QueryBuilder, type Range, hashQuery } from './query-builder.js'
 import { ReadOptions, Target, TargetState } from './target.js'
 import { QueryAwareTransformer, Transformer, TransformerArgs, TransformerOptions } from './transformer.js'
 import { BlockCursor, HookContext } from './types.js'
@@ -49,6 +49,15 @@ export type StreamInfo = {
     initial: number
     last: number
     current: BlockCursor
+    /**
+     * The configured query ranges, as resolved at startup and BEFORE the resume bound is applied
+     * — `initial` is just `ranges[0].from`, and `last` tracks the end of the final range.
+     *
+     * Kept unbounded on purpose: a target that names files by the range they cover must tell an
+     * un-queried gap between two ranges apart from a block that was queried and simply had no
+     * data. After a resume the bounded ranges no longer show the gap, so only this list can.
+     */
+    ranges: Range[]
     /**
      * List of block cursors representing unfinalized blocks in chronological order.
      * Used for handling blockchain forks by tracking alternative chain versions
@@ -200,6 +209,7 @@ export class PortalStream<Q extends QueryBuilder<any>, T = any> {
     })
 
     const initial = raw[0]?.range.from || 0
+    const ranges = raw.map((r) => r.range)
 
     this.#logger.debug(`${bounded.length} range(s) configured`)
 
@@ -271,6 +281,7 @@ export class PortalStream<Q extends QueryBuilder<any>, T = any> {
                 },
                 state: {
                   initial,
+                  ranges,
                   current: cursorFromHeader(lastBatchBlock as any),
                   last: lastBlockNumber,
                   rollbackChain: extractRollbackChain({

--- a/packages/pipes/src/portal-cache/node/portal-cache.test.ts
+++ b/packages/pipes/src/portal-cache/node/portal-cache.test.ts
@@ -164,6 +164,12 @@ describe('Portal cache', () => {
                 },
                 "initial": 0,
                 "last": 5,
+                "ranges": [
+                  {
+                    "from": 0,
+                    "to": 5,
+                  },
+                ],
                 "rollbackChain": [],
               },
             },
@@ -300,6 +306,12 @@ describe('Portal cache', () => {
                 },
                 "initial": 0,
                 "last": 5,
+                "ranges": [
+                  {
+                    "from": 0,
+                    "to": 5,
+                  },
+                ],
                 "rollbackChain": [],
               },
             },
@@ -425,6 +437,12 @@ describe('Portal cache', () => {
                 },
                 "initial": 0,
                 "last": 5,
+                "ranges": [
+                  {
+                    "from": 0,
+                    "to": 5,
+                  },
+                ],
                 "rollbackChain": [
                   {
                     "hash": "0x3",
@@ -501,6 +519,12 @@ describe('Portal cache', () => {
                 },
                 "initial": 0,
                 "last": 5,
+                "ranges": [
+                  {
+                    "from": 0,
+                    "to": 5,
+                  },
+                ],
                 "rollbackChain": [],
               },
             },
@@ -562,6 +586,12 @@ describe('Portal cache', () => {
                 },
                 "initial": 0,
                 "last": 5,
+                "ranges": [
+                  {
+                    "from": 0,
+                    "to": 5,
+                  },
+                ],
                 "rollbackChain": [],
               },
             },

--- a/packages/pipes/src/targets/parquet/errors.ts
+++ b/packages/pipes/src/targets/parquet/errors.ts
@@ -47,4 +47,8 @@ export const PARQUET_ERROR_CODES = {
   RECOVERY_DELETE_FAILED: 'E2314',
   /** A nested column declaration is malformed (empty STRUCT fields, LIST without element, over-deep nesting). */
   NESTED_SCHEMA_INVALID: 'E2315',
+  /** A segment's coverage range could not be formed or is inverted (internal invariant). */
+  COVERAGE_RANGE_INVALID: 'E2316',
+  /** The persisted coverage map disagrees with the cursor stored beside it. */
+  STATE_COVERAGE_INVALID: 'E2317',
 } as const

--- a/packages/pipes/src/targets/parquet/parquet-state.ts
+++ b/packages/pipes/src/targets/parquet/parquet-state.ts
@@ -10,7 +10,7 @@ import { TMP_PREFIX } from './writer.js'
 /** Base name of the durable state file living at the root of the output dir. */
 const STATE_BASENAME = '_sqd_parquet_state'
 
-/** Published data files are named `<min>-<max>.parquet`; nothing else in a table dir is ours. */
+/** Published data files are named `<from>-<to>.parquet`; nothing else in a table dir is ours. */
 const DATA_FILE_RE = /^(\d+)-(\d+)\.parquet$/
 
 type PersistedState = {
@@ -24,6 +24,13 @@ type PersistedState = {
    * field existed (treated as "no persisted finalized head").
    */
   finalized?: BlockCursor
+  /**
+   * Per-table first block the next published file will cover. Tracked per table (not derived from
+   * `cursor`) because a table with no rows in a window publishes no file while the cursor moves on
+   * regardless — only this record remembers how far back that table's next file must reach. Absent
+   * in state written before coverage naming existed.
+   */
+  coverage?: Record<string, number>
 }
 
 export type ParquetStateOptions = {
@@ -59,6 +66,8 @@ export class ParquetState {
   readonly #statePath: string
   readonly #logger: Logger
 
+  #coverage: Record<string, number> | undefined
+
   constructor(options: ParquetStateOptions) {
     this.#baseDir = options.dir
     this.#tables = options.tables
@@ -71,12 +80,22 @@ export class ParquetState {
   }
 
   /**
+   * Per-table coverage starts read from the state file, or `undefined` when the state predates
+   * coverage naming (or there is no state at all). Populated by {@link getCursor}.
+   */
+  get coverage(): Record<string, number> | undefined {
+    return this.#coverage
+  }
+
+  /**
    * Prepares the output directory and returns the cursor to resume from (or `undefined` to start
    * from the stream beginning).
    *
    * Always: `mkdir -p` the base dir + every table dir, and delete every `.tmp-*` file. When a
-   * committed cursor exists, additionally delete every published data file whose `maxBlock`
-   * exceeds it (incomplete-checkpoint remnants).
+   * committed cursor exists, additionally delete every published data file whose coverage end
+   * exceeds it (incomplete-checkpoint remnants) — refusing up front if one straddles the cursor
+   * without being explained by the persisted coverage, which would mean the state file and the
+   * data files came from different runs (`E2317`).
    */
   async getCursor(): Promise<TargetState | undefined> {
     await mkdir(this.#baseDir, { recursive: true })
@@ -91,6 +110,8 @@ export class ParquetState {
       return undefined
     }
 
+    this.#coverage = state.coverage
+
     await this.#deleteFilesAboveCursor(state.cursor.number)
 
     // Hand the persisted finalized head back as resume state so the source can re-seed its
@@ -101,15 +122,18 @@ export class ParquetState {
   /**
    * Atomically persists the checkpoint cursor: write a temp file, fsync it, rename over the
    * state file, then fsync the directory so the rename is durable. Called only after every open
-   * writer for the checkpoint has been published.
+   * writer for the checkpoint has been published, so `coverage` describes the files on disk.
    */
-  async saveCursor(cursor: BlockCursor, finalized?: BlockCursor): Promise<void> {
+  async saveCursor(cursor: BlockCursor, finalized?: BlockCursor, coverage?: Record<string, number>): Promise<void> {
     const payload: PersistedState = { cursor }
     if (this.#id) {
       payload.id = this.#id
     }
     if (finalized) {
       payload.finalized = finalized
+    }
+    if (coverage) {
+      payload.coverage = coverage
     }
 
     const tmpPath = path.join(this.#baseDir, `${TMP_PREFIX}state-${path.basename(this.#statePath)}`)
@@ -157,15 +181,39 @@ export class ParquetState {
   }
 
   /**
-   * Deletes every published `<min>-<max>.parquet` whose `max` exceeds the committed cursor.
+   * Deletes every published `<from>-<to>.parquet` whose `to` exceeds the committed cursor.
    *
    * A surviving over-cursor file is a correctness hazard, not a cosmetic leftover: `read(cursor)`
    * re-fetches the same blocks and either collides with it (fatal) or, if rotation lands on a
    * different range, overlaps it (silent duplicate rows). So a failed `unlink` here is fatal —
    * we surface it with remediation guidance rather than swallowing it and counting it as removed.
+   *
+   * Reading the range off the filename is sound for both naming schemes: a coverage-named file
+   * ends at the checkpoint cursor that published it, and a legacy min/max-named file ends at its
+   * last row, which is itself never above that cursor. Either way `to > cursor` means "published
+   * after the last commit".
+   *
+   * An over-cursor file that also *starts* at or below the cursor (`from <= cursor < to`)
+   * straddles the commit point, so on the face of it it holds committed data (blocks `<= cursor`)
+   * that a resume from `cursor + 1` will never re-fetch. Two very different things produce that
+   * shape, and the persisted coverage tells them apart:
+   *
+   * - `from` equals the table's persisted coverage start — this is the file that table was about
+   *   to publish when the checkpoint was interrupted. A sparse table's coverage start legitimately
+   *   sits at or below the cursor (it kept the start while it sat out earlier checkpoints), so its
+   *   *stretched* remnant straddles by construction. Its rows can only have come from processing
+   *   blocks above the cursor, so a resume regenerates them: delete it like any other remnant.
+   * - `from` is anything else — the files were written by a run that committed further than the
+   *   cursor now records (a restored older state file, or a cursor rewound by hand). Deleting it
+   *   would destroy committed data, so we refuse up front (scanning every table before deleting
+   *   anything) and leave the operator a decision.
+   *
+   * With no persisted coverage (state predating coverage naming) nothing explains a straddle: a
+   * row-min/max name's `from` is its first row, so committed rows really are inside. Refuse.
    */
   async #deleteFilesAboveCursor(cursorNumber: number): Promise<void> {
-    let removed = 0
+    const overCursor: { path: string; from: number; to: number; table: string }[] = []
+
     for (const table of this.#tables) {
       const dir = path.join(this.#baseDir, table)
       const entries = await readdir(dir).catch(() => [] as string[])
@@ -173,29 +221,55 @@ export class ParquetState {
         const match = DATA_FILE_RE.exec(name)
         if (!match) continue
 
-        const maxBlock = Number.parseInt(match[2], 10)
-        if (maxBlock <= cursorNumber) continue
+        const from = Number.parseInt(match[1], 10)
+        const to = Number.parseInt(match[2], 10)
+        if (to <= cursorNumber) continue
 
-        const filePath = path.join(dir, name)
-        try {
-          await unlink(filePath)
-        } catch (error) {
+        if (from <= cursorNumber && from !== this.#coverage?.[table]) {
+          // With no coverage recorded at all, the straddle can also be a pre-upgrade crash remnant
+          // (a back-keyed row puts a legacy min/max name's `from` at or below the cursor) — a
+          // shape the old recovery deleted and re-derived. We can't tell it apart from real state
+          // divergence, but the remedy for it is one file, not the whole table.
+          const legacyHint =
+            this.#coverage === undefined
+              ? ` If this is the first start after upgrading from a version that kept no coverage ` +
+                `record and the previous run crashed, the file is an ordinary checkpoint remnant — ` +
+                `deleting just this file and restarting is enough.`
+              : ''
+
           throw new ParquetTargetError(
-            PARQUET_ERROR_CODES.RECOVERY_DELETE_FAILED,
-            `Crash recovery could not delete the over-cursor Parquet file '${filePath}' ` +
-              `(its blocks exceed the committed cursor ${formatBlock(cursorNumber)}): ` +
-              `${error instanceof Error ? error.message : String(error)}. Leaving it would duplicate or ` +
-              `overlap re-fetched data — remove it manually and restart.`,
+            PARQUET_ERROR_CODES.STATE_COVERAGE_INVALID,
+            `Parquet file '${path.join(dir, name)}' covers block range ${from}-${to}, which straddles ` +
+              `the committed cursor ${formatBlock(cursorNumber)} and does not start where table ` +
+              `'${table}' was next due to publish from (${this.#coverage?.[table] ?? 'no coverage recorded'}): ` +
+              `the data files were written by a run that committed further than the state file now ` +
+              `records (a restored older state file, or a cursor rewound by hand). Refusing to delete ` +
+              `it, since that would destroy committed data. Either restore the state file that matches ` +
+              `the data files, or delete both the state file and '${table}/' to re-index.${legacyHint}`,
           )
         }
 
-        removed++
+        overCursor.push({ path: path.join(dir, name), from, to, table })
       }
     }
 
-    if (removed > 0) {
+    for (const file of overCursor) {
+      try {
+        await unlink(file.path)
+      } catch (error) {
+        throw new ParquetTargetError(
+          PARQUET_ERROR_CODES.RECOVERY_DELETE_FAILED,
+          `Crash recovery could not delete the over-cursor Parquet file '${file.path}' ` +
+            `(its blocks exceed the committed cursor ${formatBlock(cursorNumber)}): ` +
+            `${error instanceof Error ? error.message : String(error)}. Leaving it would duplicate or ` +
+            `overlap re-fetched data — remove it manually and restart.`,
+        )
+      }
+    }
+
+    if (overCursor.length > 0) {
       this.#logger.warn(
-        `Crash recovery: removed ${removed} Parquet file(s) above the committed cursor ` +
+        `Crash recovery: removed ${overCursor.length} Parquet file(s) above the committed cursor ` +
           `(block ${formatBlock(cursorNumber)}) before resuming.`,
       )
     }

--- a/packages/pipes/src/targets/parquet/parquet-store.test.ts
+++ b/packages/pipes/src/targets/parquet/parquet-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
@@ -193,6 +193,114 @@ describe('ParquetStore', () => {
           { blockNumber: 2, user: nullProto, tags: null },
         ]),
       ).not.toThrow()
+    })
+  })
+
+  describe('coverage', () => {
+    it('seeds from persisted starts and falls back for tables the state does not mention', () => {
+      const other: ParquetTable = { table: 'other', schema: { blockNumber: { type: 'INT64' } } }
+      const store = new ParquetStore({ dir, tables: [BLOCKS_TABLE, other], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+
+      // `blocks` owes an earlier window (start 5) while this run resumes at 7; `other` was declared
+      // after the state was written, so it falls back to where this run does.
+      store.seedCoverage({ blocks: 5 }, 7)
+
+      expect(store.coverage()).toEqual({ blocks: 5, other: 7 })
+    })
+
+    it.each([
+      ['non-numeric', 'garbage' as unknown as number],
+      ['NaN', Number.NaN],
+      // pad(-5) renders as "0000000000-5", so the filename would gain an extra dash and stop
+      // matching the data-file pattern — crash recovery would never see that file again.
+      ['negative', -5],
+      ['fractional', 2.5],
+    ])('ignores a %s persisted start rather than steering the filename with it', (_label, value) => {
+      const store = new ParquetStore({ dir, tables: [BLOCKS_TABLE], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+
+      store.seedCoverage({ blocks: value }, 7)
+
+      expect(store.coverage()).toEqual({ blocks: 7 })
+    })
+
+    it('skips the gap between disjoint ranges when advancing past a publish', async () => {
+      await mkdir(path.join(dir, 'blocks'), { recursive: true })
+      const store = new ParquetStore({ dir, tables: [BLOCKS_TABLE], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      store.seedCoverage(undefined, 0, [
+        { from: 0, to: 1 },
+        { from: 5, to: 6 },
+      ])
+      store.insert('blocks', [{ blockNumber: 1, hash: '0x1', timestamp: 1 }])
+      await store.flushBatch({ finalized: { number: 1, hash: '0x1' }, rollbackChain: [] })
+
+      await store.publishAll(1)
+
+      // Blocks 2-4 are never queried, so the next file must start at 5 — not 2.
+      expect(store.coverage()).toEqual({ blocks: 5 })
+    })
+
+    it('keeps a writer it could not name a window for, and publishes it once the boundary moves', async () => {
+      // The boundary cursor does not advance while the finalized head is stuck, so a second
+      // checkpoint at the same block has no window to name (coverage start 2 > to 1). The rows
+      // released in between — an aggregate keyed back at block 1 — must stay in the open writer:
+      // dropping it here would lose them and orphan its temp file.
+      await mkdir(path.join(dir, 'blocks'), { recursive: true })
+      const store = new ParquetStore({ dir, tables: [BLOCKS_TABLE], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      store.seedCoverage(undefined, 0)
+      const stuck = { finalized: { number: 1, hash: '0x1' }, rollbackChain: [] }
+
+      store.insert('blocks', [{ blockNumber: 1, hash: '0x1', timestamp: 1 }])
+      await store.flushBatch(stuck)
+      await store.publishAll(1)
+
+      store.insert('blocks', [{ blockNumber: 1, hash: '0x1', timestamp: 1 }])
+      await store.flushBatch(stuck)
+      expect(await store.publishAll(1)).toEqual([])
+      expect(store.hasOpenWriters).toBe(true)
+
+      // Once the head moves the window exists, and the held row is in the file that names it.
+      const published = await store.publishAll(3)
+      expect(published.map((p) => `${p.from}-${p.to}`)).toEqual(['2-3'])
+      expect(published[0].rows).toBe(1)
+    })
+
+    it('does not drop the writers of tables left out of an explicit publish set', async () => {
+      // The range-end checkpoint passes only the tables that owe coverage. Any other open writer
+      // belongs to a later window, not to the bin.
+      const other: ParquetTable = { table: 'other', schema: { blockNumber: { type: 'INT64' } } }
+      for (const table of ['blocks', 'other']) {
+        await mkdir(path.join(dir, table), { recursive: true })
+      }
+      const store = new ParquetStore({ dir, tables: [BLOCKS_TABLE, other], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      store.seedCoverage(undefined, 0)
+
+      store.insert('blocks', [{ blockNumber: 1, hash: '0x1', timestamp: 1 }])
+      store.insert('other', [{ blockNumber: 1 }])
+      await store.flushBatch({ finalized: { number: 1, hash: '0x1' }, rollbackChain: [] })
+
+      const published = await store.publishAll(1, { closeTails: true, tables: ['blocks'] })
+
+      expect(published.map((p) => p.table)).toEqual(['blocks'])
+      expect(store.hasOpenWriters).toBe(true)
+      expect((await store.publishAll(2)).map((p) => `${p.table} ${p.from}-${p.to}`)).toEqual(['other 0-2'])
+    })
+
+    it('refuses to publish before coverage is seeded rather than inventing a range', async () => {
+      // The target gets its table dirs from ParquetState.getCursor(); this test drives the store
+      // directly, so it has to make them itself.
+      await mkdir(path.join(dir, 'blocks'), { recursive: true })
+      const store = new ParquetStore({ dir, tables: [BLOCKS_TABLE], rowGroupSize: 1, defaultCodec: 'SNAPPY' })
+      store.insert('blocks', [{ blockNumber: 1, hash: '0x1', timestamp: 1 }])
+      await store.flushBatch({ finalized: { number: 1, hash: '0x1' }, rollbackChain: [] })
+
+      expect.assertions(1)
+      try {
+        await store.publishAll(1)
+      } catch (e) {
+        expect((e as ParquetTargetError).code).toBe(PARQUET_ERROR_CODES.COVERAGE_RANGE_INVALID)
+      } finally {
+        await store.close()
+      }
     })
   })
 })

--- a/packages/pipes/src/targets/parquet/parquet-store.ts
+++ b/packages/pipes/src/targets/parquet/parquet-store.ts
@@ -2,7 +2,13 @@ import path from 'node:path'
 
 import { ParquetSchema } from '@dsnp/parquetjs'
 
-import { type BlockCursor, type Finalization, type FinalizationBuffer, finalizationBuffer } from '~/core/index.js'
+import {
+  type BlockCursor,
+  type Finalization,
+  type FinalizationBuffer,
+  type Range,
+  finalizationBuffer,
+} from '~/core/index.js'
 
 import { PARQUET_ERROR_CODES, ParquetTargetError } from './errors.js'
 import {
@@ -16,6 +22,15 @@ import {
   toParquetSchemaShape,
 } from './schema.js'
 import { ParquetSegmentWriter, type PublishedSegment } from './writer.js'
+
+/** Per-table first block the next published file will cover, keyed by table name. */
+export type CoverageStarts = Record<string, number>
+
+/** A published segment plus the table and coverage window it belongs to. */
+export type PublishedFile = PublishedSegment & { table: string; from: number; to: number }
+
+/** A persisted coverage start that could not be honoured, and what was seeded instead. */
+export type ClampedCoverage = { table: string; persisted: number; seeded: number }
 
 type Row = Record<string, unknown>
 
@@ -60,6 +75,11 @@ export class ParquetStore {
   readonly #staged = new Map<string, Row[]>()
   // The current open segment per table — at most one. Reset (published/discarded) at checkpoints.
   readonly #writers = new Map<string, ParquetSegmentWriter>()
+  // First block each table's NEXT published file will claim to cover. Seeded by `seedCoverage`
+  // and advanced only when that table actually publishes — see `publishAll`.
+  readonly #coverageStart = new Map<string, number>()
+  // Configured query ranges, ascending. Empty means "one implicit range" (no gaps to skip).
+  #ranges: Range[] = []
   readonly #rowGroupSize: number
   // Per-cell type checking is a hot-path cost, so it only runs outside production.
   readonly #validateValues = process.env.NODE_ENV !== 'production'
@@ -70,6 +90,7 @@ export class ParquetStore {
     for (const table of options.tables) {
       const blockColumn = blockColumnOf(table)
       const getBlockNumber = (row: Row): number => readBlockNumber(table.table, blockColumn, row)
+
       this.#configs.set(table.table, {
         blockColumn,
         getBlockNumber,
@@ -126,7 +147,7 @@ export class ParquetStore {
       if (released.length > 0) {
         const writer = this.#getOrCreateWriter(table, config)
         for (const row of released) {
-          await writer.appendRow(config.wrapRow ? config.wrapRow(row) : row, config.getBlockNumber(row))
+          await writer.appendRow(config.wrapRow ? config.wrapRow(row) : row)
         }
         stats.push({ table, rows: released.length })
       }
@@ -153,19 +174,173 @@ export class ParquetStore {
   }
 
   /**
-   * Publishes every currently-open segment writer (each holds ≥1 finalized row by lazy-open) and
-   * resets them, returning each published file's stats. Call immediately before persisting the
-   * checkpoint cursor.
+   * Seeds each table's next-file coverage start and records the configured query ranges (which
+   * `publishAll` needs to skip blocks the pipe will never fetch).
+   *
+   * `persisted` wins; a table absent from it — a cold start, a newly declared table, or state
+   * written before coverage was tracked — falls back to `fallbackStart`, which the caller must set
+   * to the first block this run may publish (NOT the source's `initial`, which is the configured
+   * query start and ignores any resume).
+   *
+   * A persisted value that isn't a non-negative integer is treated as absent rather than trusted:
+   * `pad(-5)` renders as `0000000000-5`, which the data-file pattern cannot parse, so crash
+   * recovery would go blind to that file and let it duplicate rows.
+   *
+   * Whichever start is chosen is clamped forward to the first actually-queried block, so a
+   * `fallbackStart` of `cursor + 1` (or a persisted value) that lands in an un-queried gap between
+   * ranges can't seed a file that names blocks the pipe never fetched.
+   *
+   * A persisted value ahead of `nextQueriedBlock(fallbackStart)` — the furthest a file could
+   * consistently start for the resume point — is clamped back down to it rather than trusted:
+   * honouring it would leave the blocks between the cursor and that start claimed by no file at
+   * all. The two things that produce it are both handled by clamping — the query ranges were
+   * edited since the state was written (the recorded start refers to a gap that no longer exists,
+   * and the clamped value covers the newly-queried blocks correctly), or the cursor was rewound by
+   * hand (recovery has already deleted the files above it, so re-indexing from the clamp is exactly
+   * right). Returns what it clamped so the caller can say so out loud.
+   *
+   * @internal — lifecycle, driven by the target.
    */
-  async publishAll(): Promise<(PublishedSegment & { table: string })[]> {
-    const published: (PublishedSegment & { table: string })[] = []
+  seedCoverage(persisted: CoverageStarts | undefined, fallbackStart: number, ranges: Range[] = []): ClampedCoverage[] {
+    this.#ranges = [...ranges].sort((a, b) => a.from - b.from)
 
-    for (const [table, writer] of this.#writers) {
-      published.push({ table, ...(await writer.publish()) })
+    const ceiling = this.#nextQueriedBlock(fallbackStart)
+    const clamped: ClampedCoverage[] = []
+
+    for (const table of this.#configs.keys()) {
+      const start = persisted?.[table]
+      const valid = Number.isInteger(start) && (start as number) >= 0
+
+      if (valid && (start as number) > ceiling) {
+        clamped.push({ table, persisted: start as number, seeded: ceiling })
+        this.#coverageStart.set(table, ceiling)
+        continue
+      }
+
+      this.#coverageStart.set(table, this.#nextQueriedBlock(valid ? (start as number) : fallbackStart))
     }
-    this.#writers.clear()
+
+    return clamped
+  }
+
+  /**
+   * Bumps every table whose next-file start still sits below `rangeFrom` up to it. Called on entry
+   * to a configured range so a range the stream skipped entirely — it produced no batch, so no tail
+   * was closed for it — is not folded into the next file's coverage, which would claim the
+   * un-queried gap after it. A table owing a window *within* the current range (start already at or
+   * past `rangeFrom`) is left untouched.
+   *
+   * @internal — lifecycle, driven by the target.
+   */
+  advanceCoverageInto(rangeFrom: number): void {
+    const target = this.#nextQueriedBlock(rangeFrom)
+    for (const [table, start] of this.#coverageStart) {
+      if (start < target) {
+        this.#coverageStart.set(table, target)
+      }
+    }
+  }
+
+  /**
+   * Per-table coverage starts, to persist alongside the checkpoint cursor.
+   *
+   * @internal — lifecycle, driven by the target.
+   */
+  coverage(): CoverageStarts {
+    return Object.fromEntries(this.#coverageStart)
+  }
+
+  /**
+   * Tables whose coverage has fallen behind `to` — i.e. that owe a file for a window they sat out.
+   *
+   * @internal — lifecycle, driven by the target.
+   */
+  tablesOwingCoverage(to: number): string[] {
+    return [...this.#configs.keys()].filter((table) => {
+      const from = this.#coverageStart.get(table)
+
+      return from !== undefined && from <= to
+    })
+  }
+
+  /**
+   * Publishes a segment per table for the window ending at `to`, and resets the open writers.
+   * Call immediately before persisting the checkpoint cursor.
+   *
+   * Each file is named for the **window it covers** — `[the table's coverage start, to]` — not the
+   * min/max block of its rows, so a consumer reads coverage off the filename instead of guessing
+   * whether a gap means "no data" or "not indexed yet".
+   *
+   * By default only tables with an open writer publish; a table with no rows keeps its coverage
+   * start, so the next file it does publish stretches back across the windows it sat out. That
+   * keeps a sparse table gap-free without a tiny file per window.
+   *
+   * With `closeTails`, every table still owing coverage publishes — writing an **empty** segment if
+   * it has no rows. Stretching alone can't close a table's final window (there is no next file to
+   * stretch), so the caller must force this where coverage would otherwise end: at stream end, and
+   * before crossing into a later query range.
+   *
+   * `tables` lets a caller that has already computed the owing set (via {@link tablesOwingCoverage})
+   * pass it in rather than have it recomputed here.
+   *
+   * A writer this call does not publish — its table was left out of `tables`, or its coverage start
+   * is still ahead of `to` (the boundary cursor has not advanced since it last published, so there
+   * is no window to name yet) — is deliberately left **open**, to be published by a later
+   * checkpoint or discarded by {@link close}. Dropping it here would lose its finalized rows and
+   * orphan its temp file.
+   *
+   * @internal — lifecycle, driven by the target.
+   */
+  async publishAll(to: number, options: { closeTails?: boolean; tables?: string[] } = {}): Promise<PublishedFile[]> {
+    const published: PublishedFile[] = []
+    const tables = options.tables ?? (options.closeTails ? this.tablesOwingCoverage(to) : [...this.#writers.keys()])
+
+    for (const table of tables) {
+      const from = this.#coverageStart.get(table)
+      if (from === undefined) {
+        throw new ParquetTargetError(
+          PARQUET_ERROR_CODES.COVERAGE_RANGE_INVALID,
+          `Internal: table '${table}' has an open writer but no coverage start — seedCoverage() ` +
+            `must run before the first publish.`,
+        )
+      }
+      if (from > to) continue
+
+      // Only tail-closing invents a writer for a table that has none; a plain checkpoint publishes
+      // what is open and nothing else, so it never writes a zero-row file.
+      const open = this.#writers.get(table)
+      if (!open && !options.closeTails) continue
+
+      const config = this.#configs.get(table)!
+      const writer = open ?? this.#getOrCreateWriter(table, config)
+
+      published.push({ table, from, to, ...(await writer.publish({ from, to })) })
+      this.#writers.delete(table)
+      this.#coverageStart.set(table, this.#nextQueriedBlock(to + 1))
+    }
 
     return published
+  }
+
+  /**
+   * The first block at or after `block` that the pipe actually queries.
+   *
+   * Coverage must never advance into the gap between two configured ranges: those blocks are never
+   * fetched, so a later file naming itself across them would claim to cover data the pipe never
+   * looked at — the exact inverse of the guarantee the naming exists to give. With no ranges
+   * recorded (a single implicit range) `block` is already correct.
+   */
+  #nextQueriedBlock(block: number): number {
+    if (this.#ranges.length === 0) return block
+
+    for (const range of this.#ranges) {
+      if (range.to !== undefined && block > range.to) continue
+
+      return Math.max(block, range.from)
+    }
+
+    // Past every configured range — nothing further will be queried, so leave it where it is.
+    return block
   }
 
   /**

--- a/packages/pipes/src/targets/parquet/parquet-target.test.ts
+++ b/packages/pipes/src/targets/parquet/parquet-target.test.ts
@@ -5,8 +5,8 @@ import path from 'node:path'
 import { ParquetReader, ParquetSchema, ParquetWriter } from '@dsnp/parquetjs'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { createTarget } from '~/core/index.js'
-import { evmPortalStream } from '~/evm/index.js'
+import { type PortalRange, createTarget } from '~/core/index.js'
+import { evmPortalStream, evmQuery } from '~/evm/index.js'
 import { type MockPortal, type MockResponse, blockDecoder, mockPortal, testLogger } from '~/testing/index.js'
 
 import { PARQUET_ERROR_CODES, ParquetTargetError } from './errors.js'
@@ -44,6 +44,19 @@ const insertBlocks = ({
     'blocks',
     data.map((b) => ({ blockNumber: b.number, hash: b.hash, timestamp: b.timestamp })),
   )
+}
+
+/**
+ * A decoder over two disjoint ranges — `blockDecoder` only takes one. The blocks between them are
+ * never queried, which is what the coverage naming has to notice.
+ */
+function twoRangeDecoder(a: PortalRange, b: PortalRange) {
+  return evmQuery()
+    .addRange(a)
+    .addRange(b)
+    .addFields({ block: { number: true, hash: true, timestamp: true } })
+    .build()
+    .pipe((d) => d.flatMap((block) => block.header))
 }
 
 /** Builds a 200 response carrying the given block numbers, optionally with a finalized head. */
@@ -193,14 +206,15 @@ describe('parquetTarget', () => {
   })
 
   describe('read-back correctness', () => {
-    it('writes exactly the finalized rows with correct types and <min>-<max> filename', async () => {
+    it('writes exactly the finalized rows with correct types and a <from>-<to> coverage filename', async () => {
       portal = await mockPortal([blocksResponse([1, 2, 3], 3)])
 
       await evmPortalStream({ id: 'test', portal: portal.url, outputs: blockDecoder({ from: 0, to: 3 }) }).pipeTo(
         parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }),
       )
 
-      expect(await listDataFiles(dir, 'blocks')).toEqual(['000000000001-000000000003.parquet'])
+      // The stream starts at block 0, so the window covered is 0–3 even though no row sits at 0.
+      expect(await listDataFiles(dir, 'blocks')).toEqual(['000000000000-000000000003.parquet'])
       expect(await readBlocks(dir)).toEqual([
         { blockNumber: 1, hash: '0x1', timestamp: 1000 },
         { blockNumber: 2, hash: '0x2', timestamp: 2000 },
@@ -215,7 +229,7 @@ describe('parquetTarget', () => {
         parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }),
       )
 
-      const reader = await ParquetReader.openFile(path.join(dir, 'blocks', '000000000001-000000000001.parquet'))
+      const reader = await ParquetReader.openFile(path.join(dir, 'blocks', '000000000000-000000000001.parquet'))
       const raw = (await reader.getCursor().next()) as Record<string, unknown>
       await reader.close()
       expect(typeof raw['blockNumber']).toBe('bigint')
@@ -329,8 +343,10 @@ describe('parquetTarget', () => {
         }),
       )
 
+      // Every block from the stream's start (0) through the last checkpoint is claimed exactly
+      // once, with no gap between one file's `to` and the next file's `from`.
       expect(await listDataFiles(dir, 'blocks')).toEqual([
-        '000000000001-000000000001.parquet',
+        '000000000000-000000000001.parquet',
         '000000000002-000000000002.parquet',
         '000000000003-000000000003.parquet',
       ])
@@ -471,7 +487,7 @@ describe('parquetTarget', () => {
         { blockNumber: 7, hash: '0x7a', timestamp: 7000 },
       ])
       // The block-1 file was published before the reorg and must survive it untouched.
-      expect(await listDataFiles(dir, 'blocks')).toContain('000000000001-000000000001.parquet')
+      expect(await listDataFiles(dir, 'blocks')).toContain('000000000000-000000000001.parquet')
     })
 
     it('drops forked rows in every table buffer, not just the first (multi-table)', async () => {
@@ -539,8 +555,446 @@ describe('parquetTarget', () => {
     })
   })
 
+  describe('coverage naming', () => {
+    it("stretches a sparse table's next file back over windows that produced no rows", async () => {
+      // `sparse` has rows only in blocks 1 and 6, and each response is its own batch + checkpoint
+      // (maxBytes:1), so blocks 2–5 are windows it was present for but produced nothing in.
+      const sparseTable: ParquetTable = { table: 'sparse', schema: { blockNumber: { type: 'INT64' } } }
+      portal = await mockPortal([
+        blocksResponse([1], 1),
+        blocksResponse([2, 3], 3),
+        blocksResponse([4, 5], 5),
+        blocksResponse([6], 6),
+      ])
+
+      await evmPortalStream({
+        id: 'test',
+        portal: { url: portal.url, maxBytes: 1 },
+        outputs: blockDecoder({ from: 0, to: 6 }),
+      }).pipeTo(
+        parquetTarget({
+          dir,
+          tables: [BLOCKS_TABLE, sparseTable],
+          settings: { rollover: { maxBytes: 1 }, rowGroupSize: 1 },
+          onData: ({ store, data }) => {
+            insertBlocks({ store, data })
+            const rows = data.filter((b) => b.number === 1 || b.number === 6)
+            if (rows.length > 0) {
+              store.insert(
+                'sparse',
+                rows.map((b) => ({ blockNumber: b.number })),
+              )
+            }
+          },
+        }),
+      )
+
+      // Contiguous: 0–1 then 2–6. The empty windows are named by the file that comes after them,
+      // so "no file covers block 4" never happens just because block 4 had no rows.
+      expect(await listDataFiles(dir, 'sparse')).toEqual([
+        '000000000000-000000000001.parquet',
+        '000000000002-000000000006.parquet',
+      ])
+      // ...and no empty file was written for the windows sparse sat out.
+      expect((await readRows(dir, 'sparse', (raw) => Number(raw['blockNumber']))).sort((a, b) => a - b)).toEqual([1, 6])
+      // The dense table checkpoints on the same windows and stays contiguous too.
+      expect(await listDataFiles(dir, 'blocks')).toEqual([
+        '000000000000-000000000001.parquet',
+        '000000000002-000000000003.parquet',
+        '000000000004-000000000005.parquet',
+        '000000000006-000000000006.parquet',
+      ])
+    })
+
+    it('resumes coverage where the previous run left off, across a restart', async () => {
+      // Run 1: blocks 1–3, sparse writes only at block 1.
+      const sparseTable: ParquetTable = { table: 'sparse', schema: { blockNumber: { type: 'INT64' } } }
+      const tables = [BLOCKS_TABLE, sparseTable]
+      const onData = ({
+        store,
+        data,
+      }: {
+        store: ParquetStore
+        data: { number: number; hash: string; timestamp: number }[]
+      }) => {
+        insertBlocks({ store, data })
+        const rows = data.filter((b) => b.number === 1 || b.number === 5)
+        if (rows.length > 0) {
+          store.insert(
+            'sparse',
+            rows.map((b) => ({ blockNumber: b.number })),
+          )
+        }
+      }
+
+      portal = await mockPortal([blocksResponse([1], 1), blocksResponse([2, 3], 3)])
+      await evmPortalStream({
+        id: 'test',
+        portal: { url: portal.url, maxBytes: 1 },
+        outputs: blockDecoder({ from: 0, to: 3 }),
+      }).pipeTo(parquetTarget({ dir, tables, settings: { rollover: { maxBytes: 1 } }, onData }))
+      await portal.close()
+
+      // sparse published 0–1, sat out 2–3, then closed that tail at stream end — so run 1 leaves
+      // no unclaimed blocks behind and the next run starts cleanly at 4.
+      expect(await listDataFiles(dir, 'sparse')).toEqual([
+        '000000000000-000000000001.parquet',
+        '000000000002-000000000003.parquet',
+      ])
+      const persisted = JSON.parse(await readFile(path.join(dir, '_sqd_parquet_state.test.json'), 'utf8'))
+      expect(persisted.coverage).toEqual({ blocks: 4, sparse: 4 })
+
+      // Run 2 resumes at block 4 and sparse finally writes again at block 5.
+      portal = await mockPortal([blocksResponse([4, 5], 5)])
+      await evmPortalStream({
+        id: 'test',
+        portal: { url: portal.url, maxBytes: 1 },
+        outputs: blockDecoder({ from: 0, to: 5 }),
+      }).pipeTo(parquetTarget({ dir, tables, settings: { rollover: { maxBytes: 1 } }, onData }))
+
+      // Both tables cover 0–5 end to end, with no gap and no overlap across the restart boundary.
+      expect(await listDataFiles(dir, 'sparse')).toEqual([
+        '000000000000-000000000001.parquet',
+        '000000000002-000000000003.parquet',
+        '000000000004-000000000005.parquet',
+      ])
+      expect(await listDataFiles(dir, 'blocks')).toEqual([
+        '000000000000-000000000001.parquet',
+        '000000000002-000000000003.parquet',
+        '000000000004-000000000005.parquet',
+      ])
+      // The 2–3 file is sparse's tail marker: it claims the window without inventing rows.
+      expect((await readRows(dir, 'sparse', (raw) => Number(raw['blockNumber']))).sort((a, b) => a - b)).toEqual([1, 5])
+    })
+
+    it('leaves the gap between two disjoint ranges unclaimed', async () => {
+      // Blocks 2-4 are never queried, so no file may name them: "absent" has to keep meaning
+      // "not indexed". Stretching the second file back to block 2 would claim the pipe covered
+      // blocks it never asked the portal for.
+      portal = await mockPortal([blocksResponse([0, 1], 1), blocksResponse([5, 6], 6)])
+
+      await evmPortalStream({
+        id: 'test',
+        portal: { url: portal.url, maxBytes: 1 },
+        outputs: twoRangeDecoder({ from: 0, to: 1 }, { from: 5, to: 6 }),
+      }).pipeTo(
+        parquetTarget({ dir, tables: [BLOCKS_TABLE], settings: { rollover: { maxBytes: 1 } }, onData: insertBlocks }),
+      )
+
+      expect(await listDataFiles(dir, 'blocks')).toEqual([
+        '000000000000-000000000001.parquet',
+        '000000000005-000000000006.parquet',
+      ])
+    })
+
+    it('resumes a disjoint-range backfill interrupted between the ranges', async () => {
+      // The exact durable state a run leaves after finishing range [0,1] and crossing toward [5,6]:
+      // cursor at block 1, coverage at 5 (the next queried block past the 2-4 gap). The store
+      // unit tests prove a real run produces this pair; here we drive the resume path off it.
+      await mkdir(path.join(dir, 'blocks'), { recursive: true })
+      await writeFile(
+        path.join(dir, '_sqd_parquet_state.test.json'),
+        JSON.stringify({ id: 'test', cursor: { number: 1, hash: '0x1' }, coverage: { blocks: 5 } }),
+      )
+      await seedParquetFile(path.join(dir, 'blocks', '000000000000-000000000001.parquet'), [
+        { blockNumber: 1, hash: '0x1', timestamp: 1000 },
+      ])
+
+      // Resume must accept coverage 5 at cursor 1 (the gap justifies it) instead of rejecting the
+      // state, then finish the second range — leaving both windows tiled end to end.
+      portal = await mockPortal([blocksResponse([5, 6], 6)])
+      await evmPortalStream({
+        id: 'test',
+        portal: { url: portal.url, maxBytes: 1 },
+        outputs: twoRangeDecoder({ from: 0, to: 1 }, { from: 5, to: 6 }),
+      }).pipeTo(
+        parquetTarget({ dir, tables: [BLOCKS_TABLE], settings: { rollover: { maxBytes: 1 } }, onData: insertBlocks }),
+      )
+
+      expect(await listDataFiles(dir, 'blocks')).toEqual([
+        '000000000000-000000000001.parquet',
+        '000000000005-000000000006.parquet',
+      ])
+    })
+
+    it('resumes a run that crashed between publishing a stretched file and committing', async () => {
+      // The durable state left by a crash inside a checkpoint: cursor 5 committed, and the
+      // interrupted checkpoint at cursor 6 already renamed `sparse`'s stretched 2-6 file into
+      // place. `sparse` sat out the cursor-5 checkpoint, so its coverage start (2) is below the
+      // cursor and the remnant straddles it — the ordinary case, not a corrupt state file.
+      const sparseTable: ParquetTable = { table: 'sparse', schema: BLOCKS_TABLE.schema }
+      for (const table of ['blocks', 'sparse']) {
+        await mkdir(path.join(dir, table), { recursive: true })
+      }
+      await writeFile(
+        path.join(dir, '_sqd_parquet_state.test.json'),
+        JSON.stringify({ id: 'test', cursor: { number: 5, hash: '0x5' }, coverage: { blocks: 6, sparse: 2 } }),
+      )
+      await seedParquetFile(path.join(dir, 'blocks', '000000000000-000000000005.parquet'), [
+        { blockNumber: 5, hash: '0x5', timestamp: 5000 },
+      ])
+      await seedParquetFile(path.join(dir, 'sparse', '000000000000-000000000001.parquet'), [
+        { blockNumber: 1, hash: '0x1', timestamp: 1000 },
+      ])
+      await seedParquetFile(path.join(dir, 'sparse', '000000000002-000000000006.parquet'), [
+        { blockNumber: 6, hash: '0x6', timestamp: 6000 },
+      ])
+
+      portal = await mockPortal([blocksResponse([6, 7], 7)])
+      await evmPortalStream({
+        id: 'test',
+        portal: { url: portal.url, maxBytes: 1 },
+        outputs: blockDecoder({ from: 0, to: 7 }),
+      }).pipeTo(
+        parquetTarget({
+          dir,
+          tables: [BLOCKS_TABLE, sparseTable],
+          settings: { rollover: { maxBytes: 1 } },
+          onData: ({ store, data }) => {
+            insertBlocks({ store, data })
+            const rows = data.filter((b) => b.number === 7)
+            if (rows.length > 0) {
+              store.insert(
+                'sparse',
+                rows.map((b) => ({ blockNumber: b.number, hash: b.hash, timestamp: b.timestamp })),
+              )
+            }
+          },
+        }),
+      )
+
+      // The remnant was re-derived from the re-fetched blocks, and both tables tile 0-7 end to end.
+      expect(await listDataFiles(dir, 'blocks')).toEqual([
+        '000000000000-000000000005.parquet',
+        '000000000006-000000000007.parquet',
+      ])
+      expect(await listDataFiles(dir, 'sparse')).toEqual([
+        '000000000000-000000000001.parquet',
+        '000000000002-000000000007.parquet',
+      ])
+      expect((await readRows(dir, 'sparse', (raw) => Number(raw['blockNumber']))).sort((a, b) => a - b)).toEqual([1, 7])
+    })
+
+    it('does not fail a row keyed below the window that emitted it', async () => {
+      // An OHLC-style aggregate keyed at its window's FIRST block but emitted once the window
+      // closes. The row lands in a later file than its own block number — legitimate, because the
+      // filename states which blocks were processed, not where the rows point.
+      portal = await mockPortal([blocksResponse([1], 1), blocksResponse([2, 3], 3)])
+
+      await evmPortalStream({
+        id: 'test',
+        portal: { url: portal.url, maxBytes: 1 },
+        outputs: blockDecoder({ from: 0, to: 3 }),
+      }).pipeTo(
+        parquetTarget({
+          dir,
+          tables: [BLOCKS_TABLE],
+          settings: { rollover: { intervalBlocks: 1 } },
+          onData: ({ store, data }) => {
+            store.insert(
+              'blocks',
+              data.map((b) => ({
+                blockNumber: b.number === 2 ? 1 : b.number,
+                hash: b.hash,
+                timestamp: b.timestamp,
+              })),
+            )
+          },
+        }),
+      )
+
+      // The back-keyed row is in the 2–3 file; nothing threw and no row was dropped.
+      expect((await readBlocks(dir)).map((r) => r.blockNumber).sort((a, b) => a - b)).toEqual([1, 1, 3])
+      expect(await listDataFiles(dir, 'blocks')).toEqual([
+        '000000000000-000000000001.parquet',
+        '000000000002-000000000003.parquet',
+      ])
+    })
+
+    it('starts coverage at the stream start, not block 0, for a backfill from a non-zero block', async () => {
+      portal = await mockPortal([blocksResponse([100, 101], 101)])
+
+      await evmPortalStream({ id: 'test', portal: portal.url, outputs: blockDecoder({ from: 100, to: 101 }) }).pipeTo(
+        parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }),
+      )
+
+      // Naming this 0-101 would claim 100 blocks the pipe never looked at.
+      expect(await listDataFiles(dir, 'blocks')).toEqual(['000000000100-000000000101.parquet'])
+    })
+
+    it('does not reach back past the cursor when resuming state that predates coverage tracking', async () => {
+      // Legacy state: a cursor, no `coverage` field. Blocks 0–2 belong to whatever the old run
+      // wrote under row-based names, so the first new file must start at 3 — not at the stream's
+      // configured start of 0, which would re-claim them.
+      await writeFile(
+        path.join(dir, '_sqd_parquet_state.test.json'),
+        JSON.stringify({ cursor: { number: 2, hash: '0x2' } }),
+      )
+      portal = await mockPortal([blocksResponse([3, 4], 4)])
+
+      await evmPortalStream({ id: 'test', portal: portal.url, outputs: blockDecoder({ from: 0, to: 4 }) }).pipeTo(
+        parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }),
+      )
+
+      expect(await listDataFiles(dir, 'blocks')).toEqual(['000000000003-000000000004.parquet'])
+    })
+
+    it('closes a tail owed by the persisted state even when the resume yields no batches', async () => {
+      // The state a run leaves when it crashes between its final regular checkpoint and the
+      // stream-end checkpoint: cursor already at the end of the range, `blocks` still owing 2-3.
+      // The resumed run gets zero batches (the backfill is complete), so no batch ever arrives to
+      // seed coverage — the tail must close from the persisted map alone, or it stays unclaimed
+      // on every subsequent run.
+      await mkdir(path.join(dir, 'blocks'), { recursive: true })
+      await writeFile(
+        path.join(dir, '_sqd_parquet_state.test.json'),
+        JSON.stringify({ id: 'test', cursor: { number: 3, hash: '0x3' }, coverage: { blocks: 2 } }),
+      )
+      await seedParquetFile(path.join(dir, 'blocks', '000000000000-000000000001.parquet'), [
+        { blockNumber: 1, hash: '0x1', timestamp: 1000 },
+      ])
+
+      portal = await mockPortal([])
+      await evmPortalStream({ id: 'test', portal: portal.url, outputs: blockDecoder({ from: 0, to: 3 }) }).pipeTo(
+        parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }),
+      )
+
+      expect(await listDataFiles(dir, 'blocks')).toEqual([
+        '000000000000-000000000001.parquet',
+        '000000000002-000000000003.parquet',
+      ])
+      // The tail file claims the window without inventing rows.
+      expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1])
+      const persisted = JSON.parse(await readFile(path.join(dir, '_sqd_parquet_state.test.json'), 'utf8'))
+      expect(persisted.coverage).toEqual({ blocks: 4 })
+    })
+
+    it('holds rows for an unnameable window across no-op rotations until the boundary moves', async () => {
+      // The finalized head sticks at 1 while later batches release back-keyed rows into a writer
+      // whose window cannot be named yet (coverage 2 > boundary 1). Size-rotation keeps firing;
+      // those checkpoints publish nothing and skip the durable-state rewrite, and the held rows
+      // must survive to the file that finally names their window.
+      portal = await mockPortal([blocksResponse([1], 1), blocksResponse([2], 1), blocksResponse([3, 4], 4)])
+
+      await evmPortalStream({
+        id: 'test',
+        portal: { url: portal.url, maxBytes: 1 },
+        outputs: blockDecoder({ from: 0, to: 4 }),
+      }).pipeTo(
+        parquetTarget({
+          dir,
+          tables: [BLOCKS_TABLE],
+          settings: { rollover: { maxBytes: 1 }, rowGroupSize: 1 },
+          onData: ({ store, data }) => {
+            // Every row keyed at block 1 (an aggregate re-stamped to an already-final block), so
+            // rows keep releasing while the boundary cursor stays pinned at 1.
+            store.insert(
+              'blocks',
+              data.map((b) => ({ blockNumber: 1, hash: b.hash, timestamp: b.timestamp })),
+            )
+          },
+        }),
+      )
+
+      expect(await listDataFiles(dir, 'blocks')).toEqual([
+        '000000000000-000000000001.parquet',
+        '000000000002-000000000004.parquet',
+      ])
+      expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1, 1, 1, 1])
+    })
+  })
+
+  describe('coverage naming across gaps (store-level)', () => {
+    const newStore = async () => {
+      await mkdir(path.join(dir, 'blocks'), { recursive: true })
+
+      return new ParquetStore({ dir, tables: [BLOCKS_TABLE], rowGroupSize: 100, defaultCodec: 'SNAPPY' })
+    }
+
+    it('clamps a resume fallback that lands in a gap up to the next queried block', async () => {
+      // Legacy resume (no persisted coverage) at the end of range [0,1]: fallbackStart is cursor+1=2,
+      // which sits in the never-queried gap 2-4. The next file must start at 5, not 2 — a `2-6` name
+      // would claim blocks 2-4 the pipe never fetched.
+      const store = await newStore()
+      store.seedCoverage(undefined, 2, [
+        { from: 0, to: 1 },
+        { from: 5, to: 6 },
+      ])
+
+      const published = await store.publishAll(6, { closeTails: true })
+      expect(published.map((p) => `${p.from}-${p.to}`)).toEqual(['5-6'])
+    })
+
+    it('does not fold a skipped empty middle range into the next file', async () => {
+      // Ranges [0,1], [5,6] (produces no batch, so it is skipped), [10,11]. After [0,1] closes,
+      // coverage advances to 5; entering [10,11] must lift it to 10 so the next file is `10-11`, not
+      // `5-11` — the latter would claim the never-queried gap 7-9.
+      const store = await newStore()
+      store.seedCoverage(undefined, 0, [
+        { from: 0, to: 1 },
+        { from: 5, to: 6 },
+        { from: 10, to: 11 },
+      ])
+
+      await store.publishAll(1, { closeTails: true })
+      store.advanceCoverageInto(10)
+      const published = await store.publishAll(11, { closeTails: true })
+      expect(published.map((p) => `${p.from}-${p.to}`)).toEqual(['10-11'])
+    })
+
+    it('leaves a table owing a window within the current range untouched', async () => {
+      // advanceCoverageInto must only lift a coverage start that lags BELOW the range it is entering;
+      // a table mid-range (owing a sat-out window) keeps its earlier start so it still stretches.
+      const store = await newStore()
+      store.seedCoverage(undefined, 0, [{ from: 0, to: 10 }])
+
+      store.advanceCoverageInto(0)
+      const published = await store.publishAll(4, { closeTails: true })
+      expect(published.map((p) => `${p.from}-${p.to}`)).toEqual(['0-4'])
+    })
+
+    it('accepts a persisted coverage start that a query gap justifies', async () => {
+      // Ranges [0,1] and [5,6], resume at cursor+1 = 2 (in the gap). The furthest a file could start
+      // is nextQueriedBlock(2) = 5, so a persisted 5 is exactly consistent — not ahead.
+      const store = await newStore()
+      store.seedCoverage({ blocks: 5 }, 2, [
+        { from: 0, to: 1 },
+        { from: 5, to: 6 },
+      ])
+
+      const published = await store.publishAll(6, { closeTails: true })
+      expect(published.map((p) => `${p.from}-${p.to}`)).toEqual(['5-6'])
+    })
+
+    it('clamps a persisted coverage start ahead of what the cursor allows, and reports it', async () => {
+      // Single range 0-100, resume at cursor+1 = 4. A persisted start of 50 cannot be consistent
+      // with that cursor (no gap justifies it). Honouring it would leave blocks 4-49 named by no
+      // file at all, so it is clamped back to 4 — and the caller is told, since the usual cause is
+      // an edit to the configured ranges.
+      const store = await newStore()
+
+      const clamped = store.seedCoverage({ blocks: 50 }, 4, [{ from: 0, to: 100 }])
+
+      expect(clamped).toEqual([{ table: 'blocks', persisted: 50, seeded: 4 }])
+      const published = await store.publishAll(60, { closeTails: true })
+      expect(published.map((p) => `${p.from}-${p.to}`)).toEqual(['4-60'])
+    })
+
+    it('re-covers the blocks a removed gap exposed when the query ranges change', async () => {
+      // Run 1 queried [0,1] + [5,6] and stopped at cursor 1 with coverage 5. Run 2 widens that to a
+      // single [0,10]: blocks 2-4 are now fetched, so the next file must claim them rather than
+      // honour a start that referred to a gap which no longer exists.
+      const store = await newStore()
+
+      store.seedCoverage({ blocks: 5 }, 2, [{ from: 0, to: 10 }])
+
+      const published = await store.publishAll(10, { closeTails: true })
+      expect(published.map((p) => `${p.from}-${p.to}`)).toEqual(['2-10'])
+    })
+  })
+
   describe('empty table', () => {
-    it('produces no file for a declared table that receives no rows', async () => {
+    it('claims its window with a zero-row file when a declared table receives no rows', async () => {
       const emptyTable: ParquetTable = { table: 'empty', schema: { blockNumber: { type: 'INT64' } } }
       portal = await mockPortal([blocksResponse([1, 2, 3], 3)])
 
@@ -549,8 +1003,35 @@ describe('parquetTarget', () => {
       )
 
       expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1, 2, 3])
-      // The empty table's directory exists but holds no parquet file.
-      expect(await listDataFiles(dir, 'empty')).toEqual([])
+      // Blocks 0-3 WERE indexed, they just held nothing for this table — so one file says exactly
+      // that. Publishing nothing would be indistinguishable from never having indexed the range.
+      expect(await listDataFiles(dir, 'empty')).toEqual(['000000000000-000000000003.parquet'])
+
+      const reader = await ParquetReader.openFile(path.join(dir, 'empty', '000000000000-000000000003.parquet'))
+      expect(Number(reader.getRowCount())).toBe(0)
+      await reader.close()
+    })
+
+    it('claims one window per run, not one per checkpoint', async () => {
+      // Four checkpoints, but `empty` sits out all of them: the stretch means it owes a single
+      // file at stream end rather than a degenerate one per window.
+      const emptyTable: ParquetTable = { table: 'empty', schema: { blockNumber: { type: 'INT64' } } }
+      portal = await mockPortal([blocksResponse([1], 1), blocksResponse([2], 2), blocksResponse([3], 3)])
+
+      await evmPortalStream({
+        id: 'test',
+        portal: { url: portal.url, maxBytes: 1 },
+        outputs: blockDecoder({ from: 0, to: 3 }),
+      }).pipeTo(
+        parquetTarget({
+          dir,
+          tables: [BLOCKS_TABLE, emptyTable],
+          settings: { rollover: { maxBytes: 1 }, rowGroupSize: 1 },
+          onData: insertBlocks,
+        }),
+      )
+
+      expect(await listDataFiles(dir, 'empty')).toEqual(['000000000000-000000000003.parquet'])
     })
   })
 
@@ -609,9 +1090,9 @@ describe('parquetTarget', () => {
         { blockNumber: 3, logIndex: 0, address: '0xa3' },
         { blockNumber: 3, logIndex: 1, address: '0xb3' },
       ])
-      // Each table published its own single file covering blocks 1–3.
-      expect(await listDataFiles(dir, 'blocks')).toEqual(['000000000001-000000000003.parquet'])
-      expect(await listDataFiles(dir, 'logs')).toEqual(['000000000001-000000000003.parquet'])
+      // Each table published its own single file covering the same window, blocks 0–3.
+      expect(await listDataFiles(dir, 'blocks')).toEqual(['000000000000-000000000003.parquet'])
+      expect(await listDataFiles(dir, 'logs')).toEqual(['000000000000-000000000003.parquet'])
     })
   })
 
@@ -689,7 +1170,7 @@ describe('parquetTarget', () => {
   })
 
   describe('ParquetSegmentWriter', () => {
-    it('lazy-opens, tracks range/rowCount, and publishes <min>-<max>', async () => {
+    it('lazy-opens, tracks rowCount, and names the file for the coverage range it is given', async () => {
       const segDir = path.join(dir, 'seg')
       await mkdir(segDir, { recursive: true })
       const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
@@ -698,18 +1179,63 @@ describe('parquetTarget', () => {
       expect(writer.isOpen).toBe(false)
       expect(await writer.size()).toBe(0)
 
-      await writer.appendRow({ blockNumber: 5 }, 5)
-      await writer.appendRow({ blockNumber: 8 }, 8)
+      await writer.appendRow({ blockNumber: 5 })
+      await writer.appendRow({ blockNumber: 8 })
       expect(writer.isOpen).toBe(true)
       expect(writer.rowCount).toBe(2)
-      expect(writer.minBlock).toBe(5)
-      expect(writer.maxBlock).toBe(8)
       expect(await writer.size()).toBeGreaterThan(0)
 
-      const published = await writer.publish()
-      expect(published.path.endsWith('000000000005-000000000008.parquet')).toBe(true)
+      // Rows span 5–8, but the window covered is 2–10: the name follows the window.
+      const published = await writer.publish({ from: 2, to: 10 })
+      expect(published.path.endsWith('000000000002-000000000010.parquet')).toBe(true)
       expect(published.rows).toBe(2)
       expect(published.bytes).toBeGreaterThan(0)
+    })
+
+    it('accepts rows keyed outside the window, since the name states coverage not content', async () => {
+      const segDir = path.join(dir, 'seg')
+      await mkdir(segDir, { recursive: true })
+      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
+
+      const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
+      // An aggregate stamped with its window's first block, emitted while covering a later window.
+      await writer.appendRow({ blockNumber: 1 })
+
+      const published = await writer.publish({ from: 6, to: 10 })
+      expect(published.path.endsWith('000000000006-000000000010.parquet')).toBe(true)
+      expect(published.rows).toBe(1)
+    })
+
+    it('publishes a zero-row segment so a table can claim a window it produced nothing in', async () => {
+      const segDir = path.join(dir, 'seg')
+      await mkdir(segDir, { recursive: true })
+      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
+
+      const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
+      expect(writer.isOpen).toBe(false)
+
+      const published = await writer.publish({ from: 2, to: 4 })
+      expect(published.path.endsWith('000000000002-000000000004.parquet')).toBe(true)
+      expect(published.rows).toBe(0)
+
+      // A real, readable Parquet file — schema and footer present, just no rows.
+      const reader = await ParquetReader.openFile(published.path)
+      expect(Number(reader.getRowCount())).toBe(0)
+      expect(reader.getSchema().fieldList.length).toBe(1)
+      await reader.close()
+    })
+
+    it('refuses an inverted coverage range', async () => {
+      const segDir = path.join(dir, 'seg')
+      await mkdir(segDir, { recursive: true })
+      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
+
+      const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
+      await writer.appendRow({ blockNumber: 5 })
+
+      await expect(writer.publish({ from: 10, to: 4 })).rejects.toThrowError(/inverted coverage range/)
+      await writer.discard()
+      expect((await readdir(segDir)).filter((f) => f.startsWith('.tmp-'))).toEqual([])
     })
 
     it('refuses to overwrite an existing file (collision)', async () => {
@@ -718,12 +1244,12 @@ describe('parquetTarget', () => {
       const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
 
       const first = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
-      await first.appendRow({ blockNumber: 1 }, 1)
-      await first.publish()
+      await first.appendRow({ blockNumber: 1 })
+      await first.publish({ from: 0, to: 1 })
 
       const second = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
-      await second.appendRow({ blockNumber: 1 }, 1)
-      await expect(second.publish()).rejects.toThrowError(/Refusing to overwrite/)
+      await second.appendRow({ blockNumber: 1 })
+      await expect(second.publish({ from: 0, to: 1 })).rejects.toThrowError(/Refusing to overwrite/)
       await second.discard()
     })
 
@@ -733,7 +1259,7 @@ describe('parquetTarget', () => {
       const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
 
       const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
-      await writer.appendRow({ blockNumber: 1 }, 1)
+      await writer.appendRow({ blockNumber: 1 })
       await writer.discard()
 
       expect((await readdir(segDir)).filter((f) => f.startsWith('.tmp-'))).toEqual([])
@@ -746,7 +1272,7 @@ describe('parquetTarget', () => {
       const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
 
       const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
-      await writer.appendRow({ blockNumber: 1 }, 1)
+      await writer.appendRow({ blockNumber: 1 })
       await writer.discard()
       await writer.discard()
 
@@ -800,6 +1326,121 @@ describe('parquetTarget', () => {
         cursor: { number: 7, hash: '0x7' },
         finalized: { number: 7, hash: '0x7f' },
       })
+    })
+
+    it('refuses a data file that straddles the cursor without destroying it first', async () => {
+      // A restored older state file, or a hand-rewound cursor: the committed cursor is block 1, but
+      // a data file covers 0-3 — it straddles the cursor, so it holds committed data (blocks <= 1) a
+      // resume from block 2 would never re-fetch. Deleting it would lose that data.
+      await writeFile(
+        path.join(dir, '_sqd_parquet_state.json'),
+        JSON.stringify({ cursor: { number: 1, hash: '0x1' }, coverage: { blocks: 4 } }),
+      )
+      const blocksDir = path.join(dir, 'blocks')
+      await mkdir(blocksDir, { recursive: true })
+      await seedParquetFile(path.join(blocksDir, '000000000000-000000000003.parquet'), [
+        { blockNumber: 3, hash: '0x3', timestamp: 0 },
+      ])
+      const state = new ParquetState({ dir, tables: ['blocks'], logger: testLogger() })
+
+      await expect(state.getCursor()).rejects.toThrowError(/straddles the committed cursor/)
+      // The point of refusing first: the file is still there to be recovered from by hand.
+      expect(await listDataFiles(dir, 'blocks')).toEqual(['000000000000-000000000003.parquet'])
+    })
+
+    it("deletes a sparse table's stretched remnant, which straddles the cursor by construction", async () => {
+      // The ordinary crash window, not a corrupt state file: the checkpoint at cursor 6 published
+      // `sparse`'s stretched 2-6 file and died before saveCursor, so the state still says cursor 5.
+      // `sparse` sat out the cursor-5 checkpoint, which is exactly why its coverage start (2) is
+      // below the cursor and its next file straddles it. Refusing here would make an ordinary crash
+      // unrecoverable; the file holds only rows from blocks above the cursor, which a resume
+      // re-fetches and regenerates.
+      await writeFile(
+        path.join(dir, '_sqd_parquet_state.json'),
+        JSON.stringify({ cursor: { number: 5, hash: '0x5' }, coverage: { blocks: 6, sparse: 2 } }),
+      )
+      for (const table of ['blocks', 'sparse']) {
+        await mkdir(path.join(dir, table), { recursive: true })
+      }
+      await seedParquetFile(path.join(dir, 'sparse', '000000000002-000000000006.parquet'), [
+        { blockNumber: 6, hash: '0x6', timestamp: 0 },
+      ])
+      await seedParquetFile(path.join(dir, 'blocks', '000000000000-000000000005.parquet'), [
+        { blockNumber: 5, hash: '0x5', timestamp: 0 },
+      ])
+      const state = new ParquetState({ dir, tables: ['blocks', 'sparse'], logger: testLogger() })
+
+      expect(await state.getCursor()).toEqual({ latest: { number: 5, hash: '0x5' }, finalized: null })
+      expect(await listDataFiles(dir, 'sparse')).toEqual([])
+      // The committed file, which ends exactly at the cursor, is untouched.
+      expect(await listDataFiles(dir, 'blocks')).toEqual(['000000000000-000000000005.parquet'])
+    })
+
+    it('still refuses a straddling file that the persisted coverage does not explain', async () => {
+      // Same straddle shape as the remnant above, but the coverage map says `sparse` was next due
+      // to publish from block 4 — so the 2-6 file was written by a different run, and its blocks
+      // 2-3 are committed data no resume would re-fetch.
+      await writeFile(
+        path.join(dir, '_sqd_parquet_state.json'),
+        JSON.stringify({ cursor: { number: 5, hash: '0x5' }, coverage: { sparse: 4 } }),
+      )
+      await mkdir(path.join(dir, 'sparse'), { recursive: true })
+      await seedParquetFile(path.join(dir, 'sparse', '000000000002-000000000006.parquet'), [
+        { blockNumber: 6, hash: '0x6', timestamp: 0 },
+      ])
+      const state = new ParquetState({ dir, tables: ['sparse'], logger: testLogger() })
+
+      await expect(state.getCursor()).rejects.toThrowError(/straddles the committed cursor/)
+      expect(await listDataFiles(dir, 'sparse')).toEqual(['000000000002-000000000006.parquet'])
+    })
+
+    it('accepts coverage ahead of the cursor when a query gap justifies it (no straddling file)', async () => {
+      // Regression: a disjoint-range backfill stopped at a range boundary persists cursor=1 with
+      // coverage=5 (the next queried block after the 2-4 gap between ranges [0,1] and [5,6]). The
+      // [0,1] file ends exactly at the cursor, so nothing straddles it — resume must accept this.
+      await writeFile(
+        path.join(dir, '_sqd_parquet_state.json'),
+        JSON.stringify({ cursor: { number: 1, hash: '0x1' }, coverage: { blocks: 5 } }),
+      )
+      const blocksDir = path.join(dir, 'blocks')
+      await mkdir(blocksDir, { recursive: true })
+      await seedParquetFile(path.join(blocksDir, '000000000000-000000000001.parquet'), [
+        { blockNumber: 1, hash: '0x1', timestamp: 0 },
+      ])
+      const state = new ParquetState({ dir, tables: ['blocks'], logger: testLogger() })
+
+      expect(await state.getCursor()).toEqual({ latest: { number: 1, hash: '0x1' }, finalized: null })
+      expect(state.coverage).toEqual({ blocks: 5 })
+      // The committed file is untouched.
+      expect(await listDataFiles(dir, 'blocks')).toEqual(['000000000000-000000000001.parquet'])
+    })
+
+    it('accepts coverage exactly one block past the cursor (the normal case)', async () => {
+      await writeFile(
+        path.join(dir, '_sqd_parquet_state.json'),
+        JSON.stringify({ cursor: { number: 3, hash: '0x3' }, coverage: { blocks: 4 } }),
+      )
+      const state = new ParquetState({ dir, tables: ['blocks'], logger: testLogger() })
+
+      expect(await state.getCursor()).toEqual({ latest: { number: 3, hash: '0x3' }, finalized: null })
+      expect(state.coverage).toEqual({ blocks: 4 })
+    })
+
+    it('points a legacy (no-coverage) straddle at the one-file remedy', async () => {
+      // Pre-upgrade state: a cursor, no coverage map. The old version's crash remnant can itself
+      // straddle the cursor (a back-keyed row puts a row-min/max name's `from` at or below it),
+      // and with nothing to explain the straddle the refusal fires on the first post-upgrade
+      // start. The message must offer the single-file remedy for that case, not only the
+      // delete-the-table one.
+      await writeFile(path.join(dir, '_sqd_parquet_state.json'), JSON.stringify({ cursor: { number: 2, hash: '0x2' } }))
+      await mkdir(path.join(dir, 'blocks'), { recursive: true })
+      await seedParquetFile(path.join(dir, 'blocks', '000000000002-000000000004.parquet'), [
+        { blockNumber: 2, hash: '0x2', timestamp: 0 },
+      ])
+      const state = new ParquetState({ dir, tables: ['blocks'], logger: testLogger() })
+
+      await expect(state.getCursor()).rejects.toThrowError(/deleting just this file and restarting is enough/)
+      expect(await listDataFiles(dir, 'blocks')).toEqual(['000000000002-000000000004.parquet'])
     })
 
     it('throws (does not silently leave overlap) when an over-cursor file cannot be deleted', async () => {

--- a/packages/pipes/src/targets/parquet/parquet-target.ts
+++ b/packages/pipes/src/targets/parquet/parquet-target.ts
@@ -6,6 +6,7 @@ import {
   type HookContext,
   type Logger,
   type Metrics,
+  type Range,
   createTarget,
   formatBlock,
   formatNumber,
@@ -62,10 +63,37 @@ type ParquetTargetMetrics = {
  * {@link finalizationBuffer}) and only appends a row once its block is at or below the
  * portal's finalized head. A reorg drops the in-memory buffer; published files are never touched.
  *
+ * **Key a row at the last block it depends on.** The buffer holds a row until *its own block
+ * column* finalizes — that column is the row's declaration of "I am safe once this block can no
+ * longer reorg". For a plain per-event row that is simply the event's block. For an **aggregate**
+ * (an OHLC candle, a rolling sum) it must be the *last* block in the window, not the first: a candle
+ * over blocks 1–5 keyed at block 1 is released as soon as block 1 finalizes, so if blocks 2–5 later
+ * reorg the already-written file keeps a candle computed from a dead chain (and a recomputed one is
+ * appended beside it). Keyed at block 5 it stays buffered until the whole window finalizes, and a
+ * reorg drops and recomputes it cleanly.
+ *
  * **Constant memory.** Finalized rows stream straight to a temp file and the file rotates by byte
  * size, so a multi-gigabyte finalized backfill never lands wholly in RAM (`@dsnp/parquetjs`
  * flushes row groups to disk incrementally — verified by the Step 0 spike). `rowGroupSize` bounds
  * the writer's in-memory buffer.
+ *
+ * **Coverage-named files.** Files are named `<from>-<to>.parquet` for the block window they
+ * **cover** — the window the pipe processed — not for the min/max block of the rows inside. Within
+ * a configured query range, a table's files tile it end to end: a table with no rows for a while
+ * publishes nothing and names the whole span when it next writes, and whatever span is still owed
+ * when the stream ends is claimed by a zero-row file. So for files written by this version, a block
+ * range absent from a table means "not indexed", never "indexed, no data".
+ *
+ * Three things that follow, and are easy to get wrong:
+ * - Gaps **between** configured ranges stay absent — those blocks are never fetched, so no file
+ *   claims them. That is the same statement, not an exception to it.
+ * - The name bounds coverage, not content. `onData` may key a row outside the window that emitted
+ *   it (an aggregate stamped with its window's first block), so do not use the filename to locate
+ *   a given block's rows — use the row-group statistics in the footer, which is what DuckDB, Spark
+ *   and Athena prune on anyway.
+ * - Files written **before** this version were named for their rows' min/max, are indistinguishable
+ *   by name, and their gaps are not healed retroactively. The guarantee covers the range written
+ *   from the upgrade onward.
  *
  * **Crash safety.** A writer holding ≥1 finalized row is always published at the very next
  * checkpoint, and the persisted cursor advances only at a checkpoint — so no finalized row is ever
@@ -82,6 +110,8 @@ type ParquetTargetMetrics = {
  * Known trade-offs:
  * - One busy table's checkpoint rotates **all** open writers, so low-volume tables get smaller
  *   files (the "small files" problem) — inherent to a single global cursor.
+ * - A table that produces no rows at all still gets one zero-row file per run (and one per query
+ *   range), which is the price of coverage being readable off the filenames.
  * - Byte-only rotation can stall the cursor on a slow live tail (finalized data stays invisible
  *   until the file closes; a crash re-fetches more). Set `rollover.intervalMs`/`intervalBlocks`
  *   for live tailing.
@@ -140,14 +170,32 @@ export function parquetTarget<T>(options: {
         // Captured for the checkpoint closure's metric labels — assigned on the first batch.
         let metricsId = ''
         let lastBoundary: BlockCursor | undefined = startCursor
+        // The configured range the stream is currently inside; a change means a gap was skipped.
+        let openRange: Range | undefined
         // Latest (source-clamped) finalized head, persisted alongside the cursor at each checkpoint
         // so the source can re-seed its watermark after an unclean restart. Seeded from resume state.
         let lastFinalized: BlockCursor | undefined = resumeState?.finalized ?? undefined
 
-        const checkpoint = async (cursor: BlockCursor | undefined, reason: string): Promise<void> => {
+        const checkpoint = async (
+          cursor: BlockCursor,
+          reason: string,
+          closeTails = false,
+          owingTables?: string[],
+        ): Promise<void> => {
           const startedMs = Date.now()
-          const published = await store.publishAll()
-          if (cursor) await state.saveCursor(cursor, lastFinalized)
+          // Files are named for the window they cover, which ends at the cursor being committed —
+          // so publish must see the same cursor that is about to be persisted.
+          const published = await store.publishAll(cursor.number, { closeTails, tables: owingTables })
+
+          // A stalled boundary can re-trigger rotation on every batch while no writer has a window
+          // to name yet; rewriting an identical state file (two fsyncs) each time buys nothing.
+          if (published.length === 0 && cursor.number === lastCheckpointBlock) {
+            lastCheckpointMs = Date.now()
+
+            return
+          }
+
+          await state.saveCursor(cursor, lastFinalized, store.coverage())
 
           if (metrics) {
             for (const file of published) {
@@ -158,16 +206,16 @@ export function parquetTarget<T>(options: {
           }
 
           lastCheckpointMs = Date.now()
-          if (cursor) lastCheckpointBlock = cursor.number
+          lastCheckpointBlock = cursor.number
 
           if (published.length > 0) {
             const rows = published.reduce((s, f) => s + f.rows, 0)
             const bytes = published.reduce((s, f) => s + f.bytes, 0)
             logger.info({
-              message: `checkpoint (${reason}): published ${published.length} file(s), ${formatNumber(rows)} rows / ${humanBytes(bytes)}${cursor ? `, cursor → block ${formatBlock(cursor.number)}` : ''}`,
+              message: `checkpoint (${reason}): published ${published.length} file(s), ${formatNumber(rows)} rows / ${humanBytes(bytes)}, cursor → block ${formatBlock(cursor.number)}`,
               files: published.map((f) => f.path),
             })
-          } else if (cursor) {
+          } else {
             logger.debug(`checkpoint (${reason}): no open files, cursor → block ${formatBlock(cursor.number)}`)
           }
         }
@@ -176,6 +224,57 @@ export function parquetTarget<T>(options: {
           if (!metrics) {
             metrics = registerParquetMetrics(ctx.metrics)
             metricsId = ctx.id
+            // Seeded on the first batch because `stream.state` only exists once the source has
+            // resolved its ranges. Fallback for a table the state doesn't cover yet:
+            //   - Resuming: cursor + 1. `initial` is the *configured* query start (pre-resume), so
+            //     using it here would let the first file claim blocks an earlier run already wrote.
+            //   - Cold start: `initial` — the stream's configured start. Hardcoding 0 instead would
+            //     make a backfill from block N claim to cover 0..N of blocks it never looked at.
+            const clamped = store.seedCoverage(
+              state.coverage,
+              startCursor ? startCursor.number + 1 : ctx.stream.state.initial,
+              ctx.stream.state.ranges,
+            )
+            for (const { table, persisted, seeded } of clamped) {
+              logger.warn(
+                `Persisted coverage for table '${table}' starts at block ${formatBlock(persisted)}, ahead of ` +
+                  `block ${formatBlock(seeded)} — the furthest a file could start for the committed cursor. ` +
+                  `Seeding ${formatBlock(seeded)} instead, so the blocks after the cursor stay claimed. This is ` +
+                  `expected if the configured query ranges changed since the state file was written.`,
+              )
+            }
+          }
+
+          // Crossing from one configured range into a later one: the blocks between them are never
+          // fetched, so every table must close its coverage at the old range's end before anything
+          // names a window on the far side of the gap. The tail closes at `lastBoundary` itself and
+          // never at a re-labelled copy of it — a cursor pairing one block's number with another
+          // block's hash would be persisted, and the next resume would hand the portal that hash as
+          // its parent. `lastBoundary` is the previous batch's min(finalized, current) and
+          // `openRange` is the range that batch's `current` fell in, so it is inside the range;
+          // the guard covers `openRange` having gone stale over a batch outside every range.
+          const range = rangeOf(ctx.stream.state.ranges, ctx.stream.state.current.number)
+          const tail = lastBoundary
+          if (
+            openRange !== undefined &&
+            range !== undefined &&
+            range.from > openRange.from &&
+            tail !== undefined &&
+            tail.number <= (openRange.to ?? Number.POSITIVE_INFINITY)
+          ) {
+            const owing = store.tablesOwingCoverage(tail.number)
+            if (owing.length > 0) {
+              await checkpoint(tail, 'range-end', true, owing)
+            }
+          }
+          openRange = range ?? openRange
+
+          // A configured range the stream skipped entirely (it yielded no batch, so the crossing
+          // above never fired for it) must not be folded into the next file's coverage. Advance any
+          // table still lagging below the current range's start up to it — this also runs on the
+          // first batch after a restart, where there is no `openRange` transition to detect.
+          if (range !== undefined) {
+            store.advanceCoverageInto(range.from)
           }
 
           // 1. user stages rows via store.insert(...)
@@ -211,9 +310,24 @@ export function parquetTarget<T>(options: {
           if (reasons.length > 0) await checkpoint(boundaryCursor, reasons.join('+'))
         }
 
-        // 5. stream end — flush any open writers and persist the final cursor.
-        if (lastBoundary !== undefined && (store.hasOpenWriters || lastBoundary.number > lastCheckpointBlock)) {
-          await checkpoint(lastBoundary, 'stream-end')
+        // 5. stream end — flush open writers, close every table's trailing coverage and persist the
+        //    final cursor. Tails must close here: stretching only claims a sat-out window once the
+        //    table publishes again, and after the stream ends it never will.
+        if (lastBoundary !== undefined) {
+          // A resume can complete without a single batch (backfill already done), leaving the
+          // first-batch seeding unrun while the persisted map still owes a tail from a run that
+          // crashed between its last checkpoint and stream end. Seed from the map alone: an owed
+          // [coverage, cursor] pair never spans an un-queried gap (coverage is advanced into a
+          // range before any checkpoint inside it), and the next run that does see batches
+          // re-clamps every start through the real ranges.
+          if (!metrics && startCursor) {
+            store.seedCoverage(state.coverage, startCursor.number + 1)
+          }
+
+          const owing = store.tablesOwingCoverage(lastBoundary.number)
+          if (owing.length > 0 || store.hasOpenWriters || lastBoundary.number > lastCheckpointBlock) {
+            await checkpoint(lastBoundary, 'stream-end', true, owing)
+          }
         }
       } finally {
         await store.close()
@@ -224,6 +338,11 @@ export function parquetTarget<T>(options: {
     // Published files and open writers hold only finalized rows, so they are never rolled back.
     resolveFork: (canonicalBlocks) => store.resolveFork(canonicalBlocks),
   })
+}
+
+/** The configured range `block` falls in, or `undefined` when no ranges are recorded. */
+function rangeOf(ranges: Range[], block: number): Range | undefined {
+  return ranges.find((r) => block >= r.from && (r.to === undefined || block <= r.to))
 }
 
 function registerParquetMetrics(metrics: Metrics): ParquetTargetMetrics {

--- a/packages/pipes/src/targets/parquet/schema.ts
+++ b/packages/pipes/src/targets/parquet/schema.ts
@@ -139,11 +139,11 @@ const LIBRARY_TYPE: Record<ParquetLeafType, LibraryLeafType> = {
 const SUPPORTED_TYPES = new Set<string>(Object.keys(LIBRARY_TYPE))
 
 // The block column's value is compared directly against the portal's finalized block NUMBER
-// (`Number(row[col]) <= finalized.number`) and used for `<min>-<max>` file naming and the
-// `maxBlock > cursor` recovery check, so it must hold the block number itself. TIMESTAMP (and
-// its TIMESTAMP_MILLIS alias) is int64-backed but carries epoch-ms, and DATE is int32-backed
-// but carries days-since-epoch — comparing either against a block number silently never (or
-// always) finalizes, so both are excluded, as is everything non-numeric.
+// (`Number(row[col]) <= finalized.number`) to decide when a row may leave the finalization buffer,
+// so it must hold the block number itself. TIMESTAMP (and its TIMESTAMP_MILLIS alias) is
+// int64-backed but carries epoch-ms, and DATE is int32-backed but carries days-since-epoch —
+// comparing either against a block number silently never (or always) finalizes, so both are
+// excluded, as is everything non-numeric.
 const INTEGER_BLOCK_TYPES = new Set<ParquetColumnType>(['INT64', 'INT32'])
 
 /** The block-number column name for a table, applying the default. */

--- a/packages/pipes/src/targets/parquet/writer.ts
+++ b/packages/pipes/src/targets/parquet/writer.ts
@@ -17,13 +17,19 @@ export const TMP_PREFIX = '.tmp-'
 // reset-to-0 across restarts can never collide with a leftover temp file.
 let segmentSeq = 0
 
+/**
+ * Block range a published file **covers** — the window the pipe processed, not the rows' own
+ * min/max. The two are independent: the window's edge blocks may carry no data, and a row may be
+ * keyed outside the window that emitted it. That is the point — the filename states coverage, not
+ * content.
+ */
+export type SegmentRange = { from: number; to: number }
+
 /** Summary of a segment that was just published to its final path. */
 export type PublishedSegment = {
   path: string
   rows: number
   bytes: number
-  minBlock: number
-  maxBlock: number
 }
 
 export type ParquetSegmentWriterOptions = {
@@ -43,7 +49,11 @@ export type ParquetSegmentWriterOptions = {
  * tracks the block range and row count it has seen, exposes the growing temp file size for
  * byte-based rotation, and publishes atomically:
  *
- *   `close()` (footer) → fsync file → atomic `rename` temp → `<dir>/<min>-<max>.parquet` → fsync dir
+ *   `close()` (footer) → fsync file → atomic `rename` temp → `<dir>/<from>-<to>.parquet` → fsync dir
+ *
+ * The published name comes from the {@link SegmentRange} the caller passes to `publish()` — the
+ * window the pipe processed. The writer never inspects the rows' own block numbers; it has no way
+ * to know which blocks it was *responsible* for, only which ones happened to produce rows.
  *
  * A published file is immutable and contains only finalized rows, so it is never rewritten.
  */
@@ -59,8 +69,6 @@ export class ParquetSegmentWriter {
   // stream's close() if a footer write throws, which would otherwise leak the descriptor.
   #stream: WriteStream | undefined
   #rowCount = 0
-  #minBlock: number | undefined
-  #maxBlock: number | undefined
   #closed = false
 
   constructor(options: ParquetSegmentWriterOptions) {
@@ -79,38 +87,33 @@ export class ParquetSegmentWriter {
     return this.#rowCount
   }
 
-  get minBlock(): number | undefined {
-    return this.#minBlock
-  }
-
-  get maxBlock(): number | undefined {
-    return this.#maxBlock
-  }
-
   /**
-   * Appends one row, lazy-opening the temp file on first use. `blockNumber` is tracked
-   * separately (not re-read from the row) so range naming stays correct regardless of the
-   * declared block column's encoding.
+   * Appends one row, lazy-opening the temp file on first use.
+   *
+   * The writer tracks no block range of its own: the filename comes from the coverage window the
+   * caller passes to {@link publish}, and per-block min/max is already written into each row group's
+   * statistics by the Parquet footer (what DuckDB/Spark/Athena prune on).
    */
-  async appendRow(row: Record<string, unknown>, blockNumber: number): Promise<void> {
-    if (!this.#writer) {
-      const stream = await openWriteStream(this.#tmpPath)
-      try {
-        this.#writer = await ParquetWriter.openStream(this.#schema, stream, { rowGroupSize: this.#rowGroupSize })
-        this.#stream = stream
-      } catch (error) {
-        // openStream writes the header immediately; if that throws, the stream we just opened would
-        // leak — force it shut before propagating.
-        stream.destroy()
-        throw error
-      }
-    }
-
-    await this.#writer.appendRow(row)
+  async appendRow(row: Record<string, unknown>): Promise<void> {
+    await this.#ensureOpen()
+    await this.#writer!.appendRow(row)
 
     this.#rowCount++
-    if (this.#minBlock === undefined || blockNumber < this.#minBlock) this.#minBlock = blockNumber
-    if (this.#maxBlock === undefined || blockNumber > this.#maxBlock) this.#maxBlock = blockNumber
+  }
+
+  async #ensureOpen(): Promise<void> {
+    if (this.#writer) return
+
+    const stream = await openWriteStream(this.#tmpPath)
+    try {
+      this.#writer = await ParquetWriter.openStream(this.#schema, stream, { rowGroupSize: this.#rowGroupSize })
+      this.#stream = stream
+    } catch (error) {
+      // openStream writes the header immediately; if that throws, the stream we just opened would
+      // leak — force it shut before propagating.
+      stream.destroy()
+      throw error
+    }
   }
 
   /**
@@ -129,22 +132,29 @@ export class ParquetSegmentWriter {
 
   /**
    * Finalizes the segment: writes the Parquet footer, fsyncs the file, atomically renames the
-   * temp file to `<dir>/<min>-<max>.parquet`, then fsyncs the directory so the rename is durable.
-   * Returns the published file's path, row count, byte size and block range.
+   * temp file to `<dir>/<from>-<to>.parquet`, then fsyncs the directory so the rename is durable.
+   * Returns the published file's path, row count and byte size.
    *
-   * Refuses to overwrite an existing target file — a collision means two segments claimed the
-   * same block range, which would silently drop data.
+   * `range` is the window the caller assigns; the file is named for it so consumers read coverage
+   * off the filename. Publishing with **no rows** is legitimate and how a table claims a window it
+   * was present for but produced nothing in — the file carries the schema and an empty row set.
+   *
+   * Refuses to overwrite an existing target file — a collision means two segments claimed the same
+   * window, which would silently drop data.
    */
-  async publish(): Promise<PublishedSegment> {
-    if (!this.#writer || this.#minBlock === undefined || this.#maxBlock === undefined) {
+  async publish(range: SegmentRange): Promise<PublishedSegment> {
+    if (range.from > range.to) {
       throw new ParquetTargetError(
-        PARQUET_ERROR_CODES.FILE_COLLISION,
-        `Internal: publish() called on an empty segment in '${this.#dir}'. Only segments with ` +
-          `at least one row may be published.`,
+        PARQUET_ERROR_CODES.COVERAGE_RANGE_INVALID,
+        `Internal: refusing to publish segment in '${this.#dir}' with an inverted coverage range ` +
+          `${range.from}-${range.to}.`,
       )
     }
 
-    await this.#writer.close()
+    // Opens the file if no row ever arrived, so a zero-row window still produces a real segment.
+    await this.#ensureOpen()
+
+    await this.#writer!.close()
     this.#closed = true
     // close() ended the stream (via the library's envelopeWriter.close → stream.end), so its fd is
     // already released; drop the reference so discard()/GC don't touch a finished stream.
@@ -153,12 +163,12 @@ export class ParquetSegmentWriter {
     // fsync the temp file so the footer is durable before the rename makes it visible.
     await fsyncFile(this.#tmpPath)
 
-    const finalPath = path.join(this.#dir, `${pad(this.#minBlock)}-${pad(this.#maxBlock)}.parquet`)
+    const finalPath = path.join(this.#dir, `${pad(range.from)}-${pad(range.to)}.parquet`)
     if (await pathExists(finalPath)) {
       throw new ParquetTargetError(
         PARQUET_ERROR_CODES.FILE_COLLISION,
-        `Refusing to overwrite existing Parquet file '${finalPath}'. A file for block range ` +
-          `${this.#minBlock}-${this.#maxBlock} already exists — this indicates overlapping segments ` +
+        `Refusing to overwrite existing Parquet file '${finalPath}'. A file covering block range ` +
+          `${range.from}-${range.to} already exists — this indicates overlapping segments ` +
           `or a dirty output directory.`,
       )
     }
@@ -170,7 +180,7 @@ export class ParquetSegmentWriter {
       .then((s) => s.size)
       .catch(() => 0)
 
-    return { path: finalPath, rows: this.#rowCount, bytes, minBlock: this.#minBlock, maxBlock: this.#maxBlock }
+    return { path: finalPath, rows: this.#rowCount, bytes }
   }
 
   /**

--- a/spec/05-sinks.md
+++ b/spec/05-sinks.md
@@ -50,8 +50,7 @@ rows (INV-25). A consumer never observes a torn batch within the class's atomic 
 coverage window it accounts for (DEF-14): windows tile the processed range per table —
 no overlaps, no gaps within a covered range; a window absent from a table means "not
 processed", never "processed, empty". Sparse tables stretch windows; empty windows at
-stream end publish as explicit empty units. *(The coverage model is unimplemented on the
-reference mainline — files are named by row min/max and no empty units publish; GAP-17.)*
+stream end publish as explicit empty units.
 
 **RP-22 — Rows within window.** [MUST] Every row in a published unit is attributed to a
 block inside that unit's window.

--- a/spec/06-consistency-durability.md
+++ b/spec/06-consistency-durability.md
@@ -25,10 +25,11 @@ hold-back buffer, DEF-15). At a checkpoint (DEF-17): open units are published
 atomically (write-temp → sync → rename), **then** the cursor/state record is persisted
 atomically. Crash window: units published above the persisted cursor — recovery deletes
 every unit whose window end exceeds the cursor plus all temporary files, then re-fetches;
-requires replay purity (RS-10). A unit *straddling* the cursor is an integrity fault:
-refuse before deleting anything *(refusal unimplemented on the mainline — a straddling
-unit is currently deleted like any over-cursor unit; GAP-17)*. Delivery: effectively
-exactly-once.
+requires replay purity (RS-10). A unit *straddling* the cursor is an integrity fault —
+refuse before deleting anything — **unless** it starts where the recorded coverage says
+that table was next due to publish from, which identifies it as the interrupted
+checkpoint's own unit (a sparse table's stretched unit straddles by construction) and so
+as a remnant to delete. Delivery: effectively exactly-once.
 
 **CN-13 — Class A (append-lagged).** Data is appended by author code first; the cursor
 record is appended **after**, non-atomically. Crash window: data committed above the

--- a/spec/13-conformance-tdd.md
+++ b/spec/13-conformance-tdd.md
@@ -1,8 +1,8 @@
 # 13 — Conformance & TDD (CT-n, GAP-n) — MUTABLE
 
-Last updated: 2026-07-19. Statuses reflect the actual TypeScript test inventory at
-commit `a739500` (this branch's mainline merge base; commits above it are docs-only),
-not aspiration.
+Last updated: 2026-07-22. Statuses reflect the actual TypeScript test inventory at
+commit `744ea82` (this branch's mainline merge base), plus the parquet
+coverage-naming suites landing with it, not aspiration.
 
 ## Harness architecture
 
@@ -133,13 +133,13 @@ known-suspect in the current implementation (see gap register).
 | WP-46 (rollback idempotence) | CT-2/3 | P | netting idempotence tested (one binding); others U |
 | WP-47 (depth bound) | CT-3 | P | retention pruning tested; deep-fork restart e2e U |
 | RP-1…RP-6 (write loop) | CT-1 | C | per-target state suites |
-| RP-21, RP-22, INV-4 (coverage) | CT-7 | U ⚠ | coverage model unimplemented on mainline; suites live in the unmerged coverage PR (GAP-17) |
+| RP-21, RP-22, INV-4 (coverage) | CT-7 | C | parquet coverage-naming suites: sparse stretch, trailing empty unit, disjoint-range gap, resume mid-gap |
 | RP-30…RP-32 (keying, migration) | CT-8 | P ⚠ | happy path C; concurrent migration U (GAP-7) |
 | RP-42 (delegated repair) | CT-2 | U ⚠ | hook optional today (GAP-3) |
 | RP-43 (contract guard) | CT-3 | P ⚠ | one binding only (GAP-9) |
 | CN-10 T atomicity | CT-2 | P ⚠ | live tx tests; kill-points U (GAP-14) |
 | CN-11 W protocol | CT-2 | P | unit/lifecycle C; integration gated off CI |
-| CN-12 K protocol | CT-2 | P ⚠ | crash-safety + recovery suites; straddle refusal absent (GAP-17) |
+| CN-12 K protocol | CT-2 | C | crash-safety + recovery suites; straddle refusal asserted (E2317) |
 | CN-13 A protocol | CT-2 | U ⚠ | crash window untested (GAP-3) |
 | CN-34 (fork commit point) | CT-2 | U ⚠ | crash-during-fork untested; class A persists nothing at fork (GAP-21) |
 | CN-45 (cross-impl, clock indep.) | CT-5 | U ⚠ | single implementation; clock ordering in two bindings (GAP-10); cache codec undiscriminated (GAP-27) |
@@ -182,7 +182,6 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
 | GAP-14 | Crash-recovery kill-point coverage exists only for class K; classes T/W/A have no kill-point tests | INV-40…INV-42 | P1 | Phase-0 ledger mode first (an ordinal script cannot answer the post-restart re-request), then the kill-point harness at the T transaction boundary |
 | GAP-15 | Indistinguishable-output collision (duplicate event signature) only logs in the evm module and is entirely undetected in solana; later outputs silently miss records | WP-24 | P2 | two outputs, same signature → startup diagnostic asserted fatal (pending OQ-6) |
 | GAP-16 | Observability payloads are consumed by the dashboard but have no golden fixtures; shapes drift silently (a version-drift accommodation already exists in the dashboard) | IB-40…IB-46 | P3 | golden scrape of /stats, /metrics, preview against a scripted run |
-| GAP-17 | The coverage-window model — coverage-based file naming, the `coverage` state map, straddle refusal, empty-unit publication, codes E2316/E2317 — is spec'd but unimplemented on mainline: files are named by row min/max, straddling files are deleted on recovery, empty tables produce no files | IB-22, RP-21, RP-22, INV-4, CN-12 | P1 | land the coverage PR, then sparse/trailing/gap/disjoint suites against it |
 | GAP-20 | The orphan-data guard is table-wide where it must be key-scoped: the write-ahead binding (E2212) probes the tracked table with no key filter while reading its sync row by key, so a co-resident pipe's legitimate first run into a populated shared table is refused — one pipe's startup made dependent on another's data, blocking a configuration INV-35/RP-41 support. The other bindings run no guard at all and restart from scratch over genuinely orphan data | CN-44, INV-35, REQ-3 | P1 | second pipe id, first run into a table another pipe populates → assert start, not refusal; then on declared-exclusive tables delete cursor state and assert coded refusal per binding |
 | GAP-21 | Append-lagged fork completion persists nothing (no rewound cursor row); a crash after resolveFork and before the next commit resumes from pre-fork state | CN-34 | P2 | kill between resolveFork and the next commit; assert recovered C = ancestor |
 | GAP-22 | A fork tears down and restarts the whole lifecycle (stop + start hooks, metrics server) per streaming segment — hooks fire per segment, not exactly once per run | WP-30, INV-17 | P2 | count start/stop hook invocations across one resolved fork; assert one each |
@@ -199,7 +198,7 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
 | GAP-33 | Profiling-surface defects: batch spans leak on empty batches and stream end (open fix PR #71); transformer-id dedup collides for 3+ same-id transformers (open fix PR #73) | OB-22 | P3 | span onStart count = onEnd count across empty batches; three same-id transformers get distinct ids |
 | GAP-34 | Observability-server hygiene: CORS accepts any origin containing "localhost" as a substring (and rejects 127.0.0.1); stop() clears the global metrics registry; /profiler hardcodes `enabled: true` | IB-40, IB-43 | P3 | origin `http://localhost.evil.com` → assert rejected |
 | GAP-36 | One-program-per-decoder (ADR-17) is enforced by proxy: `programId` is decoder-level, so nothing binds an instruction definition to its program, and the guards only reject collisions visible in the discriminator set. Two programs with disjoint tracked discriminators still pass and cross-decode | INV-24, REQ-2 | P2 | decoder over `[A, B]` with `{ aSwap: A.swap, bDeposit: B.deposit }`; feed B's on-chain `swap` → assert refusal or no emission under `aSwap`, not a decode |
-| GAP-35 | Parquet data files are named by block window with no pipe-id namespacing while the state sidecar is namespaced (`_sqd_parquet_state.<id>.json`): two pipes covering overlapping ranges in one directory collide on filename and the second fails E2309 — sharing a directory is refused by accident of naming rather than declared policy, and coverage-window naming (GAP-17) collides identically | IB-22, IB-27, INV-35 | P2 | two pipe ids, one directory, overlapping ranges → assert the declared outcome (namespaced files or a coded exclusivity refusal), not a publish collision |
+| GAP-35 | Parquet data files are named by block window with no pipe-id namespacing while the state sidecar is namespaced (`_sqd_parquet_state.<id>.json`): two pipes covering overlapping ranges in one directory collide on filename and the second fails E2309 — sharing a directory is refused by accident of naming rather than declared policy | IB-22, IB-27, INV-35 | P2 | two pipe ids, one directory, overlapping ranges → assert the declared outcome (namespaced files or a coded exclusivity refusal), not a publish collision |
 
 ## Build order
 
@@ -216,8 +215,7 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
   class (K — cheapest, file-based; the only crash imitation today is a pre-commit
   abort, one point of the CT-2 matrix). Exit: CT-1 green on the reference
   implementation for S1, ledger mode answering post-restart re-requests.
-- **Phase 1 — P1 gaps**: GAP-3 (needs ADR-15),
-  GAP-11 (range anchors), GAP-17 (land the coverage PR),
+- **Phase 1 — P1 gaps**: GAP-3 (needs ADR-15), GAP-11 (range anchors),
   GAP-14 kill-point harness for class T. Exit: register updated, fixes landed or
   accepted as documented deviations.
 - **Phase 2 — correctness core**: full CT-2 matrix all classes; CT-3 fork suite; CT-5

--- a/spec/14-interface-binding.md
+++ b/spec/14-interface-binding.md
@@ -96,10 +96,10 @@ finalized?, coverage: {<table>: next-window-start}}`, written temp-file → fsyn
 rename → dir-fsync. Data files `<table>/<from>-<to>.parquet`, names zero-padded to 12
 digits, window = coverage (DEF-14) not row min/max; publish refuses to overwrite
 (coded). Recovery deletes `*.tmp-*` always and any file with `to > cursor`; a file
-straddling the cursor is a coded refusal. *(Coverage naming, the `coverage` state map,
-and the straddle refusal are the contract target — the current mainline names files by
-row min/max, persists no coverage map, and deletes straddling files; GAP-17.)* Column
-types: INT64/INT32/UTF8/BYTE_ARRAY/BOOLEAN/DOUBLE/
+straddling the cursor is a coded refusal unless its `from` equals the table's recorded
+coverage start, which makes it the interrupted checkpoint's own file. A recorded coverage
+start ahead of what the cursor allows is clamped with a warning, not refused. Column types:
+INT64/INT32/UTF8/BYTE_ARRAY/BOOLEAN/DOUBLE/
 TIMESTAMP(millis)/DATE/JSON/LIST/STRUCT; DECIMAL deliberately unsupported; block
 column INT64/INT32 required non-null. Compression: SNAPPY (default), GZIP, BROTLI,
 UNCOMPRESSED.
@@ -213,7 +213,7 @@ consumers MUST NOT read it as a block number.
 | E20xx | ClickHouse binding | E2001–E2006 (retention, table name, distributed-rollback, collapse-column, missing sign, rollback-index) |
 | E21xx | Postgres binding | E2101–E2106 (client, config, advisory lock, untracked table, missing PK, FK cycle) |
 | E22xx | BigQuery binding | E2201–E2213 (schema/partition guards, orphan data E2212, append rejection E2213) |
-| E23xx | Parquet binding | E2301–E2315 in use (schema/config; file collision E2309, state corrupt E2310, recovery delete failure E2314, nested-schema E2315); E2316/E2317 reserved for the coverage guards (GAP-17) |
+| E23xx | Parquet binding | E2301–E2317 in use (schema/config; file collision E2309, state corrupt E2310, recovery delete failure E2314, nested-schema E2315; coverage guards E2316 invalid range, E2317 state/data disagreement) |
 
 **IB-51 — Transport errors.** Non-coded, typed: HTTP error (with response), request
 timeout, body-stall timeout. Retryability: request timeouts and connection-class errors

--- a/spec/decisions/ADR-6-coverage-window-naming.md
+++ b/spec/decisions/ADR-6-coverage-window-naming.md
@@ -1,6 +1,6 @@
 # ADR-6 — Immutable file sinks: finalized-only content, coverage-window naming
 
-Status: Accepted (historical) — coverage naming/persistence not yet on mainline (GAP-17)
+Status: Accepted — implemented for the parquet binding
 
 ## Context
 
@@ -24,3 +24,9 @@ reduces to dropping hold-back rows (CN-32). Costs: rows lag finality (deferred
 visibility, INV-25), no-finality datasets lose reorg safety (FM-13), and recovery
 depends on the author-purity obligation (RS-10, INV-43). Shapes DEF-14, DEF-15,
 CN-12, IB-22.
+
+Landed for parquet in PR #123 (issue #122): coverage map persisted beside the cursor,
+straddle refusal E2317, invalid-range refusal E2316, empty units at stream end. Existing
+datasets keep their row-min/max names — the scheme is not retroactive, and recovery
+parses both. Files stay un-namespaced by pipe id, so two pipes sharing a directory still
+collide (GAP-35).


### PR DESCRIPTION
## Summary

Parquet files are named `<from>-<to>.parquet` for the **block window they cover** — the window the pipe processed — instead of the min/max block of the rows inside them. Fixes #122.

A block range absent from a table's filenames now means "not indexed", never "indexed, no data". Three mechanisms hold that up:

- **Stretching.** A table with no rows in a window publishes nothing and keeps its coverage start, so its next file reaches back over the windows it sat out. No tiny file per window.
- **Tail closing.** Stretching can't close a table's *final* window — there is no next file to stretch. So at stream end every table claims what it still owes, writing a zero-row file if it has nothing. This is also how a table that produced nothing at all states that its range was indexed.
- **Gap skipping.** Coverage never advances into the gap between two configured query ranges: those blocks are never fetched, so no file claims them. The skip is applied **everywhere coverage moves** — advancing past a publish, seeding a resume, and entering a range the stream reached without a batch — so absent stays honest in both directions, and a backfill resumed between two ranges accepts its own state instead of failing.

The window start is tracked per table and persisted next to the cursor — it can't be derived from the cursor, which advances whether or not a given table wrote anything.

### The name bounds coverage, not content

`onData` may key a row outside the window that emitted it — an OHLC candle stamped with its window's first block is emitted only once the window closes. So **do not use the filename to locate a given block's rows**; use the row-group statistics in the footer, which is what DuckDB, Spark and Athena prune on anyway. An earlier revision of this PR enforced containment and turned that ordinary pipeline into a fatal error.

## Corrections from review

The first pass at the gap handling had three defects at the boundaries between disjoint ranges — the exact case the feature exists for. Each is now fixed and regression-tested:

- **Resume between ranges failed with a false `E2317`.** After a range boundary, coverage legitimately sits ahead of `cursor + 1` because it jumped the gap. Startup validated `coverage ≤ cursor + 1` and rejected the pipe's *own consistent state*, telling the operator to delete their data. A disjoint-range backfill could not resume.
- **Legacy resume seeded into a gap.** A resume with no persisted `coverage` seeded the next file's start at `cursor + 1`, which can land in an un-queried gap, so the next file named blocks the pipe never fetched. `seedCoverage` now clamps the chosen start forward to the next queried block.
- **A skipped empty range over-claimed the gap after it.** A configured range the stream passed without a batch left coverage at that range's start, so the next file spanned the un-queried blocks after it. Coverage now advances to the range actually being entered.

`E2317` is re-grounded on evidence available *before* recovery deletes anything: a published file that **straddles** the committed cursor (deleting it as a remnant would destroy committed data), plus a seed-time check that a persisted start isn't ahead of what the cursor allows for the query ranges. Both are gap-aware, so a legitimate cross-gap resume passes.

## Coverage

| Module | Stmts | Δ | Branch | Δ |
|--------|-------|---|--------|---|
| **All files** | 84.9% | +0.2 | 85.7% | +0.2 |
| src/http-client | 61.2% | +0.0 | 63.8% | +0.8 |
| src/targets/parquet | 98.0% | +0.6 | 91.5% | +0.4 |

Base `main` vs head, full suite with ClickHouse + Postgres up (601 passed). `src/http-client` movement is unrelated run-to-run noise. These numbers predate the review fixes above, which only **added** tests and tightened branches (parquet 86 tests now green locally) — coverage can only have risen; a re-run is pending.

## Test plan

- [x] Sparse table stretches its next file back over windows that produced no rows
- [x] A table's trailing window is claimed by a zero-row file at stream end — one per run, not one per checkpoint
- [x] A table that receives no rows at all still claims its range, with a readable zero-row file
- [x] Gap between two disjoint ranges is left unclaimed (`[0,1]` + `[5,6]` → no file names blocks 2–4)
- [x] **A disjoint-range backfill resumed between the two ranges accepts its own state (was a false `E2317`) and finishes the second range — end to end**
- [x] **A resume fallback that lands in a gap is clamped up to the next queried block**
- [x] **A skipped empty middle range is not folded into the next file's coverage**
- [x] A row keyed below the window that emitted it publishes fine and is not dropped
- [x] Coverage is contiguous across a restart, with no gap and no overlap
- [x] Backfill from a non-zero block starts coverage at the stream start, not 0
- [x] Legacy state without a `coverage` field resumes at `cursor + 1`
- [x] A data file straddling the cursor, or a persisted coverage start ahead of what the cursor allows, is refused **before** recovery deletes anything (`E2317`), leaving the data files intact
- [x] Non-integer / negative / NaN persisted starts fall back instead of steering the filename
- [x] Writer refuses an inverted `from > to` range (`E2316`)
- [x] Existing fork / crash-safety / recovery / multi-table tests still pass

## Notes for reviewers

**`StreamInfo.state.ranges` is new** (additive). It carries the configured query ranges *before* the resume bound is applied — the bounded ranges no longer show a gap after a restart, so only the raw list can distinguish "never queried" from "queried, empty". `state.initial` is just `ranges[0].from`.

**This changes on-disk layout.** Recovery stays correct for both schemes — `#deleteFilesAboveCursor` reads the range off the filename, and a legacy min/max name's `to` is its last row, never above the committed cursor — so old and new files coexist safely. But contiguity starts from the upgrade point; existing datasets don't retroactively gain it, and old files are indistinguishable by name. The class doc scopes the guarantee accordingly. Needs a migration note, and isn't a patch release.

**Cost:** a table that produces nothing gets one zero-row file per run (and per query range). That's the price of coverage being readable off the filenames; it's documented in the target's trade-offs.

**Test harness note.** The resume-across-a-gap test seeds the exact interrupted state (`cursor 1`, `coverage 5`) that a real run persists, then drives the resume path, rather than crashing a first run mid-stream: the mock portal can only fake a crash by exhausting its canned responses, and that races the pre-crash checkpoint's `fsync`. The state it seeds is the one the store unit tests prove a real run produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
