### PR TITLE
fix(monitoring): keep the RPC latency watcher alive across stream restarts

### DIFF
--- a/packages/pipes/src/bitcoin/bitcoin-rpc-latency-watcher.test.ts
+++ b/packages/pipes/src/bitcoin/bitcoin-rpc-latency-watcher.test.ts
@@ -28,6 +28,7 @@ describe('BitcoinRpcLatencyWatcher', () => {
     })
 
     watcher = new BitcoinRpcLatencyWatcher([mock.url], 25)
+    watcher.start()
 
     await vi.waitFor(
       () => {
@@ -70,6 +71,7 @@ describe('BitcoinRpcLatencyWatcher', () => {
     })
 
     watcher = new BitcoinRpcLatencyWatcher([mock.url], 25)
+    watcher.start()
 
     await vi.waitFor(
       () => {
@@ -91,6 +93,7 @@ describe('BitcoinRpcLatencyWatcher', () => {
     const authedUrl = mock.url.replace('http://', `http://${credentials}@`)
 
     watcher = new BitcoinRpcLatencyWatcher([authedUrl], 25)
+    watcher.start()
 
     await vi.waitFor(
       () => {
@@ -132,6 +135,7 @@ describe('BitcoinRpcLatencyWatcher', () => {
     // Short interval + short timeout ⇒ the loop must abort the in-flight
     // request after `requestTimeoutMs` and start a new tick after `intervalMs`.
     watcher = new BitcoinRpcLatencyWatcher([mock.url], 100, 30)
+    watcher.start()
 
     await vi.waitFor(
       () => {

--- a/packages/pipes/src/bitcoin/bitcoin-rpc-latency-watcher.ts
+++ b/packages/pipes/src/bitcoin/bitcoin-rpc-latency-watcher.ts
@@ -54,12 +54,11 @@ export class BitcoinRpcLatencyWatcher extends RpcLatencyWatcher {
   ) {
     const inputs = (Array.isArray(rpcUrl) ? rpcUrl : [rpcUrl]).map(parseEndpoint)
     super(inputs.map((e) => e.url))
-    // The base ctor stops short of calling `watch()` (we use the deferred
-    // `attach()` pattern), so these fields are initialized BEFORE any tick fires.
+    // Subscribing is deferred to `start()`, so these fields are initialized
+    // BEFORE any tick fires.
     this.#endpointsByUrl = new Map(inputs.map((e) => [e.url, e]))
     this.#intervalMs = intervalMs
     this.#requestTimeoutMs = requestTimeoutMs
-    this.attach()
   }
 
   watch(url: string) {

--- a/packages/pipes/src/evm/evm-rpc-latency-watcher.test.ts
+++ b/packages/pipes/src/evm/evm-rpc-latency-watcher.test.ts
@@ -1,9 +1,29 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import type { BatchContext } from '~/core/portal-source.js'
+import { MockWebSocket, mockWebSocket } from '~/testing/mock-websocket.js'
 import { testLogger } from '~/testing/test-logger.js'
 
 import { EvmQueryBuilder } from './evm-query-builder.js'
 import { evmRpcLatencyWatcher } from './evm-rpc-latency-watcher.js'
+
+const profilerStub: Record<string, unknown> = {
+  start: () => profilerStub,
+  measure: async (_: unknown, fn: () => unknown) => fn(),
+  end: () => {},
+  data: undefined,
+}
+
+function makeBatchContext(receivedAt: Date): BatchContext {
+  return {
+    profiler: profilerStub,
+    batch: { blocksCount: 1, bytesSize: 0, requests: {}, lastBlockReceivedAt: receivedAt },
+  } as unknown as BatchContext
+}
+
+function newHeads(head: unknown) {
+  return { method: 'eth_subscription', params: { result: head } }
+}
 
 describe('evmRpcLatencyWatcher factory', () => {
   let transformer: ReturnType<typeof evmRpcLatencyWatcher> | undefined
@@ -32,5 +52,69 @@ describe('evmRpcLatencyWatcher factory', () => {
 
     const requests = builder.getRequests()
     expect(requests).toContainEqual(expect.objectContaining({ range: { from: 'latest' } }))
+  })
+})
+
+describe('evmRpcLatencyWatcher subscription', () => {
+  let transformer: ReturnType<typeof evmRpcLatencyWatcher> | undefined
+  let restoreWebSocket: () => void
+
+  beforeEach(() => {
+    restoreWebSocket = mockWebSocket()
+  })
+
+  afterEach(async () => {
+    await transformer?.stop({ logger: testLogger() })
+    transformer = undefined
+    restoreWebSocket()
+  })
+
+  it('subscribes to newHeads and matches an observed head against the portal block', async () => {
+    transformer = evmRpcLatencyWatcher({ rpcUrl: ['ws://rpc'] })
+    await transformer.start({} as never)
+
+    MockWebSocket.last.open()
+    expect(JSON.parse(MockWebSocket.last.sent[0])).toMatchObject({
+      method: 'eth_subscribe',
+      params: ['newHeads'],
+    })
+
+    MockWebSocket.last.message(newHeads({ number: '0x64', hash: '0xabc', timestamp: '0x66' }))
+
+    const result = await transformer.run(
+      [{ header: { number: 100, timestamp: 0x66 } }] as never,
+      makeBatchContext(new Date('2026-05-09T00:00:10Z')),
+    )
+
+    expect(result?.number).toBe(100)
+    expect(result?.rpc[0]).toMatchObject({ url: 'ws://rpc', hash: '0xabc' })
+  })
+
+  it('ignores a subscription frame with no head instead of crashing', async () => {
+    // `params.result` is absent on the subscription ack and on some providers' keepalives;
+    // reading `head.number` off it threw and took the whole process down.
+    transformer = evmRpcLatencyWatcher({ rpcUrl: ['ws://rpc'] })
+    await transformer.start({} as never)
+    MockWebSocket.last.open()
+
+    expect(() => MockWebSocket.last.message({ method: 'eth_subscription', params: {} })).not.toThrow()
+    expect(() => MockWebSocket.last.message({ jsonrpc: '2.0', id: 1, result: '0xsub' })).not.toThrow()
+
+    const result = await transformer.run(
+      [{ header: { number: 1, timestamp: 0 } }] as never,
+      makeBatchContext(new Date()),
+    )
+    expect(result).toBeNull()
+  })
+
+  it('closes the socket on stop', async () => {
+    transformer = evmRpcLatencyWatcher({ rpcUrl: ['ws://rpc'] })
+    await transformer.start({} as never)
+    MockWebSocket.last.open()
+
+    await transformer.stop({ logger: testLogger() })
+    transformer = undefined
+
+    expect(MockWebSocket.instances[0].closed).toBe(true)
   })
 })

--- a/packages/pipes/src/evm/evm-rpc-latency-watcher.ts
+++ b/packages/pipes/src/evm/evm-rpc-latency-watcher.ts
@@ -2,11 +2,6 @@ import { evmQuery } from '~/evm/evm-query-builder.js'
 import { RpcLatencyWatcher, WebSocketListener, rpcLatencyWatcher } from '~/monitoring/index.js'
 
 class EvmRpcLatencyWatcher extends RpcLatencyWatcher {
-  constructor(rpcUrl: string | string[]) {
-    super(rpcUrl)
-    this.attach()
-  }
-
   watch(url: string): WebSocketListener {
     const listener = new WebSocketListener(url)
 

--- a/packages/pipes/src/monitoring/rpc-latency/rpc-latency-watcher.test.ts
+++ b/packages/pipes/src/monitoring/rpc-latency/rpc-latency-watcher.test.ts
@@ -5,12 +5,17 @@ import type { BatchContext } from '~/core/portal-source.js'
 import { type RpcLatencyListener, RpcLatencyWatcher, rpcLatencyWatcher } from './rpc-latency-watcher.js'
 
 class StubWatcher extends RpcLatencyWatcher {
-  watch(): RpcLatencyListener {
-    return { stop: () => {} }
-  }
-  /** Skip subscribing — tests populate `nodes` directly via addBlock. */
-  preregister(url: string): void {
-    this.nodes.set(url, new Map())
+  watched: string[] = []
+  stopped = 0
+
+  watch(url: string): RpcLatencyListener {
+    this.watched.push(url)
+
+    return {
+      stop: () => {
+        this.stopped++
+      },
+    }
   }
 }
 
@@ -40,8 +45,7 @@ describe('rpcLatencyWatcher transformer', () => {
     // silently break (number, hash) matching, leaving the probe pairing observations across
     // chain forks. This pins the wire-up.
     const watcher = new StubWatcher(['ws://rpc-1', 'ws://rpc-2'])
-    watcher.preregister('ws://rpc-1')
-    watcher.preregister('ws://rpc-2')
+    watcher.start()
 
     const blockTimestamp = new Date('2026-05-09T00:00:00Z')
     const rpc1ReceivedAt = new Date('2026-05-09T00:00:01Z')
@@ -79,7 +83,7 @@ describe('rpcLatencyWatcher transformer', () => {
     // consumers degrade to number-only matching — this test pins that the pipeline doesn't
     // accidentally fabricate a value (e.g. empty string) on the way through.
     const watcher = new StubWatcher(['ws://rpc'])
-    watcher.preregister('ws://rpc')
+    watcher.start()
 
     watcher.addBlock('ws://rpc', {
       number: 42,
@@ -98,12 +102,84 @@ describe('rpcLatencyWatcher transformer', () => {
 
   it('returns null when no RPC has seen the block (lookup empty)', async () => {
     const watcher = new StubWatcher(['ws://rpc'])
-    watcher.preregister('ws://rpc')
+    watcher.start()
     // No addBlock calls — lookup returns [].
 
     const transformer = rpcLatencyWatcher({ watcher })
     const result = await transformer.run([{ header: { number: 999, timestamp: 0 } }], makeBatchContext(new Date()))
 
     expect(result).toBeNull()
+  })
+})
+
+describe('RpcLatencyWatcher lifecycle', () => {
+  it('re-subscribes after stop(), so a stream restart does not blind it permanently', () => {
+    // stop() used to be a one-way latch: after the first restart the sockets stayed
+    // shut and lookup() returned [] forever, freezing the gauges on their last value.
+    const watcher = new StubWatcher(['ws://rpc-1', 'ws://rpc-2'])
+
+    watcher.start()
+    expect(watcher.watched).toEqual(['ws://rpc-1', 'ws://rpc-2'])
+
+    watcher.stop()
+    expect(watcher.stopped).toBe(2)
+
+    watcher.start()
+    expect(watcher.watched).toEqual(['ws://rpc-1', 'ws://rpc-2', 'ws://rpc-1', 'ws://rpc-2'])
+  })
+
+  it('retains observed heads across a restart', () => {
+    // Dropping the buffer would stall matching until each RPC re-observed a head.
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.start()
+    watcher.addBlock('ws://rpc', { number: 7, timestamp: new Date(), receivedAt: new Date() })
+
+    watcher.stop()
+    watcher.start()
+
+    expect(watcher.lookup(7)).toHaveLength(1)
+  })
+
+  it('ignores a repeated start()', () => {
+    const watcher = new StubWatcher(['ws://rpc'])
+
+    watcher.start()
+    watcher.start()
+
+    expect(watcher.watched).toEqual(['ws://rpc'])
+  })
+
+  it('ignores a repeated stop() instead of stopping listeners twice', () => {
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.start()
+
+    watcher.stop()
+    watcher.stop()
+
+    expect(watcher.stopped).toBe(1)
+  })
+
+  it('subscribes from the transformer start hook', async () => {
+    const watcher = new StubWatcher(['ws://rpc'])
+    const transformer = rpcLatencyWatcher({ watcher })
+
+    await transformer.start({} as never)
+
+    expect(watcher.watched).toEqual(['ws://rpc'])
+  })
+
+  it('evicts the oldest heads once a node exceeds the retention cap', () => {
+    // Nothing pruned `nodes`, so entries accumulated for the process's lifetime.
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.start()
+
+    for (let i = 1; i <= 600; i++) {
+      watcher.addBlock('ws://rpc', { number: i, timestamp: new Date(), receivedAt: new Date() })
+    }
+
+    expect(watcher.nodes.get('ws://rpc')?.size).toBe(512)
+    expect(watcher.lookup(88)).toEqual([])
+    expect(watcher.lookup(89)).toHaveLength(1)
+    expect(watcher.lookup(600)).toHaveLength(1)
   })
 })

--- a/packages/pipes/src/monitoring/rpc-latency/rpc-latency-watcher.ts
+++ b/packages/pipes/src/monitoring/rpc-latency/rpc-latency-watcher.ts
@@ -6,6 +6,9 @@ import { arrayify, last } from '~/internal/array.js'
 // hot path. EVM (`eth_subscribe newHeads`) and Bitcoin (`getbestblockhash`) both populate it.
 type RpcHead = { number: number; hash?: string; timestamp: Date; receivedAt: Date }
 
+/** Lookups only move forward, so older heads are dead weight. */
+const MAX_HEADS_PER_NODE = 512
+
 export interface RpcLatencyListener {
   stop(): void
 }
@@ -13,40 +16,42 @@ export interface RpcLatencyListener {
 export abstract class RpcLatencyWatcher {
   nodes: Map<string, Map<number, RpcHead>> = new Map()
   watchers: RpcLatencyListener[] = []
+  #running = false
 
   constructor(protected rpcUrl: string | string[]) {
     this.rpcUrl = arrayify(rpcUrl)
   }
 
   /**
-   * Subscribes each configured URL via `watch()`. Subclasses **must** call this
-   * from their constructor *after* their own fields are initialized — otherwise
-   * `watch()` would observe undefined subclass state, since `super()` runs
-   * before subclass field initializers.
+   * Subscribes each URL via `watch()`. Idempotent and re-runnable after `stop()`:
+   * the stream stops and starts transformers around every restart, and a one-way
+   * stop would leave `lookup()` empty forever while the stream kept indexing.
+   *
+   * Driven by the transformer, not a subclass constructor, so `watch()` always
+   * sees initialized subclass fields.
    */
-  protected attach() {
-    for (const url of this.rpcUrl) {
-      this.nodes.set(url, new Map())
+  start() {
+    if (this.#running) return
+    this.#running = true
+
+    for (const url of arrayify(this.rpcUrl)) {
+      if (!this.nodes.has(url)) {
+        this.nodes.set(url, new Map())
+      }
+
       this.watchers.push(this.watch(url))
     }
   }
 
   stop() {
+    if (!this.#running) return
+    this.#running = false
+
     for (const listener of this.watchers) {
       listener.stop()
     }
-  }
 
-  cleanup(before: number) {
-    for (const [, blocks] of this.nodes) {
-      for (const [, block] of blocks) {
-        if (block.number > before) {
-          break
-        }
-
-        blocks.delete(block.number)
-      }
-    }
+    this.watchers = []
   }
 
   lookup(number: number) {
@@ -73,6 +78,15 @@ export abstract class RpcLatencyWatcher {
     if (!chain) throw new Error('RPC not found')
 
     chain.set(block.number, block)
+
+    // Insertion order is ascending, so the first key is the oldest. Evicting here
+    // rather than on portal batches holds the bound while the portal side is stalled.
+    while (chain.size > MAX_HEADS_PER_NODE) {
+      const oldest = chain.keys().next()
+      if (oldest.done) break
+
+      chain.delete(oldest.value)
+    }
   }
 
   abstract watch(url: string): RpcLatencyListener
@@ -101,6 +115,9 @@ export function rpcLatencyWatcher({ watcher }: { watcher: RpcLatencyWatcher }) {
     Latency | null
   >({
     profiler: { name: 'rpc latency' },
+    start() {
+      watcher.start()
+    },
     transform: (data, ctx): Latency | null => {
       const receivedAt = ctx.batch.lastBlockReceivedAt
 

--- a/packages/pipes/src/monitoring/rpc-latency/ws-client.test.ts
+++ b/packages/pipes/src/monitoring/rpc-latency/ws-client.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { MockWebSocket, mockWebSocket } from '~/testing/mock-websocket.js'
+
+import { WebSocketListener } from './ws-client.js'
+
+const PAYLOAD = { jsonrpc: '2.0', id: 1, method: 'eth_subscribe', params: ['newHeads'] }
+
+describe('WebSocketListener', () => {
+  let listener: WebSocketListener | undefined
+  let restoreWebSocket: () => void
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    restoreWebSocket = mockWebSocket()
+  })
+
+  afterEach(() => {
+    listener?.stop()
+    listener = undefined
+    restoreWebSocket()
+    vi.useRealTimers()
+  })
+
+  it('sends the subscription once the socket opens', () => {
+    listener = new WebSocketListener('ws://rpc')
+    listener.subscribe(PAYLOAD, () => {})
+
+    MockWebSocket.last.open()
+
+    expect(MockWebSocket.last.sent).toEqual([JSON.stringify(PAYLOAD)])
+  })
+
+  it('reconnects after the socket closes', () => {
+    listener = new WebSocketListener('ws://rpc')
+    listener.subscribe(PAYLOAD, () => {})
+    MockWebSocket.last.open()
+
+    MockWebSocket.last.emit('close')
+    vi.advanceTimersByTime(250)
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+    MockWebSocket.last.open()
+    expect(MockWebSocket.last.sent).toEqual([JSON.stringify(PAYLOAD)])
+  })
+
+  it('reconnects on error, which does not always come with a close', () => {
+    listener = new WebSocketListener('ws://rpc')
+    listener.subscribe(PAYLOAD, () => {})
+    MockWebSocket.last.open()
+
+    MockWebSocket.last.emit('error')
+    vi.advanceTimersByTime(250)
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('reconnects when the socket goes silent without closing', () => {
+    // The regression that froze the freshness dashboard: a half-open socket emits
+    // neither close nor error, so it looked alive while delivering nothing.
+    listener = new WebSocketListener('ws://rpc', 1_000)
+    listener.subscribe(PAYLOAD, () => {})
+    MockWebSocket.last.open()
+
+    vi.advanceTimersByTime(1_000)
+    vi.advanceTimersByTime(250)
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('keeps the socket while messages keep arriving', () => {
+    listener = new WebSocketListener('ws://rpc', 1_000)
+    listener.subscribe(PAYLOAD, () => {})
+    MockWebSocket.last.open()
+
+    for (let i = 0; i < 5; i++) {
+      vi.advanceTimersByTime(800)
+      MockWebSocket.last.message({ method: 'eth_subscription' })
+    }
+    vi.advanceTimersByTime(800)
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('schedules a single reconnect when error and close both fire', () => {
+    listener = new WebSocketListener('ws://rpc')
+    listener.subscribe(PAYLOAD, () => {})
+    MockWebSocket.last.open()
+
+    const socket = MockWebSocket.last
+    socket.emit('error')
+    socket.emit('close')
+    vi.advanceTimersByTime(250)
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('ignores events from a socket it already replaced', () => {
+    listener = new WebSocketListener('ws://rpc')
+    listener.subscribe(PAYLOAD, () => {})
+    MockWebSocket.last.open()
+
+    const stale = MockWebSocket.last
+    stale.emit('close')
+    vi.advanceTimersByTime(250)
+    expect(MockWebSocket.instances).toHaveLength(2)
+
+    stale.emit('close')
+    vi.advanceTimersByTime(30_000)
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('backs off instead of reconnecting in a tight loop', () => {
+    // A bare retry loop reconnects fast enough to get rate-limited.
+    listener = new WebSocketListener('ws://rpc')
+    listener.subscribe(PAYLOAD, () => {})
+
+    // Never opens, so the attempt counter keeps climbing.
+    for (let i = 0; i < 6; i++) {
+      MockWebSocket.last.emit('close')
+      vi.advanceTimersByTime(30_000)
+    }
+    const afterSixFailures = MockWebSocket.instances.length
+
+    MockWebSocket.last.emit('close')
+    vi.advanceTimersByTime(250)
+
+    expect(MockWebSocket.instances).toHaveLength(afterSixFailures)
+  })
+
+  it('reconnects when the handshake hangs without opening', () => {
+    // A blackholed connect emits no open, no error and no close, so the deadline
+    // has to cover connecting too — not just an established socket.
+    listener = new WebSocketListener('ws://rpc', 1_000)
+    listener.subscribe(PAYLOAD, () => {})
+
+    vi.advanceTimersByTime(1_000)
+    vi.advanceTimersByTime(250)
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('keeps backing off when the socket opens and is dropped straight away', () => {
+    // How a rate-limiting provider refuses: it accepts the upgrade, then closes.
+    // Treating `open` as proof of health resets the backoff every cycle, which is
+    // the tight loop the backoff exists to prevent.
+    listener = new WebSocketListener('ws://rpc')
+    listener.subscribe(PAYLOAD, () => {})
+
+    for (let i = 0; i < 6; i++) {
+      MockWebSocket.last.open()
+      MockWebSocket.last.emit('close')
+      vi.advanceTimersByTime(30_000)
+    }
+    const afterSixFailures = MockWebSocket.instances.length
+
+    MockWebSocket.last.open()
+    MockWebSocket.last.emit('close')
+    vi.advanceTimersByTime(250)
+
+    expect(MockWebSocket.instances).toHaveLength(afterSixFailures)
+  })
+
+  it('resets the backoff once a connection actually delivers data', () => {
+    listener = new WebSocketListener('ws://rpc')
+    listener.subscribe(PAYLOAD, () => {})
+
+    for (let i = 0; i < 6; i++) {
+      MockWebSocket.last.emit('close')
+      vi.advanceTimersByTime(30_000)
+    }
+
+    MockWebSocket.last.open()
+    MockWebSocket.last.message({ method: 'eth_subscription' })
+    const healthy = MockWebSocket.instances.length
+
+    MockWebSocket.last.emit('close')
+    vi.advanceTimersByTime(250)
+
+    expect(MockWebSocket.instances).toHaveLength(healthy + 1)
+  })
+
+  it('survives a handler that throws', () => {
+    // A throwing handler killed the freshness monitor 49 times.
+    listener = new WebSocketListener('ws://rpc')
+    listener.subscribe(PAYLOAD, () => {
+      throw new TypeError('undefined is not an object')
+    })
+    MockWebSocket.last.open()
+
+    expect(() => MockWebSocket.last.message({ method: 'eth_subscription' })).not.toThrow()
+  })
+
+  it('survives a malformed frame', () => {
+    const seen: unknown[] = []
+    listener = new WebSocketListener('ws://rpc')
+    listener.subscribe(PAYLOAD, (data) => seen.push(data))
+    MockWebSocket.last.open()
+
+    expect(() => MockWebSocket.last.emit('message', { data: 'not json' })).not.toThrow()
+
+    MockWebSocket.last.message({ ok: true })
+    expect(seen).toEqual([{ ok: true }])
+  })
+
+  it('stops reconnecting after stop()', () => {
+    listener = new WebSocketListener('ws://rpc', 1_000)
+    listener.subscribe(PAYLOAD, () => {})
+    MockWebSocket.last.open()
+
+    listener.stop()
+    const afterStop = MockWebSocket.instances.length
+    vi.advanceTimersByTime(60_000)
+
+    expect(MockWebSocket.instances).toHaveLength(afterStop)
+    expect(MockWebSocket.instances[0].closed).toBe(true)
+  })
+})

--- a/packages/pipes/src/monitoring/rpc-latency/ws-client.ts
+++ b/packages/pipes/src/monitoring/rpc-latency/ws-client.ts
@@ -1,32 +1,32 @@
-export class WebSocketListener {
-  #socket: WebSocket
+import { RpcLatencyListener } from './rpc-latency-watcher.js'
+
+const RECONNECT_MIN_MS = 250
+const RECONNECT_MAX_MS = 30_000
+
+/** Silence beyond this means a dead socket; must exceed the slowest chain's block time. */
+const DEFAULT_IDLE_TIMEOUT_MS = 60_000
+
+/**
+ * Keeps a JSON-RPC subscription alive over a WebSocket.
+ *
+ * Recovers from `close`, `error`, and silence — a half-open socket and a hung
+ * handshake both emit no event, so only a data-liveness deadline tells them apart
+ * from a quiet chain. Backoff is exponential and resets on delivered data rather
+ * than on `open`: a tight retry loop just gets the client rate-limited.
+ */
+export class WebSocketListener implements RpcLatencyListener {
+  #socket?: WebSocket
   #stopped = false
   #payload?: any
   #onMessage?: (data: any) => void
+  #attempt = 0
+  #reconnectTimer?: ReturnType<typeof setTimeout>
+  #idleTimer?: ReturnType<typeof setTimeout>
 
-  constructor(private url: string) {
-    this.#socket = new WebSocket(this.url)
-  }
-
-  private async open(): Promise<void> {
-    this.#socket.addEventListener('close', async () => {
-      if (this.#stopped) return
-
-      this.#socket = new WebSocket(this.url)
-      await this.open()
-    })
-
-    return new Promise((resolve) => {
-      this.#socket.addEventListener('open', () => {
-        this.#socket.send(JSON.stringify(this.#payload))
-        this.#socket.addEventListener('message', (event) => {
-          this.#onMessage?.(JSON.parse(event.data))
-        })
-
-        resolve()
-      })
-    })
-  }
+  constructor(
+    private url: string,
+    private idleTimeoutMs: number = DEFAULT_IDLE_TIMEOUT_MS,
+  ) {}
 
   subscribe(payload: any, onMessage: (data: any) => void) {
     // Just a simple guard to prevent multiple subscriptions
@@ -35,11 +35,107 @@ export class WebSocketListener {
     this.#payload = payload
     this.#onMessage = onMessage
 
-    void this.open()
+    this.connect()
+  }
+
+  private connect() {
+    if (this.#stopped) return
+
+    // Opened here, not in the constructor: an `open` firing before its listener is
+    // attached would leave the subscription unsent on a healthy-looking socket.
+    const socket = new WebSocket(this.url)
+    this.#socket = socket
+
+    // Armed before `open`, because a handshake that hangs emits no event at all —
+    // the deadline has to cover connecting, not just an established socket.
+    this.armIdleTimer()
+
+    // A replaced socket's events must not tear down its successor.
+    const isCurrent = () => this.#socket === socket
+
+    socket.addEventListener('open', () => {
+      if (!isCurrent()) return
+
+      socket.send(JSON.stringify(this.#payload))
+      this.armIdleTimer()
+    })
+
+    socket.addEventListener('message', (event) => {
+      if (!isCurrent()) return
+
+      // Delivered data, not `open`, is what proves the endpoint is usable: a
+      // rate-limiting provider accepts the upgrade and drops it, and resetting on
+      // `open` would turn that into the tight loop the backoff exists to prevent.
+      this.#attempt = 0
+      this.armIdleTimer()
+
+      // Runs detached from any caller's stack — a throw here reaches the top level.
+      try {
+        this.#onMessage?.(JSON.parse(event.data))
+      } catch {
+        // matches the silent-on-error behavior of PollingClient's tick
+      }
+    })
+
+    socket.addEventListener('error', () => {
+      if (isCurrent()) this.reconnect()
+    })
+
+    socket.addEventListener('close', () => {
+      if (isCurrent()) this.reconnect()
+    })
+  }
+
+  private reconnect() {
+    // `error` is usually followed by `close`; without this the pair schedules two.
+    if (this.#stopped || this.#reconnectTimer) return
+
+    this.clearIdleTimer()
+    this.closeSocket()
+
+    const backoff = Math.min(RECONNECT_MAX_MS, RECONNECT_MIN_MS * 2 ** this.#attempt)
+    this.#attempt++
+
+    // Jitter keeps watchers off a shared cadence.
+    const delay = backoff / 2 + Math.random() * (backoff / 2)
+
+    this.#reconnectTimer = setTimeout(() => {
+      this.#reconnectTimer = undefined
+      this.connect()
+    }, delay)
+  }
+
+  private armIdleTimer() {
+    this.clearIdleTimer()
+    if (this.idleTimeoutMs <= 0) return
+
+    this.#idleTimer = setTimeout(() => this.reconnect(), this.idleTimeoutMs)
+  }
+
+  private clearIdleTimer() {
+    if (!this.#idleTimer) return
+
+    clearTimeout(this.#idleTimer)
+    this.#idleTimer = undefined
+  }
+
+  private closeSocket() {
+    const socket = this.#socket
+    // Cleared first so the resulting `close` reads as stale.
+    this.#socket = undefined
+    socket?.close()
   }
 
   stop() {
     this.#stopped = true
-    this.#socket.close()
+
+    this.clearIdleTimer()
+
+    if (this.#reconnectTimer) {
+      clearTimeout(this.#reconnectTimer)
+      this.#reconnectTimer = undefined
+    }
+
+    this.closeSocket()
   }
 }

--- a/packages/pipes/src/solana/solana-rpc-latency-watcher.test.ts
+++ b/packages/pipes/src/solana/solana-rpc-latency-watcher.test.ts
@@ -1,9 +1,29 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import type { BatchContext } from '~/core/portal-source.js'
+import { MockWebSocket, mockWebSocket } from '~/testing/mock-websocket.js'
 import { testLogger } from '~/testing/test-logger.js'
 
 import { SolanaQueryBuilder } from './solana-query-builder.js'
 import { solanaRpcLatencyWatcher } from './solana-rpc-latency-watcher.js'
+
+const profilerStub: Record<string, unknown> = {
+  start: () => profilerStub,
+  measure: async (_: unknown, fn: () => unknown) => fn(),
+  end: () => {},
+  data: undefined,
+}
+
+function makeBatchContext(receivedAt: Date): BatchContext {
+  return {
+    profiler: profilerStub,
+    batch: { blocksCount: 1, bytesSize: 0, requests: {}, lastBlockReceivedAt: receivedAt },
+  } as unknown as BatchContext
+}
+
+function slotUpdate(result: unknown) {
+  return { method: 'slotsUpdatesNotification', params: { result } }
+}
 
 describe('solanaRpcLatencyWatcher factory', () => {
   let transformer: ReturnType<typeof solanaRpcLatencyWatcher> | undefined
@@ -32,5 +52,57 @@ describe('solanaRpcLatencyWatcher factory', () => {
 
     const requests = builder.getRequests()
     expect(requests).toContainEqual(expect.objectContaining({ range: { from: 'latest' } }))
+  })
+})
+
+describe('solanaRpcLatencyWatcher subscription', () => {
+  let transformer: ReturnType<typeof solanaRpcLatencyWatcher> | undefined
+  let restoreWebSocket: () => void
+
+  beforeEach(() => {
+    restoreWebSocket = mockWebSocket()
+  })
+
+  afterEach(async () => {
+    await transformer?.stop({ logger: testLogger() })
+    transformer = undefined
+    restoreWebSocket()
+  })
+
+  it('records a slot on optimisticConfirmation and leaves hash undefined', async () => {
+    transformer = solanaRpcLatencyWatcher({ rpcUrl: ['ws://rpc'] })
+    await transformer.start({} as never)
+
+    MockWebSocket.last.open()
+    expect(JSON.parse(MockWebSocket.last.sent[0])).toMatchObject({ method: 'slotsUpdatesSubscribe' })
+
+    const timestamp = new Date('2026-05-09T00:00:00Z')
+    MockWebSocket.last.message(
+      slotUpdate({ type: 'optimisticConfirmation', slot: 500, timestamp: timestamp.getTime() }),
+    )
+
+    const result = await transformer.run(
+      [{ header: { number: 500, timestamp: timestamp.getTime() / 1000 } }] as never,
+      makeBatchContext(new Date('2026-05-09T00:00:01Z')),
+    )
+
+    expect(result?.number).toBe(500)
+    expect(result?.rpc[0]?.url).toBe('ws://rpc')
+    expect(result?.rpc[0]?.hash).toBeUndefined()
+  })
+
+  it('ignores slot updates that have not reached optimisticConfirmation', async () => {
+    transformer = solanaRpcLatencyWatcher({ rpcUrl: ['ws://rpc'] })
+    await transformer.start({} as never)
+    MockWebSocket.last.open()
+
+    MockWebSocket.last.message(slotUpdate({ type: 'firstShredReceived', slot: 501, timestamp: Date.now() }))
+    expect(() => MockWebSocket.last.message({ method: 'slotsUpdatesNotification', params: {} })).not.toThrow()
+
+    const result = await transformer.run(
+      [{ header: { number: 501, timestamp: 0 } }] as never,
+      makeBatchContext(new Date()),
+    )
+    expect(result).toBeNull()
   })
 })

--- a/packages/pipes/src/solana/solana-rpc-latency-watcher.ts
+++ b/packages/pipes/src/solana/solana-rpc-latency-watcher.ts
@@ -42,11 +42,6 @@ type Notification = {
 }
 
 class SolanaRpcLatencyWatcher extends RpcLatencyWatcher {
-  constructor(rpcUrl: string | string[]) {
-    super(rpcUrl)
-    this.attach()
-  }
-
   watch(url: string) {
     const listener = new WebSocketListener(url)
 

--- a/packages/pipes/src/testing/index.ts
+++ b/packages/pipes/src/testing/index.ts
@@ -1,3 +1,4 @@
+export * from './mock-websocket.js'
 export * from './test-block-stream.js'
 export * from './test-logger.js'
 export * from './test-metrics-server.js'

--- a/packages/pipes/src/testing/mock-websocket.ts
+++ b/packages/pipes/src/testing/mock-websocket.ts
@@ -1,0 +1,64 @@
+type Handler = (event?: any) => void
+
+/**
+ * Stand-in for the global `WebSocket`, driven by the test rather than a server.
+ * Install with `mockWebSocket()`; combine with fake timers to exercise
+ * reconnect and idle-timeout behaviour without waiting on wall-clock delays.
+ */
+export class MockWebSocket {
+  static instances: MockWebSocket[] = []
+
+  sent: string[] = []
+  closed = false
+  readonly #handlers = new Map<string, Handler[]>()
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this)
+  }
+
+  static get last() {
+    return MockWebSocket.instances[MockWebSocket.instances.length - 1]
+  }
+
+  addEventListener(type: string, handler: Handler) {
+    this.#handlers.set(type, [...(this.#handlers.get(type) ?? []), handler])
+  }
+
+  emit(type: string, event?: any) {
+    for (const handler of this.#handlers.get(type) ?? []) {
+      handler(event)
+    }
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close() {
+    this.closed = true
+    this.emit('close')
+  }
+
+  open() {
+    this.emit('open')
+  }
+
+  /** Delivers `payload` as a JSON frame, the way a subscription update arrives. */
+  message(payload: unknown) {
+    this.emit('message', { data: JSON.stringify(payload) })
+  }
+}
+
+/**
+ * Swaps the global `WebSocket` for {@link MockWebSocket} and resets the instance
+ * log. Returns the restore function — call it from `afterEach`.
+ */
+export function mockWebSocket(): () => void {
+  const original = (globalThis as any).WebSocket
+  MockWebSocket.instances = []
+  ;(globalThis as any).WebSocket = MockWebSocket
+
+  return () => {
+    ;(globalThis as any).WebSocket = original
+  }
+}


### PR DESCRIPTION
## Summary

- `RpcLatencyWatcher` now subscribes from a re-runnable `start()` driven by the transformer's start hook, instead of once from a subclass constructor with `stop()` as a one-way latch. After the first stream restart the old watcher stayed shut forever: `lookup()` returned nothing, and the latency gauges held their last value while the stream kept indexing — a flat line that reads as a stable delay rather than an outage.
- `WebSocketListener` now recovers from `error` and from silence (idle watchdog), not just `close`, and backs off exponentially instead of retrying in a tight loop. It also contains throws from message handlers, which previously reached the top level and killed the process.
- Retained RPC heads are capped per node; nothing pruned them before, so the map grew for the lifetime of the process. The never-called `cleanup()` is removed in favour of that bound, which also holds while the portal side is stalled.

Found while debugging the `portal-freshness` monitor, where `freshness_portal_lag_ms` for Ethereum had been pinned at a single value for ~7h. `freshness_misses_total{kind="no_rpc_match"}` was 4.8/min — every block missing — while the portal stream itself was healthy and in sync.

## Coverage

| Module | Stmts | Δ | Branch | Δ |
|--------|-------|---|--------|---|
| **All files** | 85.2% | +0.4 | 85.7% | +0.0 |
| src/evm | 89.6% | +1.6 | 91.4% | +0.2 |
| src/monitoring/rpc-latency | 100.0% | +8.8 | 87.5% | -2.7 |
| src/portal-client/query | 96.4% | +0.0 | 87.5% | +0.2 |
| src/solana | 76.0% | +1.7 | 54.2% | +2.5 |
| src/testing | 89.0% | +1.7 | 84.9% | +1.1 |

Branch coverage in `src/monitoring/rpc-latency` dips because the backoff and idle-timeout paths add branches; statement coverage for the module is 100%.

## Test plan

- [x] Watcher re-subscribes after `stop()`, and retains observed heads across the restart
- [x] `start()` / `stop()` are idempotent
- [x] Transformer `start` hook subscribes
- [x] Oldest heads evicted past the retention cap
- [x] WebSocket reconnects on `close`, on `error`, and on silence; stays put while messages arrive
- [x] `error` + `close` schedule a single reconnect; events from a replaced socket are ignored
- [x] Reconnects back off instead of looping; `stop()` ends them
- [x] Throwing handlers and malformed frames do not propagate
- [x] EVM `newHeads` and Solana `slotsUpdates` subscriptions match observed heads against portal blocks
- [x] EVM frame with no `params.result` is ignored rather than crashing — the failure that restarted the deployed monitor 49 times
- [x] Full suite: 606 passed, 18 skipped (ClickHouse + Postgres up via `packages/pipes/docker-compose.yml`)

Mutation-checked the two central tests: disabling the idle watchdog fails the silence test, and restoring `stop()` to a one-way latch fails the restart test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
