### PR TITLE
fix(portal): honour a finalized head of block 0 and stop emitting empty batches

### DIFF
--- a/packages/pipes/src/core/portal-source.test.ts
+++ b/packages/pipes/src/core/portal-source.test.ts
@@ -1,9 +1,50 @@
 import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 
+import { SpanHooks } from '~/core/profiling.js'
 import { Target, createTarget } from '~/core/target.js'
 import { TransformerArgs, createTransformer } from '~/core/transformer.js'
 import { evmPortalStream } from '~/evm/index.js'
 import { MockPortal, blockDecoder, finalizedMockPortal, mockPortal, readAll } from '~/testing/index.js'
+
+/**
+ * Tallies span starts and ends per name. A single global total hides the interesting cases — a
+ * double-end on one span cancels out a leak on another.
+ */
+function spanCounter() {
+  const started: Record<string, number> = {}
+  const ended: Record<string, number> = {}
+
+  const track = (name: string): SpanHooks => ({
+    onStart: (child) => {
+      started[child] = (started[child] ?? 0) + 1
+
+      return track(child)
+    },
+    onEnd: () => {
+      ended[name] = (ended[name] ?? 0) + 1
+    },
+  })
+
+  return {
+    hooks: track('<root>'),
+    started,
+    ended,
+    unbalanced: () =>
+      [...new Set([...Object.keys(started), ...Object.keys(ended)])]
+        .filter((name) => (started[name] ?? 0) !== (ended[name] ?? 0))
+        .map((name) => `${name}: ${started[name] ?? 0} started, ${ended[name] ?? 0} ended`),
+  }
+}
+
+function threeBlockPortal() {
+  return mockPortal(
+    [1, 2, 3].map((number) => ({
+      statusCode: 200,
+      data: [{ header: { number, hash: `0x${number}`, timestamp: number * 1000 } }],
+      head: { finalized: { number: 0, hash: '0x0' } },
+    })),
+  )
+}
 
 describe('Portal abstract stream', () => {
   let portal: MockPortal
@@ -554,6 +595,140 @@ describe('stop lifecycle', () => {
     await expect(readAll(stream)).rejects.toThrow('start failed')
 
     expect(stopSpy).toHaveBeenCalledTimes(1)
+  })
+
+  // The read loop arms a batch/fetch span pair up front, so the last one is always for a batch
+  // that never arrives. It leaks a pair per stream, and read() restarts on every retry.
+  it('ends the span pair armed for a batch that never arrives', async () => {
+    portal = await mockPortal([
+      { statusCode: 200, data: [], head: { finalized: { number: 0, hash: '0x0' } } },
+      {
+        statusCode: 200,
+        data: [{ header: { number: 1, hash: '0x1', timestamp: 1000 } }],
+        head: { finalized: { number: 0, hash: '0x0' } },
+      },
+    ])
+
+    const spans = spanCounter()
+
+    await readAll(
+      evmPortalStream({
+        id: 'test',
+        portal: portal.url,
+        profiler: spans.hooks,
+        outputs: blockDecoder({ from: 0, to: 1 }),
+      }),
+    )
+
+    expect(spans.started['fetch data']).toBeGreaterThan(0)
+    expect(spans.unbalanced()).toEqual([])
+  })
+
+  // A 204 head poll puts a zero-block batch and flushes it, so the read loop sees a batch it
+  // never yields and nothing downstream closes its span.
+  it('ends the batch span for the empty batch a 204 head poll delivers', async () => {
+    portal = await mockPortal([
+      {
+        statusCode: 200,
+        data: [{ header: { number: 1, hash: '0x1', timestamp: 1000 } }],
+        head: { finalized: { number: 0, hash: '0x0' } },
+      },
+      { statusCode: 204 },
+      {
+        statusCode: 200,
+        data: [{ header: { number: 2, hash: '0x2', timestamp: 2000 } }],
+        head: { finalized: { number: 0, hash: '0x0' } },
+      },
+    ])
+
+    const spans = spanCounter()
+
+    const blocks = await readAll(
+      evmPortalStream({
+        id: 'test',
+        portal: portal.url,
+        profiler: spans.hooks,
+        outputs: blockDecoder({ from: 0, to: 2 }),
+      }),
+    )
+
+    // Two yielded, one dropped from the 204, one armed for the batch that never arrives.
+    expect(blocks.length).toBe(2)
+    expect(spans.started['batch']).toBe(4)
+    expect(spans.unbalanced()).toEqual([])
+  })
+
+  // Unwinding through the yield leaves readSpan already ended at the top of the loop body, so the
+  // finally would end it a second time.
+  it('does not double-end the fetch span when the consumer breaks early', async () => {
+    portal = await threeBlockPortal()
+
+    const spans = spanCounter()
+
+    for await (const _ of evmPortalStream({
+      id: 'test',
+      portal: portal.url,
+      profiler: spans.hooks,
+      outputs: blockDecoder({ from: 0, to: 3 }),
+    })) {
+      break
+    }
+
+    expect(spans.started['fetch data']).toBeGreaterThan(0)
+    expect(spans.unbalanced()).toEqual([])
+  })
+
+  it('does not double-end the fetch span when the consumer throws', async () => {
+    portal = await threeBlockPortal()
+
+    const spans = spanCounter()
+
+    await expect(
+      (async () => {
+        for await (const _ of evmPortalStream({
+          id: 'test',
+          portal: portal.url,
+          profiler: spans.hooks,
+          outputs: blockDecoder({ from: 0, to: 3 }),
+        })) {
+          throw new Error('consumer boom')
+        }
+      })(),
+    ).rejects.toThrow('consumer boom')
+
+    expect(spans.unbalanced()).toEqual([])
+  })
+
+  // A throwing transformer skips its own span.end() and the enclosing 'apply transformers' one.
+  it('ends transformer spans when a transformer throws mid-stream', async () => {
+    portal = await threeBlockPortal()
+
+    const spans = spanCounter()
+
+    let seen = 0
+    const stream = evmPortalStream({
+      id: 'test',
+      portal: portal.url,
+      profiler: spans.hooks,
+      outputs: blockDecoder({ from: 0, to: 3 }),
+    }).pipe(
+      createTransformer({
+        profiler: { name: 'boom' },
+        transform: (data) => {
+          seen++
+          if (seen === 2) {
+            throw new Error('transformer boom')
+          }
+
+          return data
+        },
+      }),
+    )
+
+    await expect(readAll(stream)).rejects.toThrow('transformer boom')
+
+    expect(spans.started['boom']).toBe(2)
+    expect(spans.unbalanced()).toEqual([])
   })
 })
 

--- a/packages/pipes/src/core/portal-source.ts
+++ b/packages/pipes/src/core/portal-source.ts
@@ -232,67 +232,76 @@ export class PortalStream<Q extends QueryBuilder<any>, T = any> {
 
       let batchSpan = Span.root('batch', this.#options.profiler).addLabels('core')
       let readSpan = batchSpan.start('fetch data').addLabels('core')
-      for await (const batch of source) {
-        readSpan.end()
+      try {
+        for await (const batch of source) {
+          readSpan.end()
 
-        const blocks = batch.blocks
+          const blocks = batch.blocks
 
-        if (blocks.length > 0) {
-          // Clamp the portal's finalized head through the monotonic watermark before it
-          // reaches any consumer, so a regressed or transiently-missing finalized head can
-          // never un-finalize already-committed data. The rollback chain is derived from the
-          // CLAMPED head so the two stay consistent (clamp can only raise finalized).
-          const finalized = this.#watermark.clamp(batch.head.finalized)
+          if (blocks.length > 0) {
+            // Clamp the portal's finalized head through the monotonic watermark before it
+            // reaches any consumer, so a regressed or transiently-missing finalized head can
+            // never un-finalize already-committed data. The rollback chain is derived from the
+            // CLAMPED head so the two stay consistent (clamp can only raise finalized).
+            const finalized = this.#watermark.clamp(batch.head.finalized)
 
-          // TODO WTF with any?
-          const lastBatchBlock = last(blocks as { header: { number: number } }[])
+            // TODO WTF with any?
+            const lastBatchBlock = last(blocks as { header: { number: number } }[])
 
-          const lastBlockNumber = Math.max(
-            Math.min(last(bounded)?.range?.to || batch.head.latest?.number || finalized?.number || Infinity),
-            lastBatchBlock.header?.number || -Infinity,
-          )
+            const lastBlockNumber = Math.max(
+              Math.min(last(bounded)?.range?.to || batch.head.latest?.number || finalized?.number || Infinity),
+              lastBatchBlock.header?.number || -Infinity,
+            )
 
-          const ctx: BatchContext = {
-            id: this.#id,
-            profiler: batchSpan,
-            metrics: this.#metricServer.metrics,
-            logger: this.#logger,
-            stream: {
-              dataset: datasetMetadata,
-              head: {
-                finalized,
-                latest: batch.head.latest,
+            const ctx: BatchContext = {
+              id: this.#id,
+              profiler: batchSpan,
+              metrics: this.#metricServer.metrics,
+              logger: this.#logger,
+              stream: {
+                dataset: datasetMetadata,
+                head: {
+                  finalized,
+                  latest: batch.head.latest,
+                },
+                query: {
+                  url: this.#portal.getUrl(),
+                  hash: await hashQuery(query),
+                  raw: query,
+                },
+                state: {
+                  initial,
+                  current: cursorFromHeader(lastBatchBlock as any),
+                  last: lastBlockNumber,
+                  rollbackChain: extractRollbackChain({
+                    blocks: batch.blocks,
+                    head: finalized,
+                  }),
+                },
               },
-              query: {
-                url: this.#portal.getUrl(),
-                hash: await hashQuery(query),
-                raw: query,
+              batch: {
+                blocksCount: batch.blocks.length,
+                bytesSize: batch.meta.bytes,
+                requests: batch.meta.requests,
+                lastBlockReceivedAt: batch.meta.lastBlockReceivedAt,
               },
-              state: {
-                initial,
-                current: cursorFromHeader(lastBatchBlock as any),
-                last: lastBlockNumber,
-                rollbackChain: extractRollbackChain({
-                  blocks: batch.blocks,
-                  head: finalized,
-                }),
-              },
-            },
-            batch: {
-              blocksCount: batch.blocks.length,
-              bytesSize: batch.meta.bytes,
-              requests: batch.meta.requests,
-              lastBlockReceivedAt: batch.meta.lastBlockReceivedAt,
-            },
+            }
+
+            const data = await this.applyTransformers(ctx, batch.blocks as T)
+
+            yield { data, ctx }
+          } else {
+            // Never yielded, so batchEnd won't run.
+            batchSpan.end()
           }
 
-          const data = await this.applyTransformers(ctx, batch.blocks as T)
-
-          yield { data, ctx }
+          batchSpan = Span.root('batch', this.#options.profiler).addLabels('core')
+          readSpan = batchSpan.start('fetch data').addLabels('core')
         }
-
-        batchSpan = Span.root('batch', this.#options.profiler).addLabels('core')
-        readSpan = batchSpan.start('fetch data').addLabels('core')
+      } finally {
+        // The last pair is always armed for a batch that never arrives.
+        readSpan.end()
+        batchSpan.end()
       }
     }
 
@@ -331,14 +340,17 @@ export class PortalStream<Q extends QueryBuilder<any>, T = any> {
   private async applyTransformers(ctx: BatchContext, data: T) {
     const span = ctx.profiler.start('apply transformers').addLabels('core')
 
-    for (const transformer of this.#transformers) {
-      data = await transformer.run(data, {
-        ...ctx,
-        profiler: span,
-        logger: this.#logger,
-      })
+    try {
+      for (const transformer of this.#transformers) {
+        data = await transformer.run(data, {
+          ...ctx,
+          profiler: span,
+          logger: this.#logger,
+        })
+      }
+    } finally {
+      span.end()
     }
-    span.end()
 
     return data
   }

--- a/packages/pipes/src/core/profiling.ts
+++ b/packages/pipes/src/core/profiling.ts
@@ -55,6 +55,7 @@ export class Span implements Profiler {
 
   readonly hidden: boolean
   readonly #hooks: SpanHooks | null
+  #ended = false
 
   /**
    * Creates a root Profiler span.
@@ -137,9 +138,14 @@ export class Span implements Profiler {
   /**
    Marks the end of the span and calculates the elapsed time.
 
+   Idempotent — a second `onEnd()` would re-close a span the backend already closed.
+
    Returns the current span instance for chaining.
    */
   end() {
+    if (this.#ended) return this
+    this.#ended = true
+
     this.elapsed = performance.now() - this.started
     if (!this.hidden) {
       this.#hooks?.onEnd()

--- a/packages/pipes/src/core/transformer.ts
+++ b/packages/pipes/src/core/transformer.ts
@@ -96,20 +96,19 @@ export class Transformer<In, Out> {
    */
   async run(data: In, ctx: BatchContext): Promise<Out> {
     const span = ctx.profiler.start(this.options.profiler)
-    let res = await this.options.transform(data, { ...ctx, profiler: span })
-    span.data = res
 
-    if (this.children.length === 0) {
-      span.end()
+    try {
+      let res = await this.options.transform(data, { ...ctx, profiler: span })
+      span.data = res
+
+      for (const child of this.children) {
+        res = await child.run(res, { ...ctx, profiler: span })
+      }
+
       return res
+    } finally {
+      span.end()
     }
-
-    for (const child of this.children) {
-      res = await child.run(res, { ...ctx, profiler: span })
-    }
-
-    span.end()
-    return res
   }
 
   /**

--- a/packages/pipes/src/portal-client/client.test.ts
+++ b/packages/pipes/src/portal-client/client.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PortalClient } from '~/portal-client/client.js'
+import { MockPortal, MockResponse, mockPortal } from '~/testing/index.js'
+
+let portal: MockPortal | undefined
+
+afterEach(async () => {
+  await portal?.close()
+  portal = undefined
+})
+
+const query = {
+  type: 'evm',
+  fromBlock: 0,
+  toBlock: 3,
+  fields: { block: { number: true, hash: true } },
+} as any
+
+function block(number: number) {
+  return { header: { number, hash: `0x${number}` } }
+}
+
+/** Block numbers per delivered batch — the shape targets actually observe. */
+async function batchShapes(client: PortalClient, perBlockUnfinalized: boolean, options?: { maxIdleTimeMs?: number }) {
+  const shapes: number[][] = []
+  for await (const batch of client.getStream(query, { ...options, perBlockUnfinalized })) {
+    shapes.push(batch.blocks.map((b: any) => b.header.number))
+  }
+
+  return shapes
+}
+
+/** Requests attributed across every delivered batch, keyed by status. */
+async function countRequests(
+  client: PortalClient,
+  perBlockUnfinalized = false,
+  options?: { request?: { retryAttempts?: number; retrySchedule?: number[] } },
+) {
+  const counted: Record<number, number> = {}
+  for await (const batch of client.getStream(query, { ...options, perBlockUnfinalized })) {
+    for (const [status, count] of Object.entries(batch.meta.requests ?? {})) {
+      counted[Number(status)] = (counted[Number(status)] ?? 0) + count
+    }
+  }
+
+  return counted
+}
+
+describe('PortalClient batching', () => {
+  // What every target except Postgres gets.
+  it('delivers one batch per response by default', async () => {
+    portal = await mockPortal([
+      {
+        statusCode: 200,
+        data: [block(1), block(2), block(3)],
+        head: { finalized: { number: 2, hash: '0x2' } },
+      },
+    ])
+
+    const client = new PortalClient({ url: portal.url })
+
+    expect(await batchShapes(client, false)).toEqual([[1, 2, 3]])
+  })
+
+  // Postgres keys undo snapshots by the batch's last block.
+  it('splits every unfinalized block into its own batch when asked', async () => {
+    portal = await mockPortal([
+      {
+        statusCode: 200,
+        data: [block(1), block(2), block(3)],
+        head: { finalized: { number: 1, hash: '0x1' } },
+      },
+    ])
+
+    const client = new PortalClient({ url: portal.url })
+
+    expect(await batchShapes(client, true)).toEqual([[1], [2], [3]])
+  })
+
+  // Read as "no finality", every hot block would be filed as finalized instead.
+  it('treats a finalized head of block 0 as finality, not as its absence', async () => {
+    portal = await mockPortal([
+      {
+        statusCode: 200,
+        data: [block(1), block(2), block(3)],
+        head: { finalized: { number: 0, hash: '0x0' } },
+      },
+    ])
+
+    const client = new PortalClient({ url: portal.url })
+
+    expect(await batchShapes(client, true)).toEqual([[1], [2], [3]])
+  })
+
+  // maxIdleTimeMs is pinned high so only cut() can separate the batches — on the default 300ms an
+  // idle flush would hide a regression.
+  it('never merges pending finalized blocks into an unfinalized block batch', async () => {
+    portal = await mockPortal([
+      {
+        statusCode: 200,
+        data: [block(1)],
+        head: { finalized: { number: 1, hash: '0x1' } },
+      },
+      {
+        statusCode: 200,
+        data: [block(2), block(3)],
+        head: { finalized: { number: 1, hash: '0x1' } },
+      },
+    ] satisfies MockResponse[])
+
+    const client = new PortalClient({ url: portal.url })
+
+    const shapes = await batchShapes(client, true, { maxIdleTimeMs: 60_000 })
+
+    expect(shapes.some((s) => s.includes(1) && s.length > 1)).toBe(false)
+    expect(shapes).toEqual([[1], [2], [3]])
+  })
+})
+
+describe('PortalClient request accounting', () => {
+  // Every hot block gets its own batch, so passing the counters to each would bill one response
+  // three times over.
+  it('counts one response as one request however many batches it becomes', async () => {
+    portal = await mockPortal([
+      {
+        statusCode: 200,
+        data: [block(1), block(2), block(3)],
+        head: { finalized: { number: 0, hash: '0x0' } },
+      },
+    ])
+
+    const client = new PortalClient({ url: portal.url })
+
+    expect(await countRequests(client, true)).toEqual({ 200: 1 })
+  })
+
+  // A 200 with an empty body hands its counters to no batch. They have to survive into the next
+  // response rather than being reset with the loop.
+  it('keeps the counters of a response that carries no blocks', async () => {
+    portal = await mockPortal([
+      { statusCode: 200, data: [], head: { finalized: { number: 3, hash: '0x3' } } },
+      {
+        statusCode: 200,
+        data: [block(1), block(2), block(3)],
+        head: { finalized: { number: 3, hash: '0x3' } },
+      },
+    ] satisfies MockResponse[])
+
+    const client = new PortalClient({ url: portal.url })
+
+    expect(await countRequests(client)).toEqual({ 200: 2 })
+  })
+
+  // The 204 branch delivers its own batch, so its counters must be cleared there — otherwise
+  // carrying them forward bills the poll a second time.
+  it('counts a head poll once', async () => {
+    portal = await mockPortal([
+      { statusCode: 204 },
+      {
+        statusCode: 200,
+        data: [block(1), block(2), block(3)],
+        head: { finalized: { number: 3, hash: '0x3' } },
+      },
+    ] satisfies MockResponse[])
+
+    const client = new PortalClient({ url: portal.url })
+
+    expect(await countRequests(client)).toEqual({ 200: 1, 204: 1 })
+  })
+
+  // Retries are counted per attempt, and a chunkless response must not take them down with it.
+  it('keeps retry counters across a response that carries no blocks', async () => {
+    portal = await mockPortal([
+      { statusCode: 503 },
+      { statusCode: 200, data: [], head: { finalized: { number: 3, hash: '0x3' } } },
+      {
+        statusCode: 200,
+        data: [block(1), block(2), block(3)],
+        head: { finalized: { number: 3, hash: '0x3' } },
+      },
+    ] satisfies MockResponse[])
+
+    const client = new PortalClient({ url: portal.url })
+
+    expect(await countRequests(client, false, { request: { retryAttempts: 2, retrySchedule: [1] } })).toEqual({
+      200: 2,
+      503: 1,
+    })
+  })
+})

--- a/packages/pipes/src/portal-client/client.ts
+++ b/packages/pipes/src/portal-client/client.ts
@@ -261,11 +261,13 @@ function createPortalStream<Q extends Query>(
 
   let { fromBlock = 0, toBlock, parentBlockHash } = query
 
+  // Outside the loop: a response carrying no blocks hands its counters to no batch, so they must
+  // survive into the next iteration.
+  let requests: Record<number, number> = {}
+
   const ingest = async () => {
     while (!buffer.signal.aborted) {
       if (toBlock != null && fromBlock > toBlock) break
-
-      let requests: Record<number, number> = {}
 
       const res = await requestStream(
         {
@@ -291,6 +293,7 @@ function createPortalStream<Q extends Query>(
           meta: { bytes: 0, requestedFromBlock: fromBlock, lastBlockReceivedAt: new Date(), requests },
           head: res.head,
         })
+        requests = {}
         buffer.flush()
         if (headPollInterval > 0) {
           await wait(headPollInterval, buffer.signal)
@@ -330,29 +333,37 @@ function createPortalStream<Q extends Query>(
 
           const finalizedHead = res.head.finalized?.number
 
-          // Split blocks into finalized and unfinalized
-          const [finalizedBlocks, unfinalizedBlocks] = finalizedHead
-            ? partition(blocks, ({ block }) => block.header?.number <= finalizedHead)
-            : [blocks, []]
+          // `!= null`: a head of 0 is real, and reading it as absent files every hot block as finalized.
+          const [finalizedBlocks, unfinalizedBlocks] =
+            finalizedHead != null
+              ? partition(blocks, ({ block }) => block.header?.number <= finalizedHead)
+              : [blocks, []]
+
+          // Carried by the first batch out, so one response counts as one request.
+          let pendingRequests = requests
 
           if (perBlockUnfinalized) {
-            // Targets that key a rollback snapshot by the batch's last block (Postgres) need every
-            // rollback-able block in its own batch, and a finalized block must never share one with
-            // an unfinalized block — otherwise a fork to the finalized head rolls back finalized
-            // writes. Finalized blocks still travel as one bulk: they can never roll back.
-            await buffer.put(
-              {
-                blocks: finalizedBlocks.map((b) => b.block),
-                head: res.head,
-                meta: {
-                  bytes: finalizedBlocks.reduce((a, b) => a + b.bytes, 0),
-                  requestedFromBlock,
-                  lastBlockReceivedAt,
-                  requests,
+            // Postgres tags undo rows with the batch's last block, so every rollback-able block
+            // needs its own batch, never shared with a finalized one.
+            if (finalizedBlocks.length > 0) {
+              await buffer.put(
+                {
+                  blocks: finalizedBlocks.map((b) => b.block),
+                  head: res.head,
+                  meta: {
+                    bytes: finalizedBlocks.reduce((a, b) => a + b.bytes, 0),
+                    requestedFromBlock,
+                    lastBlockReceivedAt,
+                    requests: pendingRequests,
+                  },
                 },
-              },
-              unfinalizedBlocks.length > 0,
-            )
+                unfinalizedBlocks.length > 0,
+              )
+              pendingRequests = {}
+            } else if (unfinalizedBlocks.length > 0) {
+              // Or blocks pending from earlier all-finalized responses inherit this batch's number.
+              await buffer.cut()
+            }
 
             for (let { block, bytes } of unfinalizedBlocks) {
               await buffer.put(
@@ -363,13 +374,12 @@ function createPortalStream<Q extends Query>(
                     bytes,
                     requestedFromBlock,
                     lastBlockReceivedAt,
-                    // We flush requests here to avoid double-counting
-                    // as we already sent them
-                    requests: finalizedBlocks.length > 0 ? {} : requests,
+                    requests: pendingRequests,
                   },
                 },
                 true,
               )
+              pendingRequests = {}
             }
           } else {
             // One batch per response. Targets that resolve a rollback from a block number carried on
@@ -384,14 +394,15 @@ function createPortalStream<Q extends Query>(
                   bytes: blocks.reduce((a, b) => a + b.bytes, 0),
                   requestedFromBlock,
                   lastBlockReceivedAt,
-                  requests,
+                  requests: pendingRequests,
                 },
               },
               unfinalizedBlocks.length > 0,
             )
+            pendingRequests = {}
           }
 
-          requests = {}
+          requests = pendingRequests
         }
       } catch (err) {
         if (buffer.signal.aborted) break

--- a/packages/pipes/src/portal-client/stream-buffer.test.ts
+++ b/packages/pipes/src/portal-client/stream-buffer.test.ts
@@ -458,4 +458,74 @@ describe('StreamBuffer', () => {
       buffer.fail(new Error('nope')) // should not throw or change state
     })
   })
+
+  describe('cut', () => {
+    // No timer may fire on its own here: the batch separation must come from cut(), not a flush.
+    const noTimers = { maxBytes: 1_000_000, maxIdleTime: 1_000_000, maxWaitTime: 1_000_000 }
+
+    it('delivers pending data as its own batch', async () => {
+      const buffer = new StreamBuffer<string>(noTimers)
+
+      const collected = collectAll(buffer)
+
+      await buffer.put(makeData(['a']))
+      await buffer.cut()
+      await buffer.put(makeData(['b']))
+      await buffer.cut()
+      buffer.close()
+
+      expect((await collected).map((d) => d.blocks)).toEqual([['a'], ['b']])
+    })
+
+    // Why cut() exists: flush() marks the batch ready without waiting, so the next put re-enters
+    // the same buffer and appends to it.
+    it('flush alone lets the next put merge into the same batch', async () => {
+      const buffer = new StreamBuffer<string>(noTimers)
+
+      await buffer.put(makeData(['a']))
+      buffer.flush()
+      await buffer.put(makeData(['b']))
+
+      expect((await buffer.take())?.blocks).toEqual(['a', 'b'])
+
+      buffer.close()
+    })
+
+    it('is a no-op when nothing is pending', async () => {
+      const buffer = new StreamBuffer<string>(noTimers)
+
+      await buffer.cut()
+
+      buffer.close()
+    })
+
+    it('resolves instead of hanging on a closed buffer', async () => {
+      const buffer = new StreamBuffer<string>(noTimers)
+
+      await buffer.put(makeData(['a']))
+      buffer.close()
+
+      await buffer.cut()
+    })
+
+    it('resolves instead of hanging on a failed buffer', async () => {
+      const buffer = new StreamBuffer<string>(noTimers)
+
+      await buffer.put(makeData(['a']))
+      buffer.fail(new Error('boom'))
+
+      await buffer.cut()
+    })
+
+    it('is released when the consumer abandons the iterator', async () => {
+      const buffer = new StreamBuffer<string>(noTimers)
+
+      await buffer.put(makeData(['a']))
+      const cutting = buffer.cut()
+
+      await buffer.iterate()[Symbol.asyncIterator]().return!()
+
+      await cutting
+    })
+  })
 })

--- a/packages/pipes/src/portal-client/stream-buffer.ts
+++ b/packages/pipes/src/portal-client/stream-buffer.ts
@@ -134,6 +134,19 @@ export class StreamBuffer<B> {
     this._ready()
   }
 
+  /**
+   * Deliver whatever is pending as its own batch. Unlike `flush()` this waits until the consumer
+   * has taken it, so a following `put` cannot merge into the same batch.
+   */
+  async cut(): Promise<void> {
+    if (this.buffer == null) return
+    // Terminal states never resolve a fresh consumedSignal; _cleanup() already released this one.
+    if (this.state === 'closed' || this.state === 'failed') return
+
+    this._ready()
+    await this.consumedSignal.promise()
+  }
+
   close() {
     if (this.state === 'closed' || this.state === 'failed') return
     this.state = 'closed'

--- a/packages/pipes/src/targets/drizzle/node-postgres/drizzle-target.test.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/drizzle-target.test.ts
@@ -838,6 +838,82 @@ describe('Drizzle target', () => {
     })
   })
 
+  // Read by truthiness a head of 0 looks like no finality, so the undo log is never written.
+  describe('class-T undo with a finalized head of block 0', () => {
+    const balances = pgTable('balances', {
+      account: integer().primaryKey(),
+      balance: integer().notNull(),
+    })
+
+    beforeEach(async () => {
+      await execute(`
+        DROP SCHEMA IF EXISTS "public" CASCADE;
+        CREATE SCHEMA IF NOT EXISTS "public";
+        CREATE TABLE balances (
+          account integer PRIMARY KEY,
+          balance integer NOT NULL
+        );
+      `)
+    })
+
+    it('rolls back a fork when only the genesis block is finalized', async () => {
+      portal = await mockPortal([
+        ...[1, 2].map(
+          (block): MockResponse => ({
+            statusCode: 200,
+            data: [{ header: { number: block, hash: `0x${block}`, timestamp: block * 1000 } }],
+            head: { finalized: { number: 0, hash: '0x0' } },
+          }),
+        ),
+        {
+          // Forks block 2; the safe ancestor is block 1, itself unfinalized.
+          statusCode: 409,
+          data: {
+            previousBlocks: [
+              { number: 1, hash: '0x1' },
+              { number: 2, hash: '0x2a' },
+            ],
+          },
+        },
+        {
+          statusCode: 200,
+          data: [
+            { header: { number: 2, hash: '0x2a', timestamp: 2000 } },
+            { header: { number: 3, hash: '0x3a', timestamp: 3000 } },
+          ],
+          head: { finalized: { number: 0, hash: '0x0' } },
+        },
+      ])
+
+      let rolledBack: number[] | undefined
+
+      await evmPortalStream({
+        id: 'test',
+        portal: portal.url,
+        outputs: blockDecoder({ from: 0, to: 3 }),
+      }).pipeTo(
+        drizzleTarget({
+          db,
+          tables: [balances],
+          onData: async ({ tx, data }) => {
+            for (const b of data) {
+              await tx.insert(balances).values({ account: b.number, balance: b.number }).onConflictDoNothing()
+            }
+          },
+          onAfterRollback: async ({ tx, cursor }) => {
+            expect(cursor.number).toEqual(1)
+
+            const rows = await tx.select().from(balances)
+            rolledBack = rows.map((r) => r.account).sort()
+          },
+        }),
+      )
+
+      // Block 2 was undone; block 1 predates the fork and stays.
+      expect(rolledBack).toEqual([1])
+    })
+  })
+
   describe('forks on tables with foreign keys', () => {
     const parentTable = pgTable('parent', {
       id: integer().primaryKey(),

--- a/packages/pipes/src/targets/drizzle/node-postgres/drizzle-target.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/drizzle-target.ts
@@ -119,11 +119,10 @@ export function drizzleTarget<T>({
             () =>
               db.transaction(async (tx) => {
                 await state.acquireLock(tx)
+                // `!= null`: a finalized head of 0 would otherwise skip the undo log entirely.
+                const finalizedHead = ctx.stream.head.finalized?.number
                 const snapshotEnabled =
-                  ctx.stream.head.finalized?.number &&
-                  ctx.stream.state.current.number >= ctx.stream.head.finalized.number
-                    ? 'true'
-                    : 'false'
+                  finalizedHead != null && ctx.stream.state.current.number >= finalizedHead ? 'true' : 'false'
 
                 /*
                  * Enable snapshotting for this transaction

--- a/packages/pipes/src/targets/drizzle/node-postgres/postgres-state.test.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/postgres-state.test.ts
@@ -106,6 +106,19 @@ describe('PostgresState — resume state & cursor persistence', () => {
     expect(insertParams).toContain(JSON.stringify(block(120)))
     expect(insertParams).toContain(JSON.stringify([block(121), block(122)]))
   })
+
+  // Falling back to the current block sweeps away the cursor rows a deep fork needs.
+  it('prunes nothing when the finalized head is block 0', async () => {
+    const client = { query: async () => ({ rows: [] }) }
+    const state = new PostgresState(client as any, { unfinalizedBlocksRetention: 1000 })
+
+    const tx = { execute: async () => ({ rowCount: 0 }) }
+
+    // The first save is one of the two that run the retention sweep.
+    const { safeBlockNumber } = await state.saveCursor(tx as any, ctxFor(block(5000), block(0), []))
+
+    expect(safeBlockNumber).toBe(0)
+  })
 })
 
 describe('PostgresState — fork', () => {

--- a/packages/pipes/src/targets/drizzle/node-postgres/postgres-state.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/postgres-state.ts
@@ -187,7 +187,7 @@ export class PostgresState {
     if (this.#saves === 1 || this.#saves % 25 === 0) {
       // Clean up old unfinalized blocks beyond retention
       const safeBlockNumber = Math.max(
-        Math.min(current.number, finalizedBlock || Infinity) - this.options.unfinalizedBlocksRetention,
+        Math.min(current.number, finalizedBlock ?? Infinity) - this.options.unfinalizedBlocksRetention,
         0,
       )
 

--- a/packages/pipes/src/testing/test-portal.ts
+++ b/packages/pipes/src/testing/test-portal.ts
@@ -114,13 +114,14 @@ export async function mockPortal(
             const headers: Record<string, string | number> = {
               'Content-Type': 'application/jsonl',
             }
-            if (mockResp.head?.finalized?.number) {
+            // `!= null`: block 0 is a valid head; dropping the header would hide finality entirely.
+            if (mockResp.head?.finalized?.number != null) {
               headers['X-Sqd-Finalized-Head-Number'] = mockResp.head.finalized.number
             }
-            if (mockResp.head?.finalized?.hash) {
+            if (mockResp.head?.finalized?.hash != null) {
               headers['X-Sqd-Finalized-Head-Hash'] = mockResp.head.finalized.hash
             }
-            if (mockResp.head?.latest?.number) {
+            if (mockResp.head?.latest?.number != null) {
               headers['X-Sqd-Head-Number'] = mockResp.head.latest.number
             }
 


### PR DESCRIPTION
## Summary

Follow-up to #126, from reviewing its two fix commits — plus the defects that review surfaced in the fixes themselves.

- **A finalized head of block 0 was read as "no finality".** Three sites tested it by truthiness, so under genesis-only finality every hot block was filed as finalized: the per-block separation the Postgres target relies on silently stopped happening, the undo log was never written, and the cursor sweep pruned the rows a deep fork needs to find its ancestor. A reorg then kept dead rows with no way to roll them back. The mock portal had the same bug, which is why no test could have caught it.
- **The finalized bulk was put even when empty**, which at the head is every response — handing the consumer a zero-block batch it could only discard. The put is load-bearing, though: it cuts blocks left pending from earlier all-finalized responses, which would otherwise ride along into the first hot batch and inherit its block number. So it becomes `StreamBuffer.cut()` rather than going away.
- **Request counters were attributed per batch**, so a response split into N per-block batches was billed N times. They were also re-created on every iteration of the ingest loop, so a response carrying no blocks — a 200 with an empty body — handed its counters to no batch and the next iteration discarded them, taking any retry attempts down with them. Hoisting the counter alone double-bills the 204 head poll, so that branch now clears what it hands off.
- **Spans could end twice, or not at all.** The read loop arms a batch/fetch pair up front, so the last pair is always for a batch that never arrives; closing it in a `finally` then re-ended a fetch span already closed at the top of the loop body, on any unwind through the `yield` (an early `break`, a throwing consumer). Separately, a throwing transformer skipped `end()` outright and leaked both its own span and the enclosing `apply transformers` one. `Span.end()` is now idempotent and both transformer paths end in a `finally`.

## Coverage

Base `main` vs head, full suite against live Postgres + ClickHouse.

| Module | Stmts | Δ | Branch | Δ |
|--------|-------|---|--------|---|
| **All files** | 84.88% | +0.12 | 85.96% | +0.26 |
| src/core | 86.69% | +0.11 | 89.91% | +0.13 |
| src/core/portal-source.ts | 93.33% | +0.22 | 84.53% | +0.84 |
| src/core/profiling.ts | 86.50% | +0.33 | 95.00% | +0.41 |
| src/core/transformer.ts | 100% | — | 97.14% | −0.15 |
| src/http-client | 62.95% | +1.71 | 69.36% | +5.54 |
| src/portal-client | 91.87% | +0.26 | 92.30% | +1.40 |
| src/portal-client/client.ts | 86.28% | +0.52 | 90.12% | +2.12 |
| src/portal-client/stream-buffer.ts | 98.83% | +0.04 | 98.48% | +0.24 |

Deltas are small because the changed lines were largely already executed — the bugs were wrong values on covered paths, not dead code. `transformer.ts` loses 0.15 branch points because the `children.length === 0` early return collapsed into the loop it duplicated.

Every new test was verified by reverting its fix and confirming it fails:

| Fix reverted | Tests that fail |
|---|---|
| `Span.end()` idempotency | 3 — consumer break, consumer throw, transformer throw |
| `else { batchSpan.end() }` | 1 — 204 head poll |
| `Transformer.run` `finally` | 1 — transformer throws mid-stream |
| `requests` hoisted out of the loop | 2 — chunkless response, retry counters |
| 204 counter clear | 1 — head poll counted once |

## Test plan

- [x] `client.test.ts` — batch shapes for both `perBlockUnfinalized` values; genesis finality splits per block (was `[[], [1], [2], [3]]`); pending finalized blocks never merge into a hot batch, with `maxIdleTimeMs` pinned high so only `cut()` can separate them; request attribution across per-block batches, a chunkless response, a 204 head poll, and a retried 503
- [x] `stream-buffer.test.ts` — `cut()` directly: batch separation, the contrast case showing `flush()` alone merges, no-op when empty, and no hang against a closed, failed, or abandoned buffer
- [x] `portal-source.test.ts` — span accounting is now per span name rather than a global total, which is what makes the double-end visible: a global count nets a `+1` double-end against a `−2` leak and reports balance
- [x] `drizzle-target.test.ts` — fork under genesis-only finality rolls back (kept `[1, 2]` instead of `[1]` before the fix)
- [x] `postgres-state.test.ts` — retention sweep prunes nothing when the finalized head is block 0 (was `safeBlockNumber: 4000`)
- [x] Full suite: 605 passed, 18 skipped (BigQuery integration, no credentials); base was 584 passed
- [x] `tsc --noEmit` and Biome clean

## Notes

- `StreamBuffer.cut()` is safe against a closed buffer either way, but only incidentally — it relied on `_reset()` being unreachable in terminal states, an invariant living two functions away with no local sign of why. It now checks explicitly, so a future change to `take()` can't turn it into a deadlock.
- An earlier revision of this description claimed the dropped-empty-batch branch was "not reachable deterministically from a mock portal." That was wrong. The 204 head-poll path puts a zero-block batch and flushes it immediately, so a plain `{ statusCode: 204 }` response reaches the branch every time; it is now covered by a real test rather than kept as a defensive guard.
- "Stop emitting empty batches" is scoped to the `perBlockUnfinalized` path. The 204 branch still emits a zero-block batch by design (it carries a head update), and the single-batch-per-response path still calls `put` unconditionally. Both are handled by the read loop's `else` branch rather than being suppressed at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
