### PR TITLE
test(conformance): Phase-0 harness — ledger mode, oracle, validators, class-K kill-points

### DIFF
--- a/packages/pipes/src/testing/conformance/chain-ledger.test.ts
+++ b/packages/pipes/src/testing/conformance/chain-ledger.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+
+import { ChainLedger, buildChain } from './chain-ledger.js'
+
+describe('ChainLedger', () => {
+  describe('anchor-keyed selection (IB-3)', () => {
+    it('serves from fromBlock when the anchor matches the held chain', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 5 }) })
+
+      const response = ledger.answer({ fromBlock: 3, toBlock: 5, parentBlockHash: '0x2' })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.statusCode === 200 && response.data.map((b) => b.header.number)).toEqual([3, 4, 5])
+    })
+
+    it('accepts a first request that carries no anchor', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 2 }) })
+
+      const response = ledger.answer({ fromBlock: 0, toBlock: 2 })
+
+      expect(response.statusCode).toBe(200)
+    })
+
+    it('answers the same anchor identically however many times it is asked', () => {
+      // The ordinal script's defect: a restarted SUT re-requests from its recovered cursor and an
+      // index-keyed simulator hands out the *next* scripted response instead of the same answer.
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 5 }) })
+      const request = { fromBlock: 3, toBlock: 5, parentBlockHash: '0x2' }
+
+      const first = ledger.answer(request)
+      ledger.answer({ fromBlock: 6, toBlock: 5, parentBlockHash: '0x5' })
+      const afterRestart = ledger.answer(request)
+
+      expect(afterRestart).toEqual(first)
+    })
+
+    it('does not judge an anchor below the blocks it holds', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 100, to: 105 }) })
+
+      // Block 49 was never held, so nothing here contradicts the anchor.
+      const response = ledger.answer({ fromBlock: 50, parentBlockHash: '0xwhatever' })
+
+      expect(response.statusCode).not.toBe(409)
+    })
+  })
+
+  describe('fork signalling (IB-4)', () => {
+    it('answers 409 when the anchor is off the canonical chain', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 5 }) })
+      ledger.fork(3, buildChain({ from: 4, to: 6, hash: (n) => `0x${n}__b` }))
+
+      const response = ledger.answer({ fromBlock: 6, toBlock: 10, parentBlockHash: '0x5' })
+
+      expect(response.statusCode).toBe(409)
+      expect(response.statusCode === 409 && response.data.previousBlocks).toEqual([
+        { number: 0, hash: '0x0' },
+        { number: 1, hash: '0x1' },
+        { number: 2, hash: '0x2' },
+        { number: 3, hash: '0x3' },
+        { number: 4, hash: '0x4__b' },
+        { number: 5, hash: '0x5__b' },
+      ])
+    })
+
+    it('keeps serving the survivors of a fork on their unchanged anchors', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 5 }) })
+      ledger.fork(3, buildChain({ from: 4, to: 6, hash: (n) => `0x${n}__b` }))
+
+      // Block 3 survived the reorg, so an anchor on it is still canonical.
+      const response = ledger.answer({ fromBlock: 4, toBlock: 6, parentBlockHash: '0x3' })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.statusCode === 200 && response.data.map((b) => b.header.hash)).toEqual([
+        '0x4__b',
+        '0x5__b',
+        '0x6__b',
+      ])
+    })
+
+    it('remembers hashes a fork orphaned', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 5 }) })
+      ledger.fork(3, buildChain({ from: 4, to: 5, hash: (n) => `0x${n}__b` }))
+
+      expect(ledger.hasServed('0x5')).toBe(true)
+      expect(ledger.chain.map((b) => b.header.hash)).not.toContain('0x5')
+    })
+
+    it('bounds the canonical window a 409 carries', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 500 }), forkWindow: 3 })
+      ledger.fork(400, buildChain({ from: 401, to: 500, hash: (n) => `0x${n}__b` }))
+
+      const response = ledger.answer({ fromBlock: 501, parentBlockHash: '0x500' })
+
+      expect(response.statusCode === 409 && response.data.previousBlocks.map((b) => b.number)).toEqual([498, 499, 500])
+    })
+  })
+
+  describe('head and range ends (IB-5, IB-6)', () => {
+    it('answers 204 when the request sits above the held head', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 5 }), finalized: { number: 5, hash: '0x5' } })
+
+      const response = ledger.answer({ fromBlock: 6, parentBlockHash: '0x5' })
+
+      expect(response.statusCode).toBe(204)
+      expect(response.statusCode === 204 && response.head?.finalized).toEqual({ number: 5, hash: '0x5' })
+    })
+
+    it('answers an empty 200 once the configured range is exhausted', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 10 }) })
+
+      const response = ledger.answer({ fromBlock: 6, toBlock: 5, parentBlockHash: '0x5' })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.statusCode === 200 && response.data).toEqual([])
+    })
+
+    it('reports a regressed finalized head verbatim, leaving the clamp to the SUT', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 5 }) })
+      ledger.setFinalized({ number: 5, hash: '0x5' })
+      ledger.setFinalized({ number: 2, hash: '0x2' })
+
+      const response = ledger.answer({ fromBlock: 0 })
+
+      expect(response.statusCode === 200 && response.head?.finalized).toEqual({ number: 2, hash: '0x2' })
+    })
+
+    it('caps a response at batchSize', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 10 }), batchSize: 3 })
+
+      const response = ledger.answer({ fromBlock: 0, toBlock: 10 })
+
+      expect(response.statusCode === 200 && response.data.map((b) => b.header.number)).toEqual([0, 1, 2])
+    })
+  })
+
+  describe('faults and adversarial histories', () => {
+    it('serves queued faults before resuming derived answers', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 2 }) })
+      ledger.injectFaults({ statusCode: 503, retryAfter: 1 }, { statusCode: 429 })
+
+      expect(ledger.answer({ fromBlock: 0 })).toEqual({ statusCode: 503, retryAfter: 1 })
+      expect(ledger.answer({ fromBlock: 0 })).toEqual({ statusCode: 429 })
+      expect(ledger.answer({ fromBlock: 0 }).statusCode).toBe(200)
+    })
+
+    it('over-returns past toBlock on demand (INV-24)', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 10 }) })
+      ledger.setAdversary({ overReturn: 2 })
+
+      const response = ledger.answer({ fromBlock: 0, toBlock: 3 })
+
+      expect(response.statusCode === 200 && response.data.map((b) => b.header.number)).toEqual([0, 1, 2, 3, 4, 5])
+    })
+
+    it('emits duplicate and out-of-order blocks on demand (GAP-29)', () => {
+      const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 3 }) })
+      ledger.setAdversary({ duplicateBlocks: true, outOfOrder: true })
+
+      const response = ledger.answer({ fromBlock: 0, toBlock: 3 })
+
+      expect(response.statusCode === 200 && response.data.map((b) => b.header.number)).toEqual([3, 2, 1, 0, 0])
+    })
+  })
+
+  it('retains a request log the ordinal simulator throws away', () => {
+    const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 5 }) })
+
+    ledger.answer({ fromBlock: 0, toBlock: 5 })
+    ledger.answer({ fromBlock: 6, toBlock: 5, parentBlockHash: '0x5' })
+
+    expect(ledger.requests).toEqual([
+      { seq: 0, fromBlock: 0, toBlock: 5, parentBlockHash: undefined, statusCode: 200 },
+      { seq: 1, fromBlock: 6, toBlock: 5, parentBlockHash: '0x5', statusCode: 200 },
+    ])
+  })
+})

--- a/packages/pipes/src/testing/conformance/chain-ledger.ts
+++ b/packages/pipes/src/testing/conformance/chain-ledger.ts
@@ -1,0 +1,262 @@
+import type { BlockRef, PortalBlockPayload, PortalHead, WireResponse } from '../portal-wire.js'
+
+/** A stream request (IB-2) reduced to the fields that select a response. */
+export type LedgerRequest = {
+  fromBlock: number
+  toBlock?: number
+  parentBlockHash?: string
+}
+
+export type LoggedRequest = LedgerRequest & {
+  /** Arrival order, 0-based. */
+  seq: number
+  /** What the ledger answered with. */
+  statusCode: WireResponse['statusCode']
+}
+
+/** A transport fault served in place of the derived answer, consumed once (IB-7, FM-10…FM-19). */
+export type LedgerFault = {
+  statusCode: 429 | 500 | 502 | 503 | 504
+  retryAfter?: number | string
+}
+
+/**
+ * Deliberate wire violations. The portal is trusted for chain integrity (ADR-1), so these exist
+ * to prove the SUT's local guards fire rather than to model anything a real portal does.
+ */
+export type LedgerAdversary = {
+  /** Serve this many blocks past `toBlock` (INV-24 over-return). */
+  overReturn?: number
+  /** Repeat the first block of every 200 response (GAP-29). */
+  duplicateBlocks?: boolean
+  /** Reverse block order within every 200 response (GAP-29). */
+  outOfOrder?: boolean
+}
+
+export type ChainLedgerOptions = {
+  /** Initial canonical chain, ascending by number. */
+  blocks?: PortalBlockPayload[]
+  finalized?: BlockRef
+  /** Latest head; IB-6 reports its number only. */
+  latest?: number
+  /** Max blocks per 200 response. Default: every available block in range. */
+  batchSize?: number
+  /** How many canonical blocks a 409 carries below the fork point (DEF-10). */
+  forkWindow?: number
+}
+
+/**
+ * The chain the simulator holds, and the authority on what any request is answered with.
+ *
+ * The distinction from a scripted response array is that selection is keyed on the request's
+ * anchor (IB-3) rather than on arrival order. An ordinal script has no answer for the re-request
+ * a restarted SUT issues from its recovered cursor — it hands out whatever response happens to sit
+ * at the next index, so every crash-recovery test has to hand-pad its script and no test can
+ * assert what the SUT asked for after coming back. Deriving from the anchor makes the re-request
+ * answerable by construction, which is what gates the CT-2 matrix and adversarial histories.
+ */
+export class ChainLedger {
+  #chain: PortalBlockPayload[]
+  #finalized: BlockRef | undefined
+  #latest: number | undefined
+  #batchSize: number
+  #forkWindow: number
+
+  #requests: LoggedRequest[] = []
+  #faults: LedgerFault[] = []
+  #adversary: LedgerAdversary = {}
+  /** Every hash the ledger ever held, including branches a fork orphaned. */
+  #served = new Map<string, number>()
+
+  constructor(options: ChainLedgerOptions = {}) {
+    this.#chain = []
+    this.#finalized = options.finalized
+    this.#latest = options.latest
+    this.#batchSize = options.batchSize ?? Number.POSITIVE_INFINITY
+    this.#forkWindow = options.forkWindow ?? 100
+
+    if (options.blocks?.length) {
+      this.append(options.blocks)
+    }
+  }
+
+  /** The canonical chain as currently held, ascending. */
+  get chain(): readonly PortalBlockPayload[] {
+    return this.#chain
+  }
+
+  /** Every request the ledger answered, in arrival order. */
+  get requests(): readonly LoggedRequest[] {
+    return this.#requests
+  }
+
+  get head(): BlockRef | undefined {
+    const last = this.#chain.at(-1)
+
+    return last ? { number: last.header.number, hash: last.header.hash } : undefined
+  }
+
+  get finalized(): BlockRef | undefined {
+    return this.#finalized
+  }
+
+  /** Appends blocks to the canonical chain. */
+  append(blocks: PortalBlockPayload[]): this {
+    for (const block of blocks) {
+      this.#chain.push(block)
+      this.#served.set(block.header.hash, block.header.number)
+    }
+    this.#chain.sort((a, b) => a.header.number - b.header.number)
+
+    return this
+  }
+
+  /**
+   * Reorgs: every block above `at` is replaced by `branch`. The orphaned hashes stay in the served
+   * history, so a request anchored on one is answerable — that is exactly the 409 path.
+   */
+  fork(at: number, branch: PortalBlockPayload[] = []): this {
+    this.#chain = this.#chain.filter((b) => b.header.number <= at)
+
+    return this.append(branch)
+  }
+
+  /**
+   * Sets the reported finalized head. Deliberately not monotonic — a regressing floor is an
+   * adversarial input the SUT must clamp (INV-2, INV-12), not something the ledger prevents.
+   */
+  setFinalized(finalized: BlockRef | undefined): this {
+    this.#finalized = finalized
+
+    return this
+  }
+
+  setLatest(latest: number | undefined): this {
+    this.#latest = latest
+
+    return this
+  }
+
+  /** Queues faults served in place of the next answers, one per request (IB-7). */
+  injectFaults(...faults: LedgerFault[]): this {
+    this.#faults.push(...faults)
+
+    return this
+  }
+
+  setAdversary(adversary: LedgerAdversary): this {
+    this.#adversary = adversary
+
+    return this
+  }
+
+  /** True when the ledger ever held this hash, on the canonical chain or an orphaned branch. */
+  hasServed(hash: string): boolean {
+    return this.#served.has(hash)
+  }
+
+  /** Answers `request` from the held chain and records it. */
+  answer(request: LedgerRequest): WireResponse {
+    const response = this.#derive(request)
+    this.#requests.push({ ...request, seq: this.#requests.length, statusCode: response.statusCode })
+
+    return response
+  }
+
+  #derive(request: LedgerRequest): WireResponse {
+    const fault = this.#faults.shift()
+    if (fault) {
+      return fault
+    }
+
+    if (this.#isForked(request)) {
+      return { statusCode: 409, data: { previousBlocks: this.#canonicalWindow(request.fromBlock) } }
+    }
+
+    const to = request.toBlock ?? Number.POSITIVE_INFINITY
+    if (request.fromBlock > to) {
+      // Range exhausted: 200 with an empty body means "no data upstream", not "at head" (IB-5).
+      return { statusCode: 200, data: [], head: this.#head() }
+    }
+
+    const inRange = this.#chain.filter((b) => b.header.number >= request.fromBlock && b.header.number <= to)
+    let blocks = inRange.slice(0, this.#batchSize)
+
+    if (this.#adversary.overReturn) {
+      blocks = [...blocks, ...this.#chain.filter((b) => b.header.number > to).slice(0, this.#adversary.overReturn)]
+    }
+    if (!blocks.length) {
+      return { statusCode: 204, head: this.#head() }
+    }
+
+    if (this.#adversary.duplicateBlocks) {
+      blocks = [blocks[0], ...blocks]
+    }
+    if (this.#adversary.outOfOrder) {
+      blocks = [...blocks].reverse()
+    }
+
+    return { statusCode: 200, data: blocks, head: this.#head() }
+  }
+
+  /**
+   * The anchor names the block the SUT believes precedes `fromBlock` (IB-3). It is a fork exactly
+   * when the canonical chain disagrees at that number.
+   */
+  #isForked(request: LedgerRequest): boolean {
+    if (request.parentBlockHash === undefined) {
+      return false
+    }
+
+    const anchorNumber = request.fromBlock - 1
+    const first = this.#chain[0]
+    if (!first || anchorNumber < first.header.number) {
+      // Below what the ledger holds — nothing to contradict the anchor with.
+      return false
+    }
+
+    const anchor = this.#chain.find((b) => b.header.number === anchorNumber)
+
+    return !anchor || anchor.header.hash !== request.parentBlockHash
+  }
+
+  /** The canonical ancestry a 409 carries: ascending, ending at the anchor's number (DEF-10). */
+  #canonicalWindow(fromBlock: number): BlockRef[] {
+    return this.#chain
+      .filter((b) => b.header.number <= fromBlock - 1)
+      .slice(-this.#forkWindow)
+      .map((b) => ({ number: b.header.number, hash: b.header.hash }))
+  }
+
+  #head(): PortalHead | undefined {
+    const head: PortalHead = {}
+    if (this.#finalized) {
+      head.finalized = this.#finalized
+    }
+    if (this.#latest != null) {
+      head.latest = { number: this.#latest }
+    }
+
+    return head.finalized || head.latest ? head : undefined
+  }
+}
+
+/** Builds a linear chain of empty blocks over `[from, to]`. */
+export function buildChain({
+  from,
+  to,
+  hash = (n) => `0x${n}`,
+  timestamp = (n) => n * 1000,
+}: {
+  from: number
+  to: number
+  hash?: (n: number) => string
+  timestamp?: (n: number) => number
+}): PortalBlockPayload[] {
+  const blocks: PortalBlockPayload[] = []
+  for (let n = from; n <= to; n++) {
+    blocks.push({ header: { number: n, hash: hash(n), timestamp: timestamp(n) } })
+  }
+
+  return blocks
+}

--- a/packages/pipes/src/testing/conformance/ct1-pipeline.test.ts
+++ b/packages/pipes/src/testing/conformance/ct1-pipeline.test.ts
@@ -1,0 +1,209 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { evmPortalStream } from '~/evm/index.js'
+import { type ParquetTable, parquetTarget } from '~/targets/parquet/index.js'
+import { blockDecoder, testLogger } from '~/testing/index.js'
+
+import { ChainLedger, buildChain } from './chain-ledger.js'
+import { type LedgerPortal, ledgerPortal } from './ledger-portal.js'
+import { parquetProbe } from './parquet-probe.js'
+import { ReferenceModel } from './reference-model.js'
+import { type DeliveredBatch, assertStructure, validateLinked, validateOrdered } from './validators.js'
+
+const BLOCKS_TABLE: ParquetTable = {
+  table: 'blocks',
+  schema: {
+    blockNumber: { type: 'INT64' },
+    hash: { type: 'UTF8' },
+    timestamp: { type: 'INT64' },
+  },
+}
+
+/** S1 — steady backfill over deep history against a healthy portal. */
+const S1 = { from: 0, to: 49, batchSize: 5 }
+
+/**
+ * CT-1 — pipeline property tests: simulator ↔ oracle lockstep, structural validators, and a
+ * quiescence diff of the sink store against the reference model.
+ *
+ * The comparison is taken at quiescence and never pins a free variable. Batch partitioning in
+ * particular is the SUT's to choose, so the oracle is asked what the run must *commit*, not how it
+ * must get there; that the partitioning itself is well-formed is a separate, structural check.
+ */
+describe('CT-1 · pipeline properties (S1 steady backfill)', () => {
+  let portal: LedgerPortal | undefined
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'sqd-ct1-'))
+  })
+
+  afterEach(async () => {
+    await portal?.close()
+    portal = undefined
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  const startPortal = async (finalized: number = S1.to) => {
+    portal = await ledgerPortal(
+      new ChainLedger({
+        blocks: buildChain({ from: S1.from, to: S1.to }),
+        finalized: { number: finalized, hash: `0x${finalized}` },
+        latest: S1.to,
+        batchSize: S1.batchSize,
+      }),
+    )
+
+    return portal
+  }
+
+  /** Runs the pipe, recording the batch partitioning the SUT chose. */
+  const runPipe = async (target = dir) => {
+    const batches: DeliveredBatch[] = []
+    let cursor: number | undefined
+
+    await evmPortalStream({
+      id: 'test',
+      portal: { url: portal!.url, maxBytes: 1 },
+      outputs: blockDecoder({ from: S1.from, to: S1.to }),
+      logger: testLogger(),
+    }).pipeTo(
+      parquetTarget({
+        dir: target,
+        tables: [BLOCKS_TABLE],
+        settings: { rollover: { maxBytes: 1 } },
+        onData: ({ store, data }) => {
+          const blocks = data as { number: number; hash: string; timestamp: number }[]
+          batches.push({ cursorBefore: cursor, blocks: blocks.map((b) => ({ number: b.number })) })
+          cursor = blocks.at(-1)?.number
+
+          store.insert(
+            'blocks',
+            blocks.map((b) => ({ blockNumber: b.number, hash: b.hash, timestamp: b.timestamp })),
+          )
+        },
+      }),
+    )
+
+    return batches
+  }
+
+  /** What the oracle says this scenario must commit. */
+  const oracleFor = (finalized: number) => {
+    const model = new ReferenceModel({
+      durability: 'K',
+      range: { from: S1.from, to: S1.to },
+      transform: (b) => [{ table: 'blocks', block: b.number, value: b.hash }],
+    })
+    model.batch(
+      buildChain({ from: S1.from, to: S1.to }).map((b) => b.header),
+      { finalized: { number: finalized, hash: `0x${finalized}` } },
+    )
+
+    return model
+  }
+
+  it('commits exactly what the reference model commits', async () => {
+    await startPortal()
+    await runPipe()
+
+    const probe = parquetProbe({ dir, tables: ['blocks'], id: 'test' })
+    const rows = await probe.readRows('blocks')
+
+    expect(rows.map((r) => r.block)).toEqual(oracleFor(S1.to).data.map((r) => r.block))
+  })
+
+  it('holds back every row above the finalized floor (INV-3, CN-12)', async () => {
+    const floor = 30
+    await startPortal(floor)
+    await runPipe()
+
+    const probe = parquetProbe({ dir, tables: ['blocks'], id: 'test' })
+    const rows = await probe.readRows('blocks')
+    const model = oracleFor(floor)
+
+    expect(rows.map((r) => r.block)).toEqual(model.data.map((r) => r.block))
+    expect(rows.at(-1)!.block).toBeLessThanOrEqual(floor)
+    expect(model.buffered.length).toBeGreaterThan(0)
+  })
+
+  it('keeps every structural validator green at quiescence', async () => {
+    await startPortal()
+    await runPipe()
+
+    const probe = parquetProbe({ dir, tables: ['blocks'], id: 'test' })
+    const rows = await probe.readRows('blocks')
+
+    assertStructure({
+      rows,
+      units: await probe.readUnits!('blocks'),
+      state: (await probe.readState())!,
+      ranges: [{ from: S1.from, to: S1.to }],
+      dataBound: rows.at(-1)?.block,
+    })
+  })
+
+  it('partitions the stream into well-formed batches (INV-20)', async () => {
+    await startPortal()
+    const batches = await runPipe()
+
+    expect(batches.length).toBeGreaterThan(1)
+    expect(validateLinked(batches)).toEqual([])
+    for (const batch of batches) {
+      expect(validateOrdered(batch.blocks.map((b) => ({ block: b.number })))).toEqual([])
+    }
+  })
+
+  it('drives the anchor forward exactly one block past each delivery (IB-3)', async () => {
+    await startPortal()
+    await runPipe()
+
+    const anchored = portal!.ledger.requests.filter((r) => r.parentBlockHash !== undefined)
+    expect(anchored.length).toBeGreaterThan(0)
+    for (const request of anchored) {
+      expect(request.parentBlockHash).toBe(`0x${request.fromBlock - 1}`)
+    }
+  })
+
+  it('never asks for a block outside the configured range (INV-24)', async () => {
+    await startPortal()
+    await runPipe()
+
+    for (const request of portal!.ledger.requests) {
+      expect(request.fromBlock).toBeGreaterThanOrEqual(S1.from)
+      expect(request.toBlock).toBe(S1.to)
+    }
+  })
+
+  it('commits the same store on an independent second run (INV-22)', async () => {
+    await startPortal()
+    await runPipe()
+
+    const second = await mkdtemp(path.join(tmpdir(), 'sqd-ct1-b-'))
+    try {
+      await runPipe(second)
+
+      const a = await parquetProbe({ dir, tables: ['blocks'], id: 'test' }).readRows('blocks')
+      const b = await parquetProbe({ dir: second, tables: ['blocks'], id: 'test' }).readRows('blocks')
+
+      expect(b).toEqual(a)
+    } finally {
+      await rm(second, { recursive: true, force: true })
+    }
+  })
+
+  it('changes nothing once idle at quiescence (INV-10)', async () => {
+    await startPortal()
+    await runPipe()
+
+    const probe = parquetProbe({ dir, tables: ['blocks'], id: 'test' })
+    const before = { state: await probe.readState(), units: await probe.readUnits!('blocks') }
+    const after = { state: await probe.readState(), units: await probe.readUnits!('blocks') }
+
+    expect(after).toEqual(before)
+  })
+})

--- a/packages/pipes/src/testing/conformance/ct2-kill-points-k.test.ts
+++ b/packages/pipes/src/testing/conformance/ct2-kill-points-k.test.ts
@@ -1,0 +1,306 @@
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { evmPortalStream } from '~/evm/index.js'
+import { type ParquetTable, parquetTarget } from '~/targets/parquet/index.js'
+import { blockDecoder, testLogger } from '~/testing/index.js'
+
+import { ChainLedger, buildChain } from './chain-ledger.js'
+import { expectCrash, obstruct, statePath, unitPath } from './kill-points.js'
+import { type LedgerPortal, ledgerPortal } from './ledger-portal.js'
+import { parquetProbe } from './parquet-probe.js'
+import { ReferenceModel } from './reference-model.js'
+import { assertStructure } from './validators.js'
+
+const BLOCKS_TABLE: ParquetTable = {
+  table: 'blocks',
+  schema: {
+    blockNumber: { type: 'INT64' },
+    hash: { type: 'UTF8' },
+    timestamp: { type: 'INT64' },
+  },
+}
+
+const LOGS_TABLE: ParquetTable = {
+  table: 'logs',
+  schema: {
+    blockNumber: { type: 'INT64' },
+    hash: { type: 'UTF8' },
+    timestamp: { type: 'INT64' },
+  },
+}
+
+const TO_BLOCK = 5
+/** Ledger batch size; with `rollover.maxBytes: 1` this makes checkpoints land on 0-1, 2-3, 4-5. */
+const BATCH = 2
+
+/**
+ * CT-2 — crash-recovery kill-point matrix for class K (checkpointed-immutable, CN-12).
+ *
+ * Class K commits by publishing every open unit atomically and *then* persisting the cursor. The
+ * matrix walks the points that protocol can be interrupted at; each one must recover to the state a
+ * clean run reaches, because the cursor alone decides what is committed and a unit published above
+ * it has to be re-derived rather than kept (RS-10).
+ *
+ * The simulator runs in ledger mode throughout: after a crash the pipe resumes from its recovered
+ * cursor and re-requests, which an ordinal script has no answer for (GAP-14).
+ */
+describe('CT-2 · class K kill-point matrix', () => {
+  let portal: LedgerPortal | undefined
+  let dir: string
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'sqd-ct2-k-'))
+  })
+
+  afterEach(async () => {
+    await portal?.close()
+    portal = undefined
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  const startPortal = async () => {
+    portal = await ledgerPortal(
+      new ChainLedger({
+        blocks: buildChain({ from: 0, to: TO_BLOCK }),
+        // Class K writes only finalized rows, so the range must be final to be published at all.
+        finalized: { number: TO_BLOCK, hash: `0x${TO_BLOCK}` },
+        batchSize: BATCH,
+      }),
+    )
+  }
+
+  const runPipe = (tables: ParquetTable[], { onBatch }: { onBatch?: (n: number) => void } = {}) => {
+    let batches = 0
+
+    return evmPortalStream({
+      id: 'test',
+      portal: { url: portal!.url, maxBytes: 1 },
+      outputs: blockDecoder({ from: 0, to: TO_BLOCK }),
+      logger: testLogger(),
+    }).pipeTo(
+      parquetTarget({
+        dir,
+        tables,
+        settings: { rollover: { maxBytes: 1 } },
+        onData: ({ store, data }) => {
+          const blocks = data as { number: number; hash: string; timestamp: number }[]
+          for (const table of tables) {
+            store.insert(
+              table.table,
+              blocks.map((b) => ({ blockNumber: b.number, hash: b.hash, timestamp: b.timestamp })),
+            )
+          }
+          onBatch?.(++batches)
+        },
+      }),
+    )
+  }
+
+  const probeFor = (tables: string[] = ['blocks']) => parquetProbe({ dir, tables, id: 'test' })
+
+  /** What a clean, uninterrupted run of this scenario must commit. */
+  const expectedBlocks = () => {
+    const model = new ReferenceModel({
+      durability: 'K',
+      range: { from: 0, to: TO_BLOCK },
+      transform: (b) => [{ table: 'blocks', block: b.number, value: b.hash }],
+    })
+    model.batch(
+      buildChain({ from: 0, to: TO_BLOCK }).map((b) => b.header),
+      { finalized: { number: TO_BLOCK, hash: `0x${TO_BLOCK}` } },
+    )
+
+    return model.data.map((r) => r.block)
+  }
+
+  /** Restarts the pipe, then diffs the store against the oracle at quiescence. */
+  const recoverAndVerify = async (tables: ParquetTable[] = [BLOCKS_TABLE]) => {
+    await runPipe(tables)
+
+    const probe = probeFor(tables.map((t) => t.table))
+    const state = await probe.readState()
+    const rows = await probe.readRows('blocks')
+
+    expect(rows.map((r) => r.block)).toEqual(expectedBlocks())
+    expect(state?.current?.number).toBe(TO_BLOCK)
+
+    assertStructure({
+      rows,
+      units: await probe.readUnits!('blocks'),
+      state: state!,
+      ranges: [{ from: 0, to: TO_BLOCK }],
+      dataBound: rows.at(-1)?.block,
+    })
+
+    return { probe, state, rows }
+  }
+
+  it('recovers when the run dies while a unit is still being built (mid-unit-write)', async () => {
+    await startPortal()
+
+    // Dies inside the very first batch, with rows staged and the checkpoint not yet reached, so no
+    // unit is ever published. (Checkpoints run per batch here, so a later batch would already have
+    // committed one.)
+    await expectCrash(() =>
+      runPipe([BLOCKS_TABLE], {
+        onBatch: (n) => {
+          if (n === 1) {
+            throw new Error('killed mid-unit-write')
+          }
+        },
+      }),
+    )
+
+    expect(await probeFor().readUnits!('blocks')).toEqual([])
+    expect(await probeFor().readState()).toBeUndefined()
+
+    await recoverAndVerify()
+  })
+
+  it('does not clear a unit published before the first cursor ever landed (GAP-36)', async () => {
+    await startPortal()
+
+    // The state record cannot be written, so the first checkpoint publishes its unit and then dies
+    // before the cursor lands — the CN-12 crash window, at the one moment no cursor exists yet.
+    const blocked = await obstruct(statePath(dir, 'test'))
+    await expectCrash(() => runPipe([BLOCKS_TABLE]))
+
+    const probe = probeFor()
+    const orphaned = await probe.readUnits!('blocks')
+    expect(orphaned.length).toBeGreaterThan(0)
+
+    await blocked.release()
+    expect(await probe.readState()).toBeUndefined()
+
+    // CN-12 requires recovery to delete every unit whose window end exceeds the cursor. With no
+    // cursor persisted that is every unit — but getCursor() returns before #deleteFilesAboveCursor
+    // can run, so the restart meets its own orphan. Downstream that surfaces either as E2309 or as
+    // duplicated rows depending on batch partitioning, a declared free variable; the deterministic
+    // fact underneath is that the orphan survives recovery. Swap this for recoverAndVerify() once
+    // GAP-36 is decided.
+    await runPipe([BLOCKS_TABLE]).catch(() => {})
+
+    expect((await probe.readUnits!('blocks')).map((u) => u.name)).toEqual(
+      expect.arrayContaining(orphaned.map((u) => u.name)),
+    )
+  })
+
+  it('recovers when the publish loop dies between two tables (mid-rename)', async () => {
+    await startPortal()
+
+    // Let checkpoint 1 (blocks 0–1) commit, then block only the `logs` unit of checkpoint 2, so one
+    // table publishes and the other does not. Without a committed cursor first this would merely
+    // re-test GAP-36 instead of the interrupted loop.
+    const blocked = await obstruct(unitPath(dir, 'logs', 2, 3))
+    await expectCrash(() => runPipe([BLOCKS_TABLE, LOGS_TABLE]))
+
+    const probe = probeFor(['blocks', 'logs'])
+    const state = await probe.readState()
+    expect(state?.current?.number).toBe(1)
+    expect((await probe.readUnits!('blocks')).length).toBe(2)
+
+    await blocked.release()
+    await recoverAndVerify([BLOCKS_TABLE, LOGS_TABLE])
+  })
+
+  it('recovers when the run dies just after a cursor was committed (post-state)', async () => {
+    await startPortal()
+
+    // Checkpoint 1 commits fully — units published *and* cursor persisted — then checkpoint 2 dies.
+    // Checkpoints run per batch, so dying inside batch 3 leaves checkpoints 1 and 2 fully
+    // committed — units published *and* cursor persisted — which is the post-state point. No
+    // obstruction here: blocking a data file would be undone by recovery, which deletes
+    // over-cursor units when the stream restarts.
+    await expectCrash(() =>
+      runPipe([BLOCKS_TABLE], {
+        onBatch: (n) => {
+          if (n === 3) {
+            throw new Error('killed after the cursor was committed')
+          }
+        },
+      }),
+    )
+
+    // Where exactly the cursor landed is checkpoint timing — a declared free variable, so it is not
+    // pinned. What must hold is that a commit point was reached and covers everything published.
+    const probe = probeFor()
+    const state = await probe.readState()
+    expect(state?.current).toBeDefined()
+    const units = await probe.readUnits!('blocks')
+    expect(units.length).toBeGreaterThan(0)
+    for (const unit of units) {
+      expect(unit.to).toBeLessThanOrEqual(state!.current!.number)
+    }
+
+    await recoverAndVerify()
+  })
+
+  it('deletes a unit published above the committed cursor before resuming (CN-12)', async () => {
+    await startPortal()
+
+    // Checkpoint 1 commits; checkpoint 2 publishes `blocks` then dies on `logs`, leaving a `blocks`
+    // unit that the cursor does not cover. Recovery must remove it rather than keep it.
+    const blocked = await obstruct(unitPath(dir, 'logs', 2, 3))
+    await expectCrash(() => runPipe([BLOCKS_TABLE, LOGS_TABLE]))
+
+    const probe = probeFor(['blocks', 'logs'])
+    const committed = (await probe.readState())!.current!.number
+    const overCursor = (await probe.readUnits!('blocks')).filter((u) => u.to > committed)
+    expect(overCursor.length).toBeGreaterThan(0)
+
+    await blocked.release()
+    await recoverAndVerify([BLOCKS_TABLE, LOGS_TABLE])
+
+    // Every surviving unit is covered by the final cursor, and none is duplicated.
+    const units = await probe.readUnits!('blocks')
+    expect(new Set(units.map((u) => u.name)).size).toBe(units.length)
+  })
+
+  it('re-requests from the recovered cursor rather than from the start', async () => {
+    // The GAP-14 assertion an ordinal script cannot make: what the SUT asked for after coming back.
+    await startPortal()
+
+    await expectCrash(() =>
+      runPipe([BLOCKS_TABLE], {
+        onBatch: (n) => {
+          if (n === 3) {
+            throw new Error('killed after the cursor was committed')
+          }
+        },
+      }),
+    )
+
+    const committed = (await probeFor().readState())!.current!
+    const before = portal!.ledger.requests.length
+
+    await runPipe([BLOCKS_TABLE])
+
+    const afterRestart = portal!.ledger.requests.slice(before)
+    expect(afterRestart[0]).toMatchObject({
+      fromBlock: committed.number + 1,
+      parentBlockHash: committed.hash,
+    })
+  })
+
+  it('leaves no temp files behind after recovery', async () => {
+    await startPortal()
+
+    await expectCrash(() =>
+      runPipe([BLOCKS_TABLE], {
+        onBatch: (n) => {
+          if (n === 3) {
+            throw new Error('killed mid-run')
+          }
+        },
+      }),
+    )
+    await recoverAndVerify()
+
+    const entries = [...(await readdir(dir)), ...(await readdir(path.join(dir, 'blocks')))]
+    expect(entries.filter((f) => f.startsWith('.tmp-'))).toEqual([])
+  })
+})

--- a/packages/pipes/src/testing/conformance/index.ts
+++ b/packages/pipes/src/testing/conformance/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Conformance harness (spec/13).
+ *
+ * The pieces are independent on purpose: ledger mode is usable without the oracle, the validators
+ * without either, and the kill switch without any of them.
+ *
+ * `parquet-probe.js` is deliberately not re-exported — it pulls in `@dsnp/parquetjs`, which is a
+ * peer dependency. Import it directly from a suite that already depends on Parquet.
+ */
+export {
+  ChainLedger,
+  type ChainLedgerOptions,
+  type LedgerAdversary,
+  type LedgerFault,
+  type LedgerRequest,
+  type LoggedRequest,
+  buildChain,
+} from './chain-ledger.js'
+export { type Obstruction, expectCrash, obstruct, statePath, unitPath } from './kill-points.js'
+export { type LedgerPortal, type LedgerPortalOptions, ledgerPortal } from './ledger-portal.js'
+export {
+  type Cursor,
+  type DurabilityClass,
+  ORACLE_ERRORS,
+  OracleError,
+  type OracleErrorCode,
+  type OracleRow,
+  type OracleState,
+  type PersistedState,
+  ReferenceModel,
+  type ReferenceModelOptions,
+  type RollbackRecord,
+} from './reference-model.js'
+export { type SinkProbe, allRows, dataBound } from './store-probe.js'
+export {
+  type Attributed,
+  type DeliveredBatch,
+  type PublishedUnit,
+  type StructuralInput,
+  type Violation,
+  assertStructure,
+  isAscendingChain,
+  validateDecodable,
+  validateInRange,
+  validateItemsBelongToParent,
+  validateLinked,
+  validateOrdered,
+  validateStructure,
+  validateWatermarks,
+} from './validators.js'

--- a/packages/pipes/src/testing/conformance/kill-points.ts
+++ b/packages/pipes/src/testing/conformance/kill-points.ts
@@ -1,0 +1,68 @@
+import { mkdir, rm } from 'node:fs/promises'
+
+/**
+ * Kill-point injection (FM-30…FM-34).
+ *
+ * A crash is injected by obstructing the filesystem rather than by mocking it: a directory is
+ * placed where the sink is about to write a file, so the syscall fails the way it would against a
+ * full or failing disk, and the run dies at exactly that step of the commit protocol.
+ *
+ * The reason it is done this way rather than with `vi.mock('node:fs/promises')` is that this
+ * project runs every suite in a single fork with `isolate: false`, so a module another file has
+ * already imported keeps its real binding and never sees the mock. Obstruction is independent of
+ * pool configuration and of module-registry state.
+ *
+ * Fidelity limit, stated plainly: the process is not actually dead, so unwinding still runs and the
+ * sink still gets to discard its open segment. What the obstruction reproduces faithfully is the
+ * *on-disk state at the moment the run stops* — which is the thing recovery has to reconcile, and
+ * the thing the CT-2 matrix is about. Recovery deletes every `.tmp-*` unconditionally anyway, so
+ * the surviving difference does not change what recovery must do.
+ */
+
+export type Obstruction = {
+  readonly path: string
+  /** Removes the obstruction so a restart can proceed. */
+  release(): Promise<void>
+}
+
+/**
+ * Makes `target` unwritable by occupying it with a directory. Creating or renaming onto it fails
+ * with EISDIR/ENOTEMPTY rather than silently overwriting.
+ */
+export async function obstruct(target: string): Promise<Obstruction> {
+  await mkdir(target, { recursive: true })
+
+  return {
+    path: target,
+    release: () => rm(target, { recursive: true, force: true }),
+  }
+}
+
+/** Width `<min>-<max>.parquet` names are padded to (IB-22). */
+const BLOCK_PAD = 12
+
+/** Path of the unit a class-K sink publishes for `[from, to]`. */
+export function unitPath(dir: string, table: string, from: number, to: number): string {
+  const pad = (block: number) => Math.trunc(block).toString().padStart(BLOCK_PAD, '0')
+
+  return `${dir}/${table}/${pad(from)}-${pad(to)}.parquet`
+}
+
+/** Path of the durable state record, namespaced by pipe id when one is set (IB-22). */
+export function statePath(dir: string, id?: string): string {
+  return `${dir}/${id ? `_sqd_parquet_state.${id}.json` : '_sqd_parquet_state.json'}`
+}
+
+/**
+ * Runs `fn` expecting it to die, and returns the error. Fails loudly when the run survives — a
+ * matrix point that quietly stops firing would otherwise keep passing forever.
+ */
+export async function expectCrash(fn: () => Promise<unknown>): Promise<Error> {
+  try {
+    await fn()
+  } catch (error) {
+    return error as Error
+  }
+
+  throw new Error('expected the run to be interrupted, but it completed')
+}

--- a/packages/pipes/src/testing/conformance/ledger-portal.test.ts
+++ b/packages/pipes/src/testing/conformance/ledger-portal.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { evmPortalStream } from '~/evm/index.js'
+import { blockDecoder, readAll } from '~/testing/index.js'
+
+import { ChainLedger, buildChain } from './chain-ledger.js'
+import { type LedgerPortal, ledgerPortal } from './ledger-portal.js'
+
+describe('ledgerPortal', () => {
+  let portal: LedgerPortal | undefined
+
+  afterEach(async () => {
+    await portal?.close()
+    portal = undefined
+  })
+
+  it('streams a bounded backfill to a real pipe', async () => {
+    portal = await ledgerPortal(new ChainLedger({ blocks: buildChain({ from: 0, to: 5 }), batchSize: 2 }))
+
+    const blocks = await readAll(
+      evmPortalStream({ id: 'test', portal: portal.url, outputs: blockDecoder({ from: 0, to: 5 }) }),
+    )
+
+    expect(blocks.map((b: any) => b.number)).toEqual([0, 1, 2, 3, 4, 5])
+  })
+
+  it('drives the anchor forward one block at a time (IB-3)', async () => {
+    portal = await ledgerPortal(new ChainLedger({ blocks: buildChain({ from: 0, to: 5 }), batchSize: 2 }))
+
+    await readAll(evmPortalStream({ id: 'test', portal: portal.url, outputs: blockDecoder({ from: 0, to: 5 }) }))
+
+    // Every request after the first anchors on the hash of the block that preceded its fromBlock.
+    const anchored = portal.ledger.requests.filter((r) => r.parentBlockHash !== undefined)
+    expect(anchored.length).toBeGreaterThan(0)
+    for (const request of anchored) {
+      expect(request.parentBlockHash).toBe(`0x${request.fromBlock - 1}`)
+    }
+  })
+
+  it('signals a fork when the pipe anchors on an orphaned block', async () => {
+    const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 3 }), batchSize: 4 })
+    portal = await ledgerPortal(ledger)
+
+    const stream = evmPortalStream({ id: 'test', portal: portal.url, outputs: blockDecoder({ from: 0, to: 6 }) })
+    const iterator = stream[Symbol.asyncIterator]()
+
+    // Drain blocks 0–3, then reorg away from the block the pipe is now anchored on.
+    await iterator.next()
+    ledger.fork(1, buildChain({ from: 2, to: 6, hash: (n) => `0x${n}__b` }))
+
+    await expect(iterator.next()).rejects.toMatchObject({ name: 'ForkError' })
+    expect(ledger.requests.at(-1)?.statusCode).toBe(409)
+  })
+
+  it('answers a fresh pipe and a resumed pipe from the same held chain', async () => {
+    // The re-request an ordinal script cannot answer: a second run starting mid-chain gets the
+    // blocks its anchor actually implies, not whatever response sits at the next index.
+    const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 5 }), batchSize: 10 })
+    portal = await ledgerPortal(ledger)
+
+    const first = await readAll(
+      evmPortalStream({ id: 'test', portal: portal.url, outputs: blockDecoder({ from: 0, to: 2 }) }),
+    )
+    const resumed = await readAll(
+      evmPortalStream({ id: 'test', portal: portal.url, outputs: blockDecoder({ from: 3, to: 5 }) }),
+    )
+
+    expect(first.map((b: any) => b.number)).toEqual([0, 1, 2])
+    expect(resumed.map((b: any) => b.number)).toEqual([3, 4, 5])
+  })
+
+  it('retries through an injected transport fault (IB-7)', async () => {
+    const ledger = new ChainLedger({ blocks: buildChain({ from: 0, to: 3 }), batchSize: 10 })
+    ledger.injectFaults({ statusCode: 503 })
+    portal = await ledgerPortal(ledger)
+
+    const blocks = await readAll(
+      evmPortalStream({ id: 'test', portal: portal.url, outputs: blockDecoder({ from: 0, to: 3 }) }),
+    )
+
+    expect(blocks.map((b: any) => b.number)).toEqual([0, 1, 2, 3])
+    expect(ledger.requests[0].statusCode).toBe(503)
+  })
+})

--- a/packages/pipes/src/testing/conformance/ledger-portal.ts
+++ b/packages/pipes/src/testing/conformance/ledger-portal.ts
@@ -1,0 +1,87 @@
+import { IncomingMessage, Server, ServerResponse, createServer } from 'node:http'
+
+import { getServerAddress, writeWireResponse } from '../portal-wire.js'
+import type { MockPortal } from '../test-portal.js'
+import type { ChainLedger, LedgerRequest } from './chain-ledger.js'
+
+export type LedgerPortalOptions = {
+  /** Serve `/finalized-stream` instead of `/stream` (IB-1). */
+  finalized?: boolean
+  /** Dataset kind reported by `/metadata`. */
+  kind?: string
+  startBlock?: number
+  /** Runs on every parsed request body before the ledger answers; assert-only. */
+  validateRequest?: (body: any) => unknown
+}
+
+export type LedgerPortal = MockPortal & {
+  ledger: ChainLedger
+}
+
+/**
+ * The simulator in ledger mode: same wire surface as {@link mockPortal}, but every response is
+ * derived from the request anchor against the held chain instead of being read off a script.
+ */
+export async function ledgerPortal(ledger: ChainLedger, options: LedgerPortalOptions = {}): Promise<LedgerPortal> {
+  const streamUrl = options.finalized ? '/finalized-stream' : '/stream'
+
+  const server = await new Promise<Server>((resolve, reject) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      if (req.url?.startsWith('/metadata')) {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.write(
+          JSON.stringify({
+            dataset: 'ledger-dataset',
+            aliases: [],
+            real_time: true,
+            start_block: options.startBlock ?? 0,
+            metadata: { kind: options.kind ?? 'evm' },
+          }),
+        )
+        res.end()
+
+        return
+      }
+
+      if (req.url !== streamUrl) {
+        res.statusCode = 404
+        res.end()
+
+        return
+      }
+
+      let body = ''
+      req.on('data', (chunk) => {
+        body += chunk
+      })
+      req.on('end', () => {
+        const parsed = body ? JSON.parse(body) : undefined
+        options.validateRequest?.(parsed)
+
+        writeWireResponse(res, ledger.answer(toLedgerRequest(parsed)))
+        res.end()
+      })
+    })
+
+    server.listen(0, () => resolve(server))
+    server.on('error', reject)
+  })
+
+  return {
+    server,
+    ledger,
+    url: getServerAddress(server),
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()))
+      }),
+  }
+}
+
+function toLedgerRequest(body: any): LedgerRequest {
+  return {
+    fromBlock: body?.fromBlock ?? 0,
+    toBlock: body?.toBlock,
+    parentBlockHash: body?.parentBlockHash,
+  }
+}

--- a/packages/pipes/src/testing/conformance/parquet-probe.ts
+++ b/packages/pipes/src/testing/conformance/parquet-probe.ts
@@ -1,0 +1,109 @@
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+
+import { ParquetReader } from '@dsnp/parquetjs'
+
+import type { OracleRow, OracleState } from './reference-model.js'
+import type { SinkProbe } from './store-probe.js'
+import type { PublishedUnit } from './validators.js'
+
+/** Published data files are named `<min>-<max>.parquet` (IB-22). */
+const DATA_FILE_RE = /^(\d+)-(\d+)\.parquet$/
+const STATE_BASENAME = '_sqd_parquet_state'
+
+export type ParquetProbeOptions = {
+  dir: string
+  tables: string[]
+  /** Pipe namespace; the state file is `_sqd_parquet_state.<id>.json` when set. */
+  id?: string
+  /** Column carrying block attribution (INV-3). */
+  blockColumn?: string
+}
+
+/**
+ * Class-K (checkpointed-immutable) store probe: the durable state file plus the published Parquet
+ * units, read straight off disk.
+ *
+ * Windows come from the filename, which on mainline is the row min/max rather than a coverage
+ * window — so `items-belong-to-parent` holds here by construction and only becomes load-bearing
+ * once coverage-window naming lands (GAP-17).
+ */
+export function parquetProbe({ dir, tables, id, blockColumn = 'blockNumber' }: ParquetProbeOptions): SinkProbe {
+  const statePath = path.join(dir, id ? `${STATE_BASENAME}.${id}.json` : `${STATE_BASENAME}.json`)
+
+  const readUnits = async (table: string): Promise<PublishedUnit[]> => {
+    const entries = await readdir(path.join(dir, table)).catch(() => [] as string[])
+    const units: PublishedUnit[] = []
+
+    for (const name of entries.sort()) {
+      const match = DATA_FILE_RE.exec(name)
+      if (!match) {
+        continue
+      }
+
+      units.push({
+        name,
+        from: Number.parseInt(match[1], 10),
+        to: Number.parseInt(match[2], 10),
+        rows: await readUnitRows(path.join(dir, table, name), table, blockColumn),
+      })
+    }
+
+    return units
+  }
+
+  return {
+    binding: 'parquet',
+
+    async readState(): Promise<OracleState | undefined> {
+      let raw: string
+      try {
+        raw = await readFile(statePath, 'utf8')
+      } catch {
+        return undefined
+      }
+
+      const parsed = JSON.parse(raw)
+
+      // Class K persists no rollback chain: only finalized rows are ever written, so there is
+      // nothing above the floor to roll back (CN-12).
+      return {
+        current: parsed.cursor,
+        finalized: parsed.finalized ?? undefined,
+        rollbackChain: [],
+      }
+    },
+
+    async readRows(table: string): Promise<OracleRow[]> {
+      const units = await readUnits(table)
+
+      return units.flatMap((unit) => unit.rows as OracleRow[]).sort((a, b) => a.block - b.block)
+    },
+
+    readUnits,
+  }
+}
+
+async function readUnitRows(filePath: string, table: string, blockColumn: string): Promise<OracleRow[]> {
+  const reader = await ParquetReader.openFile(filePath)
+  const rows: OracleRow[] = []
+
+  try {
+    const cursor = reader.getCursor()
+    let raw: Record<string, unknown> | null
+    while ((raw = (await cursor.next()) as Record<string, unknown> | null)) {
+      rows.push({ table, block: Number(raw[blockColumn]), value: normalize(raw) })
+    }
+  } finally {
+    await reader.close()
+  }
+
+  return rows
+}
+
+/** Parquet returns INT64 as BigInt; normalise so oracle comparison is not width-sensitive. */
+function normalize(raw: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(raw).map(([key, value]) => [key, typeof value === 'bigint' ? Number(value) : value]),
+  )
+}

--- a/packages/pipes/src/testing/conformance/reference-model.test.ts
+++ b/packages/pipes/src/testing/conformance/reference-model.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest'
+
+import { ORACLE_ERRORS, type OracleRow, ReferenceModel } from './reference-model.js'
+
+const block = (number: number, suffix = '') => ({ number, hash: `0x${number}${suffix}` })
+const blocks = (from: number, to: number, suffix = '') => {
+  const out = []
+  for (let n = from; n <= to; n++) {
+    out.push(block(n, suffix))
+  }
+
+  return out
+}
+
+describe('ReferenceModel', () => {
+  describe('T-BATCH', () => {
+    it('advances the cursor to the last block of the batch', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+
+      model.batch(blocks(0, 3))
+
+      expect(model.readState().current).toEqual(block(3))
+    })
+
+    it('refuses a batch that does not continue from the cursor (INV-20)', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+      model.batch(blocks(0, 3))
+
+      expect(() => model.batch(blocks(5, 6))).toThrowError(/expected 4/)
+    })
+
+    it('refuses a batch that is not strictly ascending (INV-20)', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+
+      expect(() => model.batch([block(0), block(2), block(1)])).toThrowError(/not strictly ascending/)
+    })
+
+    it('refuses blocks past the configured end (INV-24)', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0, to: 3 } })
+
+      expect(() => model.batch(blocks(0, 5))).toThrowError(/above the configured end/)
+    })
+
+    it('never lowers the floor, however the portal reports it (INV-12)', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+
+      model.batch(blocks(0, 3), { finalized: block(3) })
+      model.batch(blocks(4, 5), { finalized: block(1) })
+
+      expect(model.readState().finalized).toEqual(block(3))
+    })
+
+    it('keeps the rollback chain to exactly the processed blocks above the floor (INV-1)', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+
+      model.batch(blocks(0, 5), { finalized: block(2) })
+
+      expect(model.readState().rollbackChain.map((b) => b.number)).toEqual([3, 4, 5])
+    })
+  })
+
+  describe('hold-back (DEF-15)', () => {
+    it('releases only finalized rows for a deferred class', () => {
+      const model = new ReferenceModel({ durability: 'K', range: { from: 0 } })
+
+      model.batch(blocks(0, 5), { finalized: block(2) })
+
+      expect(model.data.map((r) => r.block)).toEqual([0, 1, 2])
+      expect(model.buffered.map((r) => r.block)).toEqual([3, 4, 5])
+    })
+
+    it('releases buffered rows once the floor reaches them', () => {
+      const model = new ReferenceModel({ durability: 'K', range: { from: 0 } })
+
+      model.batch(blocks(0, 5), { finalized: block(2) })
+      model.batch(blocks(6, 7), { finalized: block(6) })
+
+      expect(model.data.map((r) => r.block)).toEqual([0, 1, 2, 3, 4, 5, 6])
+      expect(model.buffered.map((r) => r.block)).toEqual([7])
+    })
+
+    it('commits every row immediately for a transactional class', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+
+      model.batch(blocks(0, 5), { finalized: block(2) })
+
+      expect(model.data.map((r) => r.block)).toEqual([0, 1, 2, 3, 4, 5])
+      expect(model.buffered).toEqual([])
+    })
+  })
+
+  describe('T-FORK (WP-40…WP-44)', () => {
+    it('rewinds to the newest block both chains agree on', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+      model.batch(blocks(0, 5), { finalized: block(1) })
+
+      const ancestor = model.fork([...blocks(0, 3), block(4, '__b'), block(5, '__b')])
+
+      expect(ancestor).toEqual(block(3))
+      expect(model.readState().current).toEqual(block(3))
+      expect(model.data.map((r) => r.block)).toEqual([0, 1, 2, 3])
+    })
+
+    it('leaves the floor untouched when it rewinds (INV-13, INV-14)', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+      model.batch(blocks(0, 5), { finalized: block(1) })
+
+      model.fork([...blocks(0, 3), block(4, '__b'), block(5, '__b')])
+
+      expect(model.readState().finalized).toEqual(block(1))
+    })
+
+    it('drops rollback-chain entries above the ancestor', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+      model.batch(blocks(0, 5), { finalized: block(1) })
+
+      model.fork([...blocks(0, 3), block(4, '__b'), block(5, '__b')])
+
+      expect(model.readState().rollbackChain.map((b) => b.number)).toEqual([2, 3])
+    })
+
+    it('refuses an empty canonical chain (WP-41)', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+      model.batch(blocks(0, 3))
+
+      expect(() => model.fork([])).toThrowError(/empty canonical chain/)
+    })
+
+    it('refuses a canonical chain that ends below the cursor (RP-43)', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+      model.batch(blocks(0, 5))
+
+      expect(() => model.fork(blocks(0, 2, '__b'))).toThrowError(/below the committed cursor/)
+    })
+
+    it('refuses to rewind below the finalized floor (WP-44)', () => {
+      // Only reachable from state INV-1 already forbids: a rollback record whose chain dips below
+      // its own floor. Against conforming state the window is exhausted first and the search ends
+      // in "no ancestor" instead — see the note on this branch in the gap register.
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+      model.recover({
+        current: block(7, '__a'),
+        finalized: block(5),
+        rollbackChain: [],
+        history: [{ rollbackChain: [block(3, '__a'), block(7, '__a')], finalized: block(5) }],
+      })
+
+      expect(() => model.fork([block(7, '__b')])).toThrowError(/below the finalized floor/)
+    })
+
+    it('ends in "no ancestor" rather than a finality conflict when the state is well-formed', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+      model.batch(blocks(0, 5), { finalized: block(4) })
+
+      expect(() => model.fork([block(9, '__b')])).toThrowError(/no common ancestor/)
+    })
+
+    it('falls back to the floor when it is the last canonical block standing (WP-42)', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+      model.batch(blocks(0, 3), { finalized: block(1) })
+
+      // Only block 1 (the floor) survives the narrowing; blocks 2–3 are orphaned.
+      const ancestor = model.fork([block(1), block(2, '__b'), block(3, '__b')])
+
+      expect(ancestor).toEqual(block(1))
+    })
+  })
+
+  describe('T-INIT', () => {
+    it('drops rows the cursor does not cover (CN-40…CN-44, INV-42)', () => {
+      const model = new ReferenceModel({ durability: 'K', range: { from: 0 } })
+      model.batch(blocks(0, 5), { finalized: block(5) })
+
+      model.recover({ current: block(3), finalized: block(3), rollbackChain: [] })
+
+      expect(model.data.map((r) => r.block)).toEqual([0, 1, 2, 3])
+      expect(model.readState().current).toEqual(block(3))
+    })
+
+    it('refuses malformed persisted state (INV-5)', () => {
+      const model = new ReferenceModel({ durability: 'T' })
+
+      expect(() =>
+        model.recover({ current: { hash: '0x1' } as any, finalized: undefined, rollbackChain: [] }),
+      ).toThrowError(/no block number/)
+    })
+
+    it('starts cold when there is nothing persisted', () => {
+      const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+
+      model.recover(undefined)
+
+      expect(model.readState().current).toBeUndefined()
+    })
+  })
+
+  it('applies the supplied transform rather than assuming one row per block (RS-10)', () => {
+    const transform = (b: { number: number }): OracleRow[] => [
+      { table: 'blocks', block: b.number, value: b.number },
+      { table: 'logs', block: b.number, value: b.number * 2 },
+    ]
+    const model = new ReferenceModel({ durability: 'T', range: { from: 0 }, transform })
+
+    model.batch(blocks(0, 1))
+
+    expect(model.data).toEqual([
+      { table: 'blocks', block: 0, value: 0 },
+      { table: 'logs', block: 0, value: 0 },
+      { table: 'blocks', block: 1, value: 1 },
+      { table: 'logs', block: 1, value: 2 },
+    ])
+  })
+
+  it('tracks the next coverage window per table (INV-4)', () => {
+    const model = new ReferenceModel({ durability: 'T', range: { from: 0 } })
+
+    model.batch(blocks(0, 4))
+
+    expect(model.coverage).toEqual({ blocks: 5 })
+  })
+})

--- a/packages/pipes/src/testing/conformance/reference-model.ts
+++ b/packages/pipes/src/testing/conformance/reference-model.ts
@@ -1,0 +1,398 @@
+import type { BlockRef } from '../portal-wire.js'
+
+/**
+ * Durability classes per CN-10…CN-14. `ephemeral` is the spec's class ∅ — no persistence, kept as
+ * the executable minimal model of the hold-back contract.
+ */
+export type DurabilityClass = 'T' | 'W' | 'K' | 'A' | 'ephemeral'
+
+/** Classes that write only finalized rows, through the hold-back buffer (DEF-15). */
+const DEFERRED: ReadonlySet<DurabilityClass> = new Set<DurabilityClass>(['K', 'ephemeral'])
+
+export type Cursor = BlockRef & { timestamp?: number }
+
+/** A committed row, reduced to what the oracle compares: where it belongs and what it holds. */
+export type OracleRow = {
+  table: string
+  /** Block the row is attributed to (INV-3). */
+  block: number
+  value: unknown
+}
+
+export type OracleState = {
+  /** Committed cursor. */
+  current: Cursor | undefined
+  /** Monotonic finalized floor. */
+  finalized: Cursor | undefined
+  /** Rollback chain: processed blocks above the floor. */
+  rollbackChain: Cursor[]
+}
+
+export type PersistedState = OracleState & {
+  /** Next window start per table (file sinks, INV-4). */
+  coverage?: Record<string, number>
+  /** Prior rollback records, oldest first. Defaults to one record built from the state itself. */
+  history?: RollbackRecord[]
+}
+
+/** One historical commit's rollback state — the unit WP-42's ancestor search walks. */
+export type RollbackRecord = {
+  rollbackChain: Cursor[]
+  finalized?: Cursor
+}
+
+export const ORACLE_ERRORS = {
+  STATE_MALFORMED: 'ORACLE_STATE_MALFORMED',
+  ROWS_ABOVE_CURSOR: 'ORACLE_ROWS_ABOVE_CURSOR',
+  NOT_ASCENDING: 'ORACLE_NOT_ASCENDING',
+  NOT_LINKED: 'ORACLE_NOT_LINKED',
+  OUT_OF_RANGE: 'ORACLE_OUT_OF_RANGE',
+  EMPTY_CANONICAL: 'ORACLE_EMPTY_CANONICAL',
+  CANONICAL_BELOW_CURSOR: 'ORACLE_CANONICAL_BELOW_CURSOR',
+  FINALITY_CONFLICT: 'ORACLE_FINALITY_CONFLICT',
+  NO_ANCESTOR: 'ORACLE_NO_ANCESTOR',
+  INVARIANT: 'ORACLE_INVARIANT',
+} as const
+
+export type OracleErrorCode = (typeof ORACLE_ERRORS)[keyof typeof ORACLE_ERRORS]
+
+export class OracleError extends Error {
+  constructor(
+    readonly code: OracleErrorCode,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'OracleError'
+  }
+}
+
+export type ReferenceModelOptions = {
+  durability: DurabilityClass
+  /** Pure per RS-10: same blocks in, same rows out. Default emits one row per block. */
+  transform?: (block: Cursor) => OracleRow[]
+  /** Configured range, when known — enables the INV-3 in-range and INV-20 linkage checks. */
+  range?: { from: number; to?: number }
+}
+
+/**
+ * The oracle: the spec's normative reference model, executable.
+ *
+ * It is deliberately a transcription of the pseudocode in spec/13 rather than a second
+ * implementation — every divergence from the SUT is meant to be a finding about the SUT or about
+ * the spec, never about a clever shortcut taken here.
+ *
+ * It pins only what the spec declares deterministic. The free variables — batch partitioning,
+ * flush and checkpoint timing, published-unit boundaries, retry pacing, log text — are never
+ * asserted, so a conforming implementation may vary them without failing a comparison.
+ */
+export class ReferenceModel {
+  readonly #durability: DurabilityClass
+  readonly #transform: (block: Cursor) => OracleRow[]
+  readonly #range: { from: number; to?: number } | undefined
+
+  #current: Cursor | undefined
+  #finalized: Cursor | undefined
+  #rollbackChain: Cursor[] = []
+  /**
+   * Every rollback record ever committed, oldest first.
+   *
+   * WP-42 searches the persisted *records*, each with its own chain and its own floor — not just
+   * the current chain. The distinction is load-bearing: INV-1 keeps every entry of the current
+   * chain strictly above the current floor, so against that chain alone WP-44's finality conflict
+   * can never trigger. Only an older record, written under a lower floor, can reach below it.
+   */
+  #history: RollbackRecord[] = []
+  /** Committed, reader-visible rows. */
+  #data: OracleRow[] = []
+  /** Hold-back buffer: rows awaiting finality (deferred classes only). */
+  #buffer: OracleRow[] = []
+  #coverage: Record<string, number> = {}
+
+  constructor(options: ReferenceModelOptions) {
+    this.#durability = options.durability
+    this.#range = options.range
+    this.#transform =
+      options.transform ?? ((block) => [{ table: 'blocks', block: block.number, value: { hash: block.hash } }])
+  }
+
+  get durability(): DurabilityClass {
+    return this.#durability
+  }
+
+  /** Reader-visible rows, in commit order. */
+  get data(): readonly OracleRow[] {
+    return this.#data
+  }
+
+  /** Rows held back awaiting finality. */
+  get buffered(): readonly OracleRow[] {
+    return this.#buffer
+  }
+
+  get coverage(): Readonly<Record<string, number>> {
+    return this.#coverage
+  }
+
+  /** T-INIT — adopt persisted state and repair, then assert the recovery invariant. */
+  recover(persisted: PersistedState | undefined): void {
+    if (!persisted) {
+      return
+    }
+
+    if (persisted.current && typeof persisted.current.number !== 'number') {
+      throw new OracleError(ORACLE_ERRORS.STATE_MALFORMED, 'persisted cursor has no block number')
+    }
+
+    this.#current = persisted.current
+    this.#finalized = persisted.finalized
+    this.#rollbackChain = [...(persisted.rollbackChain ?? [])]
+    this.#coverage = { ...(persisted.coverage ?? {}) }
+    this.#history = persisted.history
+      ? [...persisted.history]
+      : this.#rollbackChain.length
+        ? [{ rollbackChain: [...this.#rollbackChain], finalized: this.#finalized }]
+        : []
+
+    // CN-40…CN-44: recovery removes anything the cursor does not cover, whatever the class's
+    // crash window let through.
+    const bound = this.#current?.number ?? -1
+    this.#data = this.#data.filter((row) => row.block <= bound)
+    this.#buffer = this.#buffer.filter((row) => row.block <= bound)
+
+    this.#assertNoRowsAboveCursor()
+    this.wellformedCheck()
+  }
+
+  /** T-BATCH — the batch transition, per the normative pseudocode. */
+  batch(blocks: Cursor[], head: { finalized?: Cursor; latest?: { number: number } } = {}): void {
+    this.#requireWellFormedBatch(blocks)
+
+    // INV-12: the floor only ever advances, whatever the portal reports.
+    if (head.finalized && (!this.#finalized || head.finalized.number > this.#finalized.number)) {
+      this.#finalized = head.finalized
+    }
+
+    const floor = this.#finalized?.number ?? -1
+    // INV-1: the rollback chain is exactly the processed blocks still above the floor.
+    this.#rollbackChain = [...this.#rollbackChain, ...blocks].filter((b) => b.number > floor)
+
+    const rows = blocks.flatMap((block) => this.#transform(block))
+
+    let released: OracleRow[]
+    if (DEFERRED.has(this.#durability)) {
+      this.#buffer = [...this.#buffer, ...rows]
+      released = this.#buffer.filter((row) => row.block <= floor)
+      this.#buffer = this.#buffer.filter((row) => row.block > floor)
+    } else {
+      released = rows
+    }
+
+    this.#data = [...this.#data, ...released]
+    this.#current = blocks.at(-1)
+    this.#advanceCoverage(released)
+    this.#history.push({ rollbackChain: [...this.#rollbackChain], finalized: this.#finalized })
+
+    this.wellformedCheck()
+  }
+
+  /**
+   * T-FORK — narrow the canonical window against the rollback chain, newest first, and rewind to
+   * the ancestor both sides agree on (WP-42).
+   */
+  fork(canonical: Cursor[]): Cursor {
+    if (!canonical.length) {
+      throw new OracleError(ORACLE_ERRORS.EMPTY_CANONICAL, 'fork signalled with an empty canonical chain (WP-41)')
+    }
+
+    const top = Math.max(...canonical.map((b) => b.number))
+    if (this.#current && top < this.#current.number) {
+      throw new OracleError(
+        ORACLE_ERRORS.CANONICAL_BELOW_CURSOR,
+        `canonical head ${top} is below the committed cursor ${this.#current.number} (RP-43)`,
+      )
+    }
+
+    const ancestor = this.#searchAncestor(canonical)
+    if (!ancestor) {
+      throw new OracleError(ORACLE_ERRORS.NO_ANCESTOR, 'no common ancestor between rollback chain and canonical chain')
+    }
+
+    this.#data = this.#data.filter((row) => row.block <= ancestor.number)
+    this.#buffer = this.#buffer.filter((row) => row.block <= ancestor.number)
+    this.#current = ancestor
+    this.#rollbackChain = this.#rollbackChain.filter((b) => b.number <= ancestor.number)
+    // INV-13/INV-14: the floor is never rewound by a fork.
+    this.#history.push({ rollbackChain: [...this.#rollbackChain], finalized: this.#finalized })
+
+    this.wellformedCheck()
+
+    return ancestor
+  }
+
+  /**
+   * WP-42: walk the persisted records newest → oldest, each record's chain descending, narrowing
+   * the canonical window past every cursor visited.
+   */
+  #searchAncestor(canonical: Cursor[]): Cursor | undefined {
+    let window = [...canonical]
+
+    for (const record of [...this.#history].reverse()) {
+      if (!record.rollbackChain.length) {
+        continue
+      }
+
+      for (const visited of [...record.rollbackChain].sort((a, b) => b.number - a.number)) {
+        const match = window.find((w) => w.hash === visited.hash)
+        if (match) {
+          return match
+        }
+
+        if (!window.length) {
+          if (record.finalized && visited.number < record.finalized.number) {
+            throw new OracleError(
+              ORACLE_ERRORS.FINALITY_CONFLICT,
+              `fork would rewind to ${visited.number}, below the finalized floor ${record.finalized.number} (WP-44)`,
+            )
+          }
+          // Below the exhausted window: a deep fork, restart from here.
+          return visited
+        }
+
+        window = window.filter((w) => w.number < visited.number)
+      }
+
+      // Floor fallback: the last canonical block standing is the floor itself.
+      if (record.finalized && window.length === 1 && window[0].hash === record.finalized.hash) {
+        return record.finalized
+      }
+    }
+
+    return undefined
+  }
+
+  /** The same taxonomy the SUT's state read exposes. */
+  readState(): OracleState {
+    return {
+      current: this.#current,
+      finalized: this.#finalized,
+      rollbackChain: [...this.#rollbackChain],
+    }
+  }
+
+  /** Asserts INV-1…INV-5 after every transition. */
+  wellformedCheck(): void {
+    const floor = this.#finalized?.number
+    const cursor = this.#current?.number
+
+    // INV-1 — rollback chain well-formedness.
+    let previous = -Infinity
+    for (const entry of this.#rollbackChain) {
+      if (entry.number <= previous) {
+        throw new OracleError(
+          ORACLE_ERRORS.INVARIANT,
+          `INV-1: rollback chain is not strictly increasing at ${entry.number}`,
+        )
+      }
+      if (!entry.hash) {
+        throw new OracleError(ORACLE_ERRORS.INVARIANT, `INV-1: rollback chain entry ${entry.number} has no hash`)
+      }
+      if (floor !== undefined && entry.number <= floor) {
+        throw new OracleError(
+          ORACLE_ERRORS.INVARIANT,
+          `INV-1: rollback chain entry ${entry.number} is at or below the floor ${floor}`,
+        )
+      }
+      if (cursor !== undefined && entry.number > cursor) {
+        throw new OracleError(
+          ORACLE_ERRORS.INVARIANT,
+          `INV-1: rollback chain entry ${entry.number} is above the cursor ${cursor}`,
+        )
+      }
+      previous = entry.number
+    }
+
+    // INV-3 — attribution, including the class visibility rule (CN-20…CN-24).
+    for (const row of this.#data) {
+      if (cursor !== undefined && row.block > cursor) {
+        throw new OracleError(ORACLE_ERRORS.INVARIANT, `INV-3: row at block ${row.block} is above the cursor ${cursor}`)
+      }
+      if (
+        this.#range &&
+        (row.block < this.#range.from || (this.#range.to !== undefined && row.block > this.#range.to))
+      ) {
+        throw new OracleError(
+          ORACLE_ERRORS.INVARIANT,
+          `INV-3: row at block ${row.block} falls outside the configured range`,
+        )
+      }
+      if (DEFERRED.has(this.#durability) && floor !== undefined && row.block > floor) {
+        throw new OracleError(
+          ORACLE_ERRORS.INVARIANT,
+          `INV-3: deferred sink made block ${row.block} visible above the floor ${floor}`,
+        )
+      }
+    }
+
+    // INV-5 — no state record refers above the newest committed data.
+    const dataBound = this.#data.reduce((max, row) => Math.max(max, row.block), -Infinity)
+    if (DEFERRED.has(this.#durability) && cursor !== undefined && dataBound > cursor) {
+      throw new OracleError(
+        ORACLE_ERRORS.INVARIANT,
+        `INV-5: committed data reaches ${dataBound}, above the cursor ${cursor}`,
+      )
+    }
+  }
+
+  #requireWellFormedBatch(blocks: Cursor[]): void {
+    if (!blocks.length) {
+      throw new OracleError(ORACLE_ERRORS.NOT_LINKED, 'INV-20: empty batch')
+    }
+
+    // INV-20 — strictly ascending.
+    for (let i = 1; i < blocks.length; i++) {
+      if (blocks[i].number <= blocks[i - 1].number) {
+        throw new OracleError(
+          ORACLE_ERRORS.NOT_ASCENDING,
+          `INV-20: batch is not strictly ascending at ${blocks[i - 1].number} → ${blocks[i].number}`,
+        )
+      }
+    }
+
+    // INV-20 — linkage: the batch continues where the cursor left off.
+    const expected = this.#current ? this.#current.number + 1 : this.#range?.from
+    if (expected !== undefined && blocks[0].number !== expected) {
+      throw new OracleError(
+        ORACLE_ERRORS.NOT_LINKED,
+        `INV-20: batch starts at ${blocks[0].number}, expected ${expected}`,
+      )
+    }
+
+    if (this.#range?.to !== undefined && blocks.at(-1)!.number > this.#range.to) {
+      throw new OracleError(
+        ORACLE_ERRORS.OUT_OF_RANGE,
+        `INV-24: batch reaches ${blocks.at(-1)!.number}, above the configured end ${this.#range.to}`,
+      )
+    }
+  }
+
+  #assertNoRowsAboveCursor(): void {
+    const bound = this.#current?.number ?? -1
+    const stray = this.#data.find((row) => row.block > bound)
+    if (stray) {
+      throw new OracleError(
+        ORACLE_ERRORS.ROWS_ABOVE_CURSOR,
+        `INV-42: recovery left a row at block ${stray.block} above the cursor ${bound}`,
+      )
+    }
+  }
+
+  /** `V` in the DEF tuple: next window start per table (INV-4). */
+  #advanceCoverage(released: OracleRow[]): void {
+    for (const row of released) {
+      const next = (this.#coverage[row.table] ?? this.#range?.from ?? 0) as number
+      if (row.block >= next) {
+        this.#coverage[row.table] = row.block + 1
+      }
+    }
+  }
+}

--- a/packages/pipes/src/testing/conformance/store-probe.ts
+++ b/packages/pipes/src/testing/conformance/store-probe.ts
@@ -1,0 +1,45 @@
+import type { OracleRow, OracleState } from './reference-model.js'
+import type { PublishedUnit } from './validators.js'
+
+/**
+ * Reads a sink's committed state and data back out of its store, so the oracle can be diffed
+ * against what actually landed rather than against what the pipe reported (12 §harness rule).
+ *
+ * One interface across bindings: the comparison logic in a conformance suite must not know which
+ * engine it is looking at. Per-binding format details live behind `readState` (IB-20…IB-26).
+ */
+export type SinkProbe = {
+  /** Engine label, for failure messages. */
+  readonly binding: string
+  /** Persisted state, or undefined when the sink has never committed. */
+  readState(): Promise<OracleState | undefined>
+  /** Committed rows for one table, ascending by attribution. */
+  readRows(table: string): Promise<OracleRow[]>
+  /** Published units and the windows they claim. File sinks only. */
+  readUnits?(table: string): Promise<PublishedUnit[]>
+}
+
+/** Highest block the probe's committed data reaches, for the INV-5 watermark check. */
+export async function dataBound(probe: SinkProbe, tables: readonly string[]): Promise<number | undefined> {
+  let bound: number | undefined
+
+  for (const table of tables) {
+    for (const row of await probe.readRows(table)) {
+      if (bound === undefined || row.block > bound) {
+        bound = row.block
+      }
+    }
+  }
+
+  return bound
+}
+
+/** Every committed row across `tables`, ascending by attribution then table. */
+export async function allRows(probe: SinkProbe, tables: readonly string[]): Promise<OracleRow[]> {
+  const rows: OracleRow[] = []
+  for (const table of tables) {
+    rows.push(...(await probe.readRows(table)))
+  }
+
+  return rows.sort((a, b) => a.block - b.block || a.table.localeCompare(b.table))
+}

--- a/packages/pipes/src/testing/conformance/validators.test.ts
+++ b/packages/pipes/src/testing/conformance/validators.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  assertStructure,
+  validateDecodable,
+  validateInRange,
+  validateItemsBelongToParent,
+  validateLinked,
+  validateOrdered,
+  validateStructure,
+  validateWatermarks,
+} from './validators.js'
+
+const cursor = (number: number) => ({ number, hash: `0x${number}` })
+
+describe('structural validators', () => {
+  describe('decodable', () => {
+    it('passes when every item parses', () => {
+      expect(validateDecodable(['{"a":1}', '{"b":2}'], (s) => JSON.parse(s))).toEqual([])
+    })
+
+    it('names the item that does not parse', () => {
+      const violations = validateDecodable(['{"a":1}', 'not json'], (s) => JSON.parse(s))
+
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({ validator: 'decodable', property: 'INV-5' })
+      expect(violations[0].message).toMatch(/item 1/)
+    })
+  })
+
+  describe('ordered', () => {
+    it('accepts strictly ascending attribution', () => {
+      expect(validateOrdered([{ block: 1 }, { block: 2 }, { block: 5 }])).toEqual([])
+    })
+
+    it('rejects a repeated block by default', () => {
+      expect(validateOrdered([{ block: 1 }, { block: 1 }])).toHaveLength(1)
+    })
+
+    it('allows repeats when attribution is only required non-decreasing', () => {
+      expect(validateOrdered([{ block: 1 }, { block: 1 }], { strict: false })).toEqual([])
+    })
+
+    it('rejects a descending step', () => {
+      const violations = validateOrdered([{ block: 3 }, { block: 2 }])
+
+      expect(violations[0].message).toMatch(/3 → 2/)
+    })
+  })
+
+  describe('linked', () => {
+    it('accepts a batch that continues from the cursor', () => {
+      expect(validateLinked([{ cursorBefore: 4, blocks: [{ number: 5 }, { number: 6 }] }])).toEqual([])
+    })
+
+    it('rejects a gap', () => {
+      const violations = validateLinked([{ cursorBefore: 4, blocks: [{ number: 7 }] }])
+
+      expect(violations[0].message).toMatch(/starts at 7, expected 5/)
+    })
+
+    it('skips batches with no known preceding cursor', () => {
+      expect(validateLinked([{ blocks: [{ number: 99 }] }])).toEqual([])
+    })
+  })
+
+  describe('items-belong-to-parent', () => {
+    it('accepts rows inside their unit window', () => {
+      const units = [{ name: '0-9.parquet', from: 0, to: 9, rows: [{ block: 0 }, { block: 9 }] }]
+
+      expect(validateItemsBelongToParent(units)).toEqual([])
+    })
+
+    it('rejects a row outside the window its unit claims', () => {
+      const units = [{ name: '0-9.parquet', from: 0, to: 9, rows: [{ block: 10 }] }]
+
+      expect(validateItemsBelongToParent(units)[0].message).toMatch(/claims \[0, 9\] but holds a row at 10/)
+    })
+  })
+
+  describe('in-range', () => {
+    it('accepts attribution covered by a configured range', () => {
+      expect(validateInRange([{ block: 5 }], [{ from: 0, to: 10 }])).toEqual([])
+    })
+
+    it('accepts attribution covered by any of several disjoint ranges', () => {
+      expect(
+        validateInRange(
+          [{ block: 50 }],
+          [
+            { from: 0, to: 10 },
+            { from: 40, to: 60 },
+          ],
+        ),
+      ).toEqual([])
+    })
+
+    it('rejects attribution outside every range', () => {
+      expect(
+        validateInRange(
+          [{ block: 20 }],
+          [
+            { from: 0, to: 10 },
+            { from: 40, to: 60 },
+          ],
+        ),
+      ).toHaveLength(1)
+    })
+
+    it('treats an open-ended range as unbounded above', () => {
+      expect(validateInRange([{ block: 1_000_000 }], [{ from: 0 }])).toEqual([])
+    })
+  })
+
+  describe('watermark coherence', () => {
+    it('accepts a chain strictly above the floor and at or below the cursor', () => {
+      const state = { current: cursor(5), finalized: cursor(2), rollbackChain: [cursor(3), cursor(4), cursor(5)] }
+
+      expect(validateWatermarks(state)).toEqual([])
+    })
+
+    it('rejects a chain entry at or below the floor (INV-1)', () => {
+      const state = { current: cursor(5), finalized: cursor(3), rollbackChain: [cursor(3), cursor(4)] }
+
+      expect(validateWatermarks(state)[0].message).toMatch(/at or below the floor 3/)
+    })
+
+    it('rejects a chain entry above the cursor (INV-1)', () => {
+      const state = { current: cursor(4), finalized: cursor(1), rollbackChain: [cursor(2), cursor(9)] }
+
+      expect(validateWatermarks(state)[0].message).toMatch(/above the cursor 4/)
+    })
+
+    it('rejects a chain that is not strictly increasing', () => {
+      const state = { current: cursor(5), finalized: cursor(1), rollbackChain: [cursor(3), cursor(3)] }
+
+      expect(validateWatermarks(state).some((v) => /not strictly increasing/.test(v.message))).toBe(true)
+    })
+
+    it('rejects a hashless chain entry', () => {
+      const state = { current: cursor(5), finalized: cursor(1), rollbackChain: [{ number: 3, hash: '' }] }
+
+      expect(validateWatermarks(state).some((v) => /carries no hash/.test(v.message))).toBe(true)
+    })
+
+    it('rejects data reaching above the cursor (INV-5)', () => {
+      const state = { current: cursor(5), finalized: cursor(1), rollbackChain: [] }
+
+      expect(validateWatermarks(state, { dataBound: 7 })[0].message).toMatch(/reaches 7, above the cursor 5/)
+    })
+  })
+
+  describe('combined run', () => {
+    it('reports nothing for a coherent observation', () => {
+      expect(
+        validateStructure({
+          rows: [{ block: 1 }, { block: 2 }],
+          batches: [{ cursorBefore: 0, blocks: [{ number: 1 }, { number: 2 }] }],
+          state: { current: cursor(2), finalized: cursor(1), rollbackChain: [cursor(2)] },
+          ranges: [{ from: 0, to: 10 }],
+          dataBound: 2,
+        }),
+      ).toEqual([])
+    })
+
+    it('accumulates violations across validators', () => {
+      const violations = validateStructure({
+        rows: [{ block: 3 }, { block: 2 }],
+        batches: [{ cursorBefore: 0, blocks: [{ number: 5 }] }],
+        ranges: [{ from: 0, to: 1 }],
+      })
+
+      expect(violations.map((v) => v.validator).sort()).toEqual(['in-range', 'in-range', 'linked', 'ordered'])
+    })
+
+    it('assertStructure lists every violation it found', () => {
+      expect(() => assertStructure({ rows: [{ block: 3 }, { block: 2 }], ranges: [{ from: 0, to: 1 }] })).toThrowError(
+        /3 structural violation\(s\)/,
+      )
+    })
+
+    it('assertStructure stays silent when nothing is broken', () => {
+      expect(() => assertStructure({ rows: [{ block: 1 }] })).not.toThrow()
+    })
+  })
+})

--- a/packages/pipes/src/testing/conformance/validators.ts
+++ b/packages/pipes/src/testing/conformance/validators.ts
@@ -1,0 +1,247 @@
+import type { Cursor, OracleState } from './reference-model.js'
+
+/** A structural rule broken by an emission or a persisted state. */
+export type Violation = {
+  /** Which validator fired. */
+  validator: string
+  /** The spec property it enforces. */
+  property: string
+  message: string
+}
+
+/** Anything attributed to a block — the only thing these validators know about a row. */
+export type Attributed = {
+  block: number
+}
+
+/** A published unit (a file, a partition) and the window it claims to cover. */
+export type PublishedUnit = {
+  name: string
+  from: number
+  to: number
+  rows: Attributed[]
+}
+
+/** One batch as delivered, with the cursor that preceded it. */
+export type DeliveredBatch = {
+  blocks: { number: number }[]
+  cursorBefore?: number
+}
+
+/**
+ * Kind-agnostic structural validators.
+ *
+ * They hold of any emission or state without domain knowledge, so they stay on for every scenario
+ * rather than being written per sink. Nothing here inspects row *content* — that is the oracle's
+ * job; these only check shape, ordering, attribution and watermark coherence.
+ */
+
+/** Decodable: every item parses per its format. */
+export function validateDecodable<T>(items: readonly T[], decode: (item: T) => unknown): Violation[] {
+  const violations: Violation[] = []
+
+  items.forEach((item, index) => {
+    try {
+      decode(item)
+    } catch (error) {
+      violations.push({
+        validator: 'decodable',
+        property: 'INV-5',
+        message: `item ${index} does not parse: ${error instanceof Error ? error.message : String(error)}`,
+      })
+    }
+  })
+
+  return violations
+}
+
+/** Ordered: attribution ascends. Duplicates are a violation — attribution is unique (INV-3). */
+export function validateOrdered(
+  rows: readonly Attributed[],
+  { strict = true }: { strict?: boolean } = {},
+): Violation[] {
+  const violations: Violation[] = []
+
+  for (let i = 1; i < rows.length; i++) {
+    const previous = rows[i - 1].block
+    const current = rows[i].block
+    if (strict ? current <= previous : current < previous) {
+      violations.push({
+        validator: 'ordered',
+        property: 'INV-20',
+        message: `attribution does not ascend at index ${i}: ${previous} → ${current}`,
+      })
+    }
+  }
+
+  return violations
+}
+
+/** Linked: each batch starts exactly one block above the cursor it was requested from. */
+export function validateLinked(batches: readonly DeliveredBatch[]): Violation[] {
+  const violations: Violation[] = []
+
+  batches.forEach((batch, index) => {
+    if (batch.cursorBefore === undefined || !batch.blocks.length) {
+      return
+    }
+
+    const expected = batch.cursorBefore + 1
+    if (batch.blocks[0].number !== expected) {
+      violations.push({
+        validator: 'linked',
+        property: 'INV-20',
+        message: `batch ${index} starts at ${batch.blocks[0].number}, expected ${expected}`,
+      })
+    }
+  })
+
+  return violations
+}
+
+/** Items-belong-to-parent: every row sits inside the window its unit claims. */
+export function validateItemsBelongToParent(units: readonly PublishedUnit[]): Violation[] {
+  const violations: Violation[] = []
+
+  for (const unit of units) {
+    for (const row of unit.rows) {
+      if (row.block < unit.from || row.block > unit.to) {
+        violations.push({
+          validator: 'items-belong-to-parent',
+          property: 'INV-3',
+          message: `unit '${unit.name}' claims [${unit.from}, ${unit.to}] but holds a row at ${row.block}`,
+        })
+      }
+    }
+  }
+
+  return violations
+}
+
+/** In-range: attribution falls inside a configured range. */
+export function validateInRange(
+  rows: readonly Attributed[],
+  ranges: readonly { from: number; to?: number }[],
+): Violation[] {
+  const violations: Violation[] = []
+  if (!ranges.length) {
+    return violations
+  }
+
+  for (const row of rows) {
+    const covered = ranges.some((r) => row.block >= r.from && (r.to === undefined || row.block <= r.to))
+    if (!covered) {
+      violations.push({
+        validator: 'in-range',
+        property: 'INV-3',
+        message: `row at block ${row.block} falls outside every configured range`,
+      })
+    }
+  }
+
+  return violations
+}
+
+/**
+ * Watermark coherence: the rollback chain sits strictly above the floor and at or below the
+ * cursor, and the cursor covers the committed data (INV-1, INV-5).
+ */
+export function validateWatermarks(state: OracleState, { dataBound }: { dataBound?: number } = {}): Violation[] {
+  const violations: Violation[] = []
+  const floor = state.finalized?.number
+  const cursor = state.current?.number
+
+  let previous = -Infinity
+  for (const entry of state.rollbackChain) {
+    if (entry.number <= previous) {
+      violations.push({
+        validator: 'watermark-coherence',
+        property: 'INV-1',
+        message: `rollback chain is not strictly increasing at ${entry.number}`,
+      })
+    }
+    if (!entry.hash) {
+      violations.push({
+        validator: 'watermark-coherence',
+        property: 'INV-1',
+        message: `rollback chain entry ${entry.number} carries no hash`,
+      })
+    }
+    if (floor !== undefined && entry.number <= floor) {
+      violations.push({
+        validator: 'watermark-coherence',
+        property: 'INV-1',
+        message: `rollback chain entry ${entry.number} is at or below the floor ${floor}`,
+      })
+    }
+    if (cursor !== undefined && entry.number > cursor) {
+      violations.push({
+        validator: 'watermark-coherence',
+        property: 'INV-1',
+        message: `rollback chain entry ${entry.number} is above the cursor ${cursor}`,
+      })
+    }
+    previous = entry.number
+  }
+
+  if (dataBound !== undefined && cursor !== undefined && dataBound > cursor) {
+    violations.push({
+      validator: 'watermark-coherence',
+      property: 'INV-5',
+      message: `committed data reaches ${dataBound}, above the cursor ${cursor}`,
+    })
+  }
+
+  return violations
+}
+
+export type StructuralInput = {
+  rows?: readonly Attributed[]
+  units?: readonly PublishedUnit[]
+  batches?: readonly DeliveredBatch[]
+  state?: OracleState
+  ranges?: readonly { from: number; to?: number }[]
+  /** Highest block the committed data reaches, when known. */
+  dataBound?: number
+}
+
+/** Runs every applicable validator over one observation. */
+export function validateStructure(input: StructuralInput): Violation[] {
+  const violations: Violation[] = []
+
+  if (input.rows) {
+    violations.push(...validateOrdered(input.rows))
+    if (input.ranges) {
+      violations.push(...validateInRange(input.rows, input.ranges))
+    }
+  }
+  if (input.units) {
+    violations.push(...validateItemsBelongToParent(input.units))
+  }
+  if (input.batches) {
+    violations.push(...validateLinked(input.batches))
+  }
+  if (input.state) {
+    violations.push(...validateWatermarks(input.state, { dataBound: input.dataBound }))
+  }
+
+  return violations
+}
+
+/** Throws with every violation listed, for use as a test assertion. */
+export function assertStructure(input: StructuralInput): void {
+  const violations = validateStructure(input)
+  if (!violations.length) {
+    return
+  }
+
+  throw new Error(
+    `${violations.length} structural violation(s):\n` +
+      violations.map((v) => `  [${v.validator} · ${v.property}] ${v.message}`).join('\n'),
+  )
+}
+
+/** Convenience for the common case of checking a cursor list is a well-formed chain. */
+export function isAscendingChain(cursors: readonly Cursor[]): boolean {
+  return cursors.every((c, i) => i === 0 || c.number > cursors[i - 1].number)
+}

--- a/packages/pipes/src/testing/portal-wire.ts
+++ b/packages/pipes/src/testing/portal-wire.ts
@@ -1,0 +1,108 @@
+import { Server, ServerResponse } from 'node:http'
+
+/** A point on a chain: the pair every wire surface identifies a block by. */
+export type BlockRef = {
+  number: number
+  hash: string
+}
+
+/** One block as it appears on the wire — a single NDJSON line of a 200 response (IB-5). */
+export type PortalBlockPayload = {
+  header: {
+    number: number
+    hash: string
+    timestamp?: number
+  }
+  logs?: any[]
+  instructions?: any[]
+  transactions?: any[]
+  inputs?: any[]
+  outputs?: any[]
+  internalTransactions?: any[]
+}
+
+/** Head report carried by every stream response (IB-6). */
+export type PortalHead = {
+  finalized?: BlockRef
+  latest?: { number: number }
+}
+
+/**
+ * A response reduced to what goes on the wire, with no notion of how it was chosen — the ordinal
+ * simulator picks it from a script, the ledger derives it from the request anchor, and both must
+ * be byte-indistinguishable to the SUT.
+ */
+export type WireResponse =
+  | { statusCode: 200; data: PortalBlockPayload[]; head?: PortalHead }
+  | { statusCode: 204; head?: PortalHead }
+  | { statusCode: 409; data: { previousBlocks: BlockRef[] } }
+  | { statusCode: 429 | 500 | 502 | 503 | 504; retryAfter?: number | string }
+
+/**
+ * Head headers per IB-6. `!= null` rather than truthiness: block 0 is a valid head, and dropping
+ * the header on it would hide finality entirely.
+ */
+export function headHeaders(head: PortalHead | undefined): Record<string, string | number> {
+  const headers: Record<string, string | number> = {}
+  if (!head) {
+    return headers
+  }
+
+  if (head.finalized?.number != null) {
+    headers['X-Sqd-Finalized-Head-Number'] = head.finalized.number
+  }
+  if (head.finalized?.hash != null) {
+    headers['X-Sqd-Finalized-Head-Hash'] = head.finalized.hash
+  }
+  if (head.latest?.number != null) {
+    headers['X-Sqd-Head-Number'] = head.latest.number
+  }
+
+  return headers
+}
+
+/**
+ * Writes `response` onto `res` per IB-4/IB-5/IB-6. Leaves the response open — the caller ends it,
+ * so a fault injector can truncate a stream mid-body.
+ */
+export function writeWireResponse(res: ServerResponse, response: WireResponse): void {
+  switch (response.statusCode) {
+    case 200:
+      res.writeHead(200, {
+        'Content-Type': 'application/jsonl',
+        ...headHeaders(response.head),
+      })
+      for (const block of response.data) {
+        res.write(JSON.stringify(block) + '\n')
+      }
+      break
+
+    case 409:
+      res.writeHead(409, { 'Content-Type': 'application/json' })
+      res.write(JSON.stringify(response.data))
+      break
+
+    case 204:
+      res.writeHead(204, headHeaders(response.head))
+      break
+
+    default: {
+      const headers: Record<string, string | number> = {}
+      if (response.retryAfter != null) {
+        headers['Retry-After'] = response.retryAfter
+      }
+      res.writeHead(response.statusCode, headers)
+      break
+    }
+  }
+}
+
+/** @internal */
+export function getServerAddress(server: Server): string {
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Invalid server address')
+  }
+
+  return `http://127.0.0.1:${address.port}`
+}

--- a/packages/pipes/src/testing/test-portal.ts
+++ b/packages/pipes/src/testing/test-portal.ts
@@ -2,6 +2,14 @@ import { IncomingMessage, Server, ServerResponse, createServer } from 'http'
 
 import { Portal } from '~/core/query-builder.js'
 
+import {
+  type BlockRef,
+  type PortalBlockPayload,
+  type PortalHead,
+  getServerAddress,
+  writeWireResponse,
+} from './portal-wire.js'
+
 type ValidateRequest = (res: any) => unknown
 
 export type MockResponse =
@@ -11,32 +19,14 @@ export type MockResponse =
     }
   | {
       statusCode: 200
-      data: {
-        header: {
-          number: number
-          hash: string
-          timestamp?: number
-        }
-        logs?: any[]
-        instructions?: any[]
-        transactions?: any[]
-        inputs?: any[]
-        outputs?: any[]
-        internalTransactions?: any[]
-      }[]
-      head?: {
-        finalized?: { number: number; hash: string }
-        latest?: { number: number }
-      }
+      data: PortalBlockPayload[]
+      head?: PortalHead
       validateRequest?: ValidateRequest
     }
   | {
       statusCode: 409
       data: {
-        previousBlocks: {
-          number: number
-          hash: string
-        }[]
+        previousBlocks: BlockRef[]
       }
       validateRequest?: ValidateRequest
     }
@@ -109,37 +99,7 @@ export async function mockPortal(
       req.on('end', () => {
         mockResp.validateRequest?.(body ? JSON.parse(body) : undefined)
 
-        switch (mockResp.statusCode) {
-          case 200:
-            const headers: Record<string, string | number> = {
-              'Content-Type': 'application/jsonl',
-            }
-            // `!= null`: block 0 is a valid head; dropping the header would hide finality entirely.
-            if (mockResp.head?.finalized?.number != null) {
-              headers['X-Sqd-Finalized-Head-Number'] = mockResp.head.finalized.number
-            }
-            if (mockResp.head?.finalized?.hash != null) {
-              headers['X-Sqd-Finalized-Head-Hash'] = mockResp.head.finalized.hash
-            }
-            if (mockResp.head?.latest?.number != null) {
-              headers['X-Sqd-Head-Number'] = mockResp.head.latest.number
-            }
-
-            res.writeHead(mockResp.statusCode, headers)
-            // Send each mock data item as a JSON line
-            mockResp.data.forEach((data) => {
-              res.write(JSON.stringify(data) + '\n')
-            })
-            break
-
-          case 409:
-            res.writeHead(mockResp.statusCode, { 'Content-Type': 'application/json' })
-            res.write(JSON.stringify(mockResp.data))
-            break
-          default:
-            res.writeHead(mockResp.statusCode)
-            break
-        }
+        writeWireResponse(res, mockResp)
 
         requestCount++
 
@@ -172,14 +132,6 @@ export async function mockPortal(
   }
 
   return portal
-}
-
-function getServerAddress(server: Server): string {
-  const address = server.address()
-  if (!address || typeof address === 'string') {
-    throw new Error('Invalid server address')
-  }
-  return `http://127.0.0.1:${address.port}`
 }
 
 /** @internal */

--- a/spec/13-conformance-tdd.md
+++ b/spec/13-conformance-tdd.md
@@ -1,8 +1,8 @@
 # 13 — Conformance & TDD (CT-n, GAP-n) — MUTABLE
 
-Last updated: 2026-07-19. Statuses reflect the actual TypeScript test inventory at
-commit `a739500` (this branch's mainline merge base; commits above it are docs-only),
-not aspiration.
+Last updated: 2026-07-20. Statuses reflect the actual TypeScript test inventory, not
+aspiration: the baseline was taken at commit `a739500`, and Phase 0 has since landed the
+conformance harness under `packages/pipes/src/testing/conformance/`.
 
 ## Harness architecture
 
@@ -24,9 +24,13 @@ not aspiration.
    fault injectors ── portal faults (FM-10…FM-19), store faults (FM-20…FM-27), kill-points (FM-30…FM-34)
 ```
 
-*Simulator status:* the reference implementation covers the wire surface and the
-per-request assertion, but selects responses by request ordinal rather than from a
-ledger — the Phase-0 delta.
+*Simulator status:* ledger mode has landed (`testing/conformance/chain-ledger.ts`,
+`ledger-portal.ts`). Responses are derived from the request anchor (IB-3) against a held
+chain, 409s are synthesised from the chain's own fork history rather than scripted, and
+every request is retained in a log so post-restart behaviour is assertable. The ordinal
+simulator (`testing/test-portal.ts`) is unchanged and still serves its ~90 call sites;
+both write their responses through one shared wire layer (`testing/portal-wire.ts`), so
+the two modes cannot drift apart on the wire.
 
 **Quiescence** (comparison point): simulator drained, SUT idle-at-head (OB-2 idle), no
 retry signal active, sink store stable for one poll interval. All oracle/SUT diffs are
@@ -106,7 +110,7 @@ format) · ordered (ascending attribution) · linked (batch first = cursor+1) ·
 items-belong-to-parent (rows within their unit's window) · in-range (attribution within
 configured ranges) · watermark coherence (RC above F; C consistent with data bound).
 
-## Traceability matrix (2026-07-18)
+## Traceability matrix (2026-07-20)
 
 Status: **C** covered · **P** partial · **U** unchecked. Suffix ⚠ = known-violated or
 known-suspect in the current implementation (see gap register).
@@ -116,7 +120,7 @@ known-suspect in the current implementation (see gap register).
 | WP-1, WP-2 (resume, floor seed) | CT-1/2 | C | portal-source + watermark tests |
 | WP-3 (id validation) | CT-1 | P ⚠ | rejects, but uncoded (GAP-4) |
 | WP-4 (range resolution) | CT-1 | C | range-algebra + builder tests |
-| WP-5/CN-40…CN-44 recovery-before-write | CT-2 | P ⚠ | class K covered; T/W/A unchecked (GAP-14); orphan guard W-only and table-wide rather than key-scoped (GAP-20) |
+| WP-5/CN-40…CN-44 recovery-before-write | CT-2 | P ⚠ | class K kill-point matrix complete (CT-2); T/W/A unchecked (GAP-14); no over-cursor sweep when no cursor was ever persisted (GAP-36); orphan guard W-only and table-wide rather than key-scoped (GAP-20) |
 | WP-10, WP-15, INV-20 (ordering) | CT-1 | P | buffer/split unit tests; no adversarial simulator (GAP-29) |
 | WP-11, HZ-1 (assembly bounds) | CT-1 | C | stream-buffer tests |
 | WP-12 (backpressure) | CT-1/6 | P | unit-level only; no end-to-end saturation test |
@@ -139,7 +143,7 @@ known-suspect in the current implementation (see gap register).
 | RP-43 (contract guard) | CT-3 | P ⚠ | one binding only (GAP-9) |
 | CN-10 T atomicity | CT-2 | P ⚠ | live tx tests; kill-points U (GAP-14) |
 | CN-11 W protocol | CT-2 | P | unit/lifecycle C; integration gated off CI |
-| CN-12 K protocol | CT-2 | P ⚠ | crash-safety + recovery suites; straddle refusal absent (GAP-17) |
+| CN-12 K protocol | CT-2 | C ⚠ | kill-point matrix at every protocol step, each recovering onto the oracle; straddle refusal absent (GAP-17); first-checkpoint crash window open (GAP-36) |
 | CN-13 A protocol | CT-2 | U ⚠ | crash window untested (GAP-3) |
 | CN-34 (fork commit point) | CT-2 | U ⚠ | crash-during-fork untested; class A persists nothing at fork (GAP-21) |
 | CN-45 (cross-impl, clock indep.) | CT-5 | U ⚠ | single implementation; clock ordering in two bindings (GAP-10); cache codec undiscriminated (GAP-27) |
@@ -147,7 +151,7 @@ known-suspect in the current implementation (see gap register).
 | INV-13, INV-14 (fork safety) | CT-3 | C | at batch boundaries; mid-flush U |
 | INV-15, INV-35, LIV-10 (isolation) | CT-8 | U | no co-resident/dual-instance tests |
 | INV-21, INV-23 (fidelity, selection) | CT-5 | C | validator fixtures incl. chain edge shapes |
-| INV-22 (determinism) | CT-1 | U | no dual-run diff harness |
+| INV-22 (determinism) | CT-1 | P | dual-run diff green on S1 (CT-1); other scenarios U |
 | INV-30…INV-32 (reporting) | CT-1/4 | P ⚠ | metric registration tested; honesty cross-check U; six OB signals unimplemented (GAP-28) |
 | INV-36 (cache) | CT-5 | C | keying/gap/latest-exclusion tests |
 | PF-6, WP-12 (ingest overlap) | CT-6 | P | slot semantics unit-tested; no cadence benchmark |
@@ -156,7 +160,7 @@ known-suspect in the current implementation (see gap register).
 | RS-20…RS-25 (cache) | CT-5 | C | except overlap re-insert (U) |
 | FM corpus | CT-4 | P | scattered unit coverage; no systematic corpus |
 | SLI/PF | CT-6 | U | no benchmarks recorded |
-| IB-1…IB-9 wire | CT-5 | P | client-side tested; no golden wire fixtures |
+| IB-1…IB-9 wire | CT-5 | P | client-side tested; ledger mode asserts anchor advance (IB-3) and synthesises 409s (IB-4) per request; no golden wire fixtures |
 | IB-20…IB-26 formats | CT-5 | P ⚠ | per-binding tests; no round-trip corpus; timestamp units per-network (GAP-24) |
 | IB-40…IB-46 observability | CT-5 | U ⚠ | consumed by dashboard, no golden scrapes (GAP-16) |
 | IB-50…IB-52 error registry | CT-5 | U ⚠ | no registry-sync test (GAP-13) |
@@ -181,7 +185,7 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
 | GAP-11 | Confirmed: the resume parent-hash anchor is sent for every configured range, including later disjoint ranges where it is not the range predecessor — a resumed multi-range run gets a spurious 409/fork on the later range | WP-1, IB-3 | P1 | two disjoint ranges + resume; simulator asserts anchor semantics per request |
 | GAP-12 | Class-W binding assumes single-writer (client-assigned monotonic timestamps) with no lock and no detection; dual instance corrupts undetected | INV-15 (declaration) | P3 | document in IB-24; optional fencing probe |
 | GAP-13 | No automated sync between thrown error codes and the registry; the "all codes cross-checked" claim is manual | REQ-13, IB-50 | P3 | enumerate codes from source; diff against IB-50 table |
-| GAP-14 | Crash-recovery kill-point coverage exists only for class K; classes T/W/A have no kill-point tests | INV-40…INV-42 | P1 | Phase-0 ledger mode first (an ordinal script cannot answer the post-restart re-request), then the kill-point harness at the T transaction boundary |
+| GAP-14 | Classes T/W/A have no kill-point tests. Class K's matrix is now complete (CT-2 suite: mid-unit-write, publish-before-cursor, mid-rename, post-state, over-cursor sweep) and runs against ledger mode, so the post-restart re-request is asserted rather than hand-padded | INV-40…INV-42 | P1 | remaining: the kill-point harness at the T transaction boundary, then W and A |
 | GAP-15 | Indistinguishable-output collision (duplicate event signature) only logs in the evm module and is entirely undetected in solana; later outputs silently miss records | WP-24 | P2 | two outputs, same signature → startup diagnostic asserted fatal (pending OQ-6) |
 | GAP-16 | Observability payloads are consumed by the dashboard but have no golden fixtures; shapes drift silently (a version-drift accommodation already exists in the dashboard) | IB-40…IB-46 | P3 | golden scrape of /stats, /metrics, preview against a scripted run |
 | GAP-17 | The coverage-window model — coverage-based file naming, the `coverage` state map, straddle refusal, empty-unit publication, codes E2316/E2317 — is spec'd but unimplemented on mainline: files are named by row min/max, straddling files are deleted on recovery, empty tables produce no files | IB-22, RP-21, RP-22, INV-4, CN-12 | P1 | land the coverage PR, then sparse/trailing/gap/disjoint suites against it |
@@ -200,27 +204,32 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
 | GAP-32 | Dev-runner coerces `retry: 0` to the default 5 via a falsy-default — fail-fast intent silently ignored (open fix PR #70) | FM-40 | P3 | retry: 0 → assert a single attempt |
 | GAP-33 | Profiling-surface defects: batch spans leak on empty batches and stream end (open fix PR #71); transformer-id dedup collides for 3+ same-id transformers (open fix PR #73) | OB-22 | P3 | span onStart count = onEnd count across empty batches; three same-id transformers get distinct ids |
 | GAP-34 | Observability-server hygiene: CORS accepts any origin containing "localhost" as a substring (and rejects 127.0.0.1); stop() clears the global metrics registry; /profiler hardcodes `enabled: true` | IB-40, IB-43 | P3 | origin `http://localhost.evil.com` → assert rejected |
+| GAP-36 | Class-K recovery skips the over-cursor sweep entirely when no cursor was ever persisted: `ParquetState.getCursor` returns as soon as the state file is absent, before `#deleteFilesAboveCursor` runs. A crash between the first publish and the first cursor write therefore leaves an orphaned unit that no cursor covers, and the restart meets its own orphan — surfacing either as a permanent E2309 refusal or as silently duplicated rows, depending on batch partitioning (a declared free variable; both outcomes observed on the same scenario). Deleting unconditionally is *not* the fix: data files carry no pipe-id namespace (GAP-35) so the sink cannot tell its own remnant from a co-resident pipe's or an operator's data — the orphan-data guard question of GAP-20/ADR-16 | CN-12, RS-10, INV-42 | P1 | found by the Phase-0 class-K matrix; decide the guard with GAP-20, then assert recovery converges on the oracle instead of the current characterisation test |
+| GAP-37 | The reference-model pseudocode in this document collapses WP-42's search over persisted rollback *records* into a single current `RC`, diverging from WP-42's normative text and from `resolveForkCursor`. Under the collapsed model WP-44's finality conflict is unreachable, since INV-1 keeps every entry of one chain strictly above that chain's floor; it is reachable only from a record whose chain dips below its own floor, i.e. already-corrupt state. `fork.test.ts` "should return null when deep fork goes below finalized" does not cover the branch it names — `resolveForkCursor` returns `null` for both the finality-conflict and the no-ancestor paths, so the assertion cannot tell them apart | WP-42, WP-44, GAP-6 | P2 | fix the pseudocode to walk records; add a test distinguishing the two null outcomes (a coded error would make them distinguishable — ties into GAP-6) |
 | GAP-35 | Parquet data files are named by block window with no pipe-id namespacing while the state sidecar is namespaced (`_sqd_parquet_state.<id>.json`): two pipes covering overlapping ranges in one directory collide on filename and the second fails E2309 — sharing a directory is refused by accident of naming rather than declared policy, and coverage-window naming (GAP-17) collides identically | IB-22, IB-27, INV-35 | P2 | two pipe ids, one directory, overlapping ranges → assert the declared outcome (namespaced files or a coded exclusivity refusal), not a publish collision |
 
 ## Build order
 
-- **Phase 0 — harness skeleton**: the reference implementation already serves the
-  simulator's wire surface from an HTTP fixture (200 NDJSON · 204 · 409 with canonical
-  chain · 5xx · head headers, IB-4/IB-5) with a per-request assertion hook — sufficient
-  as-is for request-shape work (GAP-2, GAP-11). The Phase-0 delta is **ledger mode**:
-  derive responses from the request anchor (IB-3) against a held chain instead of
-  selecting them by request ordinal. An ordinal script has no answer for the re-request
-  a restarted SUT issues from its recovered cursor, so this gates the entire CT-2
-  matrix; it is also what adversarial histories require (over-return for INV-24,
-  duplicate/out-of-order for GAP-29, head regressions). Then, all new: reference model
-  (oracle), structural validators, sink store probes, and kill-point injection for one
-  class (K — cheapest, file-based; the only crash imitation today is a pre-commit
-  abort, one point of the CT-2 matrix). Exit: CT-1 green on the reference
-  implementation for S1, ledger mode answering post-restart re-requests.
+- **Phase 0 — harness skeleton** — **done (2026-07-20)**. Landed under
+  `packages/pipes/src/testing/conformance/`: ledger mode (anchor-derived responses,
+  synthesised 409s, retained request log, adversarial knobs for over-return and
+  duplicate/out-of-order), the reference model, the kind-agnostic structural validators,
+  the sink store probe interface with its class-K implementation, and kill-point
+  injection. Exit met: CT-1 green on S1 (commit diff vs oracle, hold-back, validators,
+  batch well-formedness, anchor advance, dual-run determinism, frame condition) and
+  ledger mode answering post-restart re-requests, asserted directly in CT-2.
+  Kill-points are injected by obstructing the filesystem rather than by mocking it —
+  this project runs every suite in one fork with `isolate: false`, so a module another
+  file already imported never sees a `node:fs/promises` mock. The trade-off is that the
+  process is not truly dead and unwinding still runs; what is reproduced faithfully is
+  the on-disk state at the moment the run stops, which is what recovery must reconcile.
+  A true-kill injector (child process per run) is the upgrade path if a future matrix
+  point turns on post-crash cleanup behaviour.
 - **Phase 1 — P1 gaps**: GAP-1 (needs ADR-12 decision), GAP-2, GAP-3 (needs ADR-15),
-  GAP-11 (range anchors), GAP-17 (land the coverage PR),
-  GAP-14 kill-point harness for class T. Exit: register updated, fixes landed or
-  accepted as documented deviations.
+  GAP-11 (range anchors — ledger mode now makes the per-range anchor assertable),
+  GAP-17 (land the coverage PR), GAP-36 (decide the class-K orphan guard alongside
+  GAP-20), GAP-14 kill-point harness for class T. Exit: register updated, fixes landed
+  or accepted as documented deviations.
 - **Phase 2 — correctness core**: full CT-2 matrix all classes; CT-3 fork suite; CT-5
   format round-trips (this unblocks the second-language implementation). Exit: matrix
   rows for INV/CN/WP ≥ P everywhere, C on the fork/recovery core.


### PR DESCRIPTION
## Summary

- Lands the Phase-0 conformance harness from `spec/13` under `packages/pipes/src/testing/conformance/`: **ledger mode**, the reference model (oracle), the kind-agnostic structural validators, the sink store probe interface with its class-K implementation, and kill-point injection.
- Ledger mode replaces ordinal response selection with selection derived from the request anchor (IB-3). The old simulator handed out the *next scripted response* regardless of what was asked, so it had no answer for the re-request a restarted pipe issues from its recovered cursor — crash tests had to hand-pad their scripts (`clickhouse-target.test.ts:828`) and none could assert what the pipe asked for on the way back. Anchor-derived selection makes that re-request answerable by construction, which is what gates CT-2.
- Completes the class-K kill-point matrix (GAP-14 for K; T/W/A remain Phase 1) and lands CT-1 green on scenario S1 — the declared Phase-0 exit criteria.

The existing ordinal simulator is untouched and still serves its ~90 call sites. Both modes write through one shared wire layer (`portal-wire.ts`), so they cannot drift apart on the wire; `test-portal.ts` gets 39 lines shorter as a result. **No production code is modified.**

## Findings

Two gaps were found by running the new matrix, both recorded in `spec/13` rather than fixed here:

**GAP-36 (P1, production defect).** `ParquetState.getCursor()` returns at `if (!state) return undefined` *before* `#deleteFilesAboveCursor` runs. A crash between the first publish and the first cursor write therefore leaves a published unit that no cursor covers. On restart the pipe meets its own orphan and either refuses permanently with `E2309` or **silently duplicates rows** — both outcomes observed on the same scenario, differing only by batch partitioning, which the spec declares a free variable.

Deliberately not fixed: deleting unconditionally would destroy a co-resident pipe's or an operator's data, since data files carry no pipe-id namespace (GAP-35). That is the orphan-data guard question of GAP-20/ADR-16 and belongs to the team. The test asserts the deterministic root cause (the orphan survives recovery) rather than the partitioning-dependent symptom.

**GAP-37 (P2, spec defect).** The reference-model pseudocode in `spec/13` collapses WP-42's search over persisted rollback *records* into a single current `RC`, diverging from WP-42's normative text and from `resolveForkCursor`. Under the collapsed model WP-44's finality conflict is unreachable, since INV-1 keeps every entry of one chain strictly above that chain's floor. Related: `fork.test.ts` "should return null when deep fork goes below finalized" does not cover the branch it names — `resolveForkCursor` returns `null` for both the finality-conflict and no-ancestor paths, so the assertion cannot distinguish them. The oracle follows WP-42.

## Deviation from the spec's plan

Kill-points are injected by obstructing the filesystem, not by mocking `node:fs/promises`. This project runs every suite in one fork with `isolate: false`, so a module another test file has already imported keeps its real binding and never sees the mock (`vi.resetModules()` does not help — builtins are not re-instantiated).

Honest cost: the process is not truly dead, so unwinding still runs. What is reproduced faithfully is the on-disk state at the moment the run stops, which is what recovery has to reconcile. A true-kill injector (child process per run) is the documented upgrade path. Class T will not need it — severing the connection mid-transaction is a faithful crash for Postgres.

## Coverage

| Module | Stmts | Δ | Branch | Δ |
|--------|-------|---|--------|---|
| **All files** | 85.5% | +0.1 | 86.3% | +0.3 |
| src/targets/parquet | 97.4% | +0.0 | 91.7% | +0.8 |
| src/testing | 89.0% | +0.0 | 84.4% | -0.3 |
| src/testing/conformance | 87.3% | +87.3 | 87.6% | +87.6 |

## Test plan

- [x] 83 new tests; full suite 713 passed / 0 failed
- [x] CT-1 on S1: commit diff vs oracle, hold-back above the floor, structural validators at quiescence, batch well-formedness, anchor advance, dual-run determinism (INV-22), frame condition (INV-10)
- [x] CT-2 class-K matrix: mid-unit-write, publish-before-first-cursor (GAP-36), mid-rename across two tables, post-state, over-cursor sweep, post-restart re-request anchor, no leaked temp files
- [x] Oracle: T-BATCH / T-FORK / T-INIT transitions, hold-back per durability class, WP-41/WP-42/WP-44/RP-43 refusals
- [x] Wire refactor verified by the 40 pre-existing tests that exercise the ordinal simulator
- [x] `spec/check-spec.mjs`: 0 dangling references, 0 broken links
- [x] `tsc --noEmit` and `biome check` clean
- [ ] Not run: ClickHouse integration tests — port 10123 was held by an unrelated container with different credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)
