### PR TITLE
fix(decoder): unify decode-error hook policy across evm and solana

### DIFF
--- a/packages/pipes/src/core/decode-error.test.ts
+++ b/packages/pipes/src/core/decode-error.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultDecodeError, recordSuppressedDecode } from '~/core/decode-error.js'
+import { BatchContext } from '~/core/portal-source.js'
+import { mockMetricsServer } from '~/testing/index.js'
+
+function ctxWith(id: string) {
+  const metrics = mockMetricsServer()
+  const ctx = { id, metrics: metrics.server.metrics } as unknown as BatchContext
+
+  return { ctx, metrics }
+}
+
+describe('defaultDecodeError', () => {
+  it('re-throws the error it receives', () => {
+    const { ctx } = ctxWith('pipe-1')
+    const error = new Error('boom')
+
+    expect(() => defaultDecodeError(ctx, error)).toThrow(error)
+  })
+})
+
+describe('recordSuppressedDecode', () => {
+  it('increments sqd_decode_errors_skipped_total labelled by pipe id', () => {
+    const { ctx, metrics } = ctxWith('pipe-1')
+
+    recordSuppressedDecode(ctx)
+    recordSuppressedDecode(ctx)
+
+    const skipped = metrics.counter('sqd_decode_errors_skipped_total')
+    expect(skipped.total).toBe(2)
+    expect(skipped.calls.every((c) => c.value === 1)).toBe(true)
+    expect(skipped.calls[0].labels).toEqual({ id: 'pipe-1' })
+  })
+})

--- a/packages/pipes/src/core/decode-error.ts
+++ b/packages/pipes/src/core/decode-error.ts
@@ -1,0 +1,24 @@
+import type { BatchContext } from './portal-source.js'
+
+/**
+ * Decode-error hook contract shared by every network decoder (ADR-12).
+ *
+ * One uniform policy: a decode failure is fatal by default, but a hook that
+ * returns without throwing suppresses the offending record. Suppressions are
+ * counted (INV-31) so a dropped record never vanishes silently.
+ */
+export type DecodeErrorHook = (ctx: BatchContext, error: any) => unknown | Promise<unknown>
+
+export const defaultDecodeError: DecodeErrorHook = (ctx, error) => {
+  throw error
+}
+
+export function recordSuppressedDecode(ctx: BatchContext) {
+  ctx.metrics
+    .counter({
+      name: 'sqd_decode_errors_skipped_total',
+      help: 'Records dropped by a returning (non-throwing) onError decode hook',
+      labelNames: ['id'] as const,
+    })
+    .inc({ id: ctx.id }, 1)
+}

--- a/packages/pipes/src/core/index.ts
+++ b/packages/pipes/src/core/index.ts
@@ -1,4 +1,5 @@
 export * from './cursor-key.js'
+export * from './decode-error.js'
 export * from './errors.js'
 export * from './finalization-buffer.js'
 // Only `normalizeFinalized` is consumed across module boundaries (the target state classes). The

--- a/packages/pipes/src/evm/evm-decoder.test.ts
+++ b/packages/pipes/src/evm/evm-decoder.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'v
 
 import { PortalRange, QueryAwareTransformer } from '~/core/index.js'
 import { encodeEvent, mockBlock, mockEvmPortalStream, resetMockBlockCounter } from '~/testing/evm/index.js'
-import { MockPortal, MockResponse, mockPortal, readAll, testLogger } from '~/testing/index.js'
+import { MockPortal, MockResponse, mockMetricsServer, mockPortal, readAll, testLogger } from '~/testing/index.js'
 
 import { commonAbis } from './abi/common.js'
 import {
@@ -1260,5 +1260,272 @@ describe('evmEventDecoder multi-output isolation', () => {
     expect(decoderB).toHaveLength(1)
     expect(decoderB[0].contract).toBe(CONTRACT_B)
     expect(decoderB[0].event.value).toBe(200n)
+  })
+})
+
+describe('evmEventDecoder decode errors', () => {
+  const CONTRACT = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+  const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+  const FROM = '0x0000000000000000000000007a250d5630b4cf539739df2c5dacb4c659f2488d'
+  const TO = '0x000000000000000000000000c82e11e709deb68f3631fc165ebd8b4e3fc3d18f'
+
+  let portal: MockPortal
+
+  beforeEach(async () => {
+    // A decodable Transfer followed by one that passes topic routing but has empty
+    // data — `value` (uint256) cannot be read, so `decode` throws.
+    portal = await mockPortal([
+      {
+        statusCode: 200,
+        data: [
+          {
+            header: { number: 1, hash: '0x1', timestamp: 2000 },
+            logs: [
+              {
+                address: CONTRACT,
+                topics: [TRANSFER_TOPIC, FROM, TO],
+                logIndex: 0,
+                transactionIndex: 0,
+                transactionHash: '0xdeadbeef',
+                data: '0x000000000000000000000000000000000000000000000000013737bc62530000',
+              },
+              {
+                address: CONTRACT,
+                topics: [TRANSFER_TOPIC, FROM, TO],
+                logIndex: 1,
+                transactionIndex: 1,
+                transactionHash: '0xdeadbeef',
+                data: '0x',
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  afterEach(async () => {
+    await portal?.close()
+  })
+
+  function stream(metrics: ReturnType<typeof mockMetricsServer>, onError?: (ctx: any, error: any) => unknown) {
+    return evmPortalStream({
+      id: 'test',
+      portal: portal.url,
+      logger: false,
+      metrics: metrics.server,
+      outputs: evmEventDecoder({
+        range: { from: 0, to: 1 },
+        events: { transfers: commonAbis.erc20.events.Transfer },
+        onError,
+      }).pipe((e) => e.transfers),
+    })
+  }
+
+  it('is fatal by default — no hook re-throws the decode error', async () => {
+    const metrics = mockMetricsServer()
+
+    await expect(readAll(stream(metrics))).rejects.toThrow(/decod/i)
+    expect(metrics.counter('sqd_decode_errors_skipped_total')).toBeUndefined()
+  })
+
+  it('a returning hook suppresses the record and counts the skip', async () => {
+    const metrics = mockMetricsServer()
+    const seen: any[] = []
+
+    const res = await readAll(stream(metrics, (_ctx, error) => seen.push(error)))
+
+    expect(res).toHaveLength(1)
+    expect(res[0].event.value).toBe(87600000000000000n)
+    expect(seen).toHaveLength(1)
+
+    const skipped = metrics.counter('sqd_decode_errors_skipped_total')
+    expect(skipped.total).toBe(1)
+    expect(skipped.calls[0].labels).toEqual({ id: 'test' })
+  })
+
+  it('a re-throwing hook stays fatal and records no skip', async () => {
+    const metrics = mockMetricsServer()
+
+    await expect(
+      readAll(
+        stream(metrics, (_ctx, error) => {
+          throw error
+        }),
+      ),
+    ).rejects.toThrow(/decod/i)
+    expect(metrics.counter('sqd_decode_errors_skipped_total')).toBeUndefined()
+  })
+})
+
+describe('evmEventDecoder factory decode errors', () => {
+  const UNISWAP_FACTORY = '0x1f98431c8ad98523631ae4a59f267346ea31f984'
+  const POOL = '0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8'
+  const WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
+  const USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+  const SENDER = '0xdef1cafe0000000000000000000000000000dead'
+  const RECIPIENT = '0xbeef0000000000000000000000000000deadbeef'
+
+  const POOL_CREATED_ABI = [
+    {
+      type: 'event' as const,
+      name: 'PoolCreated',
+      inputs: [
+        { name: 'token0', type: 'address', indexed: true },
+        { name: 'token1', type: 'address', indexed: true },
+        { name: 'fee', type: 'uint24', indexed: true },
+        { name: 'tickSpacing', type: 'int24', indexed: false },
+        { name: 'pool', type: 'address', indexed: false },
+      ],
+    },
+  ] as const
+
+  const SWAP_ABI = [
+    {
+      type: 'event' as const,
+      name: 'Swap',
+      inputs: [
+        { name: 'sender', type: 'address', indexed: true },
+        { name: 'recipient', type: 'address', indexed: true },
+        { name: 'amount0', type: 'int256', indexed: false },
+        { name: 'amount1', type: 'int256', indexed: false },
+        { name: 'sqrtPriceX96', type: 'uint160', indexed: false },
+        { name: 'liquidity', type: 'uint128', indexed: false },
+        { name: 'tick', type: 'int24', indexed: false },
+      ],
+    },
+  ] as const
+
+  const factoryPoolCreated = event(
+    '0x783cca1c0412dd0d695e784568c96da2e9c22ff989357a2e8b1d9b2b4e6b7118',
+    'PoolCreated(address,address,uint24,int24,address)',
+    {
+      token0: indexed(p.address),
+      token1: indexed(p.address),
+      fee: indexed(p.uint24),
+      tickSpacing: p.int24,
+      pool: p.address,
+    },
+  )
+
+  const poolSwap = event(
+    '0xc42079f94a6350d7e6235f29174924f928cc2ac818eb64fed8004e115fbcca67',
+    'Swap(address,address,int256,int256,uint160,uint128,int24)',
+    {
+      sender: indexed(p.address),
+      recipient: indexed(p.address),
+      amount0: p.int256,
+      amount1: p.int256,
+      sqrtPriceX96: p.uint160,
+      liquidity: p.uint128,
+      tick: p.int24,
+    },
+  )
+
+  function encodePoolCreated(pool: string) {
+    return encodeEvent({
+      abi: POOL_CREATED_ABI,
+      eventName: 'PoolCreated',
+      address: UNISWAP_FACTORY,
+      args: { token0: WETH, token1: USDC, fee: 3000, tickSpacing: 10, pool: pool as `0x${string}` },
+    })
+  }
+
+  function encodeSwap(address: string) {
+    return encodeEvent({
+      abi: SWAP_ABI,
+      eventName: 'Swap',
+      address: address as `0x${string}`,
+      args: {
+        sender: SENDER,
+        recipient: RECIPIENT,
+        amount0: 1n,
+        amount1: 2n,
+        sqrtPriceX96: 3n,
+        liquidity: 4n,
+        tick: 5,
+      },
+    })
+  }
+
+  let portal: MockPortal
+
+  beforeEach(async () => {
+    resetMockBlockCounter()
+
+    // A decodable PoolCreated (registers the child pool) followed by one that keeps the
+    // PoolCreated topics — so `isFactoryEvent` routes it — but carries empty data, so the
+    // factory `decode` throws. A sibling Swap from the registered pool must still survive.
+    portal = await mockEvmPortalStream({
+      blocks: [
+        mockBlock({
+          number: 1,
+          transactions: [
+            { logs: [encodePoolCreated(POOL), { ...encodePoolCreated(POOL), data: '0x' }, encodeSwap(POOL)] },
+          ],
+        }),
+      ],
+    })
+  })
+
+  afterEach(async () => {
+    await portal?.close()
+  })
+
+  function stream(metrics: ReturnType<typeof mockMetricsServer>, onError?: (ctx: any, error: any) => unknown) {
+    const poolFactory = contractFactory({
+      address: UNISWAP_FACTORY,
+      event: factoryPoolCreated,
+      childAddressField: 'pool',
+      database: contractFactorySqliteStore({ path: ':memory:' }),
+    })
+
+    return evmPortalStream({
+      id: 'test',
+      portal: portal.url,
+      logger: false,
+      metrics: metrics.server,
+      outputs: evmEventDecoder({
+        range: { from: 0, to: 1 },
+        contracts: poolFactory,
+        events: { swaps: poolSwap },
+        onError,
+      }).pipe((e) => e.swaps),
+    })
+  }
+
+  it('is fatal by default — a malformed factory event re-throws', async () => {
+    const metrics = mockMetricsServer()
+
+    await expect(readAll(stream(metrics))).rejects.toThrow(/decod/i)
+    expect(metrics.counter('sqd_decode_errors_skipped_total')).toBeUndefined()
+  })
+
+  it('a returning hook suppresses the factory event and keeps decoding siblings', async () => {
+    const metrics = mockMetricsServer()
+    const seen: any[] = []
+
+    const res = await readAll(stream(metrics, (_ctx, error) => seen.push(error)))
+
+    expect(res).toHaveLength(1)
+    expect(res[0].contract).toBe(POOL)
+    expect(seen).toHaveLength(1)
+
+    const skipped = metrics.counter('sqd_decode_errors_skipped_total')
+    expect(skipped.total).toBe(1)
+    expect(skipped.calls[0].labels).toEqual({ id: 'test' })
+  })
+
+  it('a re-throwing hook stays fatal and records no skip', async () => {
+    const metrics = mockMetricsServer()
+
+    await expect(
+      readAll(
+        stream(metrics, (_ctx, error) => {
+          throw error
+        }),
+      ),
+    ).rejects.toThrow(/decod/i)
+    expect(metrics.counter('sqd_decode_errors_skipped_total')).toBeUndefined()
   })
 })

--- a/packages/pipes/src/evm/evm-decoder.ts
+++ b/packages/pipes/src/evm/evm-decoder.ts
@@ -2,12 +2,14 @@ import type { AbiEvent, EventParams } from '@subsquid/evm-abi'
 import { Codec, Sink } from '@subsquid/evm-codec'
 
 import {
-  BatchContext,
+  DecodeErrorHook,
   PortalRange,
   ProfilerOptions,
   Transformer,
+  defaultDecodeError,
   formatWarning,
   parsePortalRange,
+  recordSuppressedDecode,
 } from '~/core/index.js'
 import { arrayify, findDuplicates } from '~/internal/array.js'
 import { Log, LogRequest } from '~/portal-client/query/evm.js'
@@ -131,7 +133,7 @@ export type DecodedEventPipeArgs<T extends Events, C extends Contracts> = {
   contracts?: C
   events: EventsMap<T>
   profiler?: ProfilerOptions
-  onError?: (ctx: BatchContext, error: any) => unknown | Promise<unknown>
+  onError?: DecodeErrorHook
 }
 
 const decodedEventFields = {
@@ -295,7 +297,7 @@ function getDuplicateEvents<T extends Events>(events: T, duplicates: string[]) {
  *   - An {@link AbiEvent} instance to capture all instances of that event
  *   - An {@link EventWithArgs} object with `event` and `params` to filter by indexed parameters
  * @param args.profiler - Optional {@link ProfilerOptions} configuration for performance monitoring
- * @param args.onError - Optional error handler callback that receives {@link BatchContext} and error
+ * @param args.onError - Optional {@link DecodeErrorHook}; returning without throwing suppresses the record (counted in `sqd_decode_errors_skipped_total`)
  * @returns A {@link Transformer} that processes EVM portal data and returns {@link EventResponse} with decoded events
  *
  * @example
@@ -324,9 +326,10 @@ export function evmEventDecoder<T extends Events, C extends Contracts>({
   contracts,
   events,
   profiler,
-  onError,
+  onError: onErrorHook,
 }: DecodedEventPipeArgs<T, C>) {
   const decodedRange = parsePortalRange(range)
+  const onError = onErrorHook || defaultDecodeError
   const normalizedEvents = getNormalizedEvents(events)
   const { eventsWithParams, eventsWithoutParams } = splitEvents(normalizedEvents)
   const eventTopic0 = eventsWithoutParams.map((event) => event.event.topic)
@@ -386,7 +389,12 @@ export function evmEventDecoder<T extends Events, C extends Contracts>({
             if (!block.logs) continue
             for (const log of block.logs) {
               if (Factory.isFactory(contracts) && contracts.isFactoryEvent(log)) {
-                contracts.decode(log, block.header.number)
+                try {
+                  await contracts.decode(log, block.header.number)
+                } catch (error) {
+                  await onError(ctx, error)
+                  recordSuppressedDecode(ctx)
+                }
               }
             }
           }
@@ -446,11 +454,8 @@ export function evmEventDecoder<T extends Events, C extends Contracts>({
                   timestamp: new Date(block.header.timestamp * 1000),
                 })
               } catch (error) {
-                if (onError) {
-                  await onError(ctx, error)
-                }
-
-                throw error
+                await onError(ctx, error)
+                recordSuppressedDecode(ctx)
               }
               break
             }

--- a/packages/pipes/src/solana/solana-instruction-decoder.test.ts
+++ b/packages/pipes/src/solana/solana-instruction-decoder.test.ts
@@ -1,8 +1,8 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { solanaInstructionDecoder } from '~/solana/solana-instruction-decoder.js'
 import { solanaPortalStream } from '~/solana/solana-portal-source.js'
-import { MockPortal, MockResponse, mockPortal, readAll } from '~/testing/index.js'
+import { MockPortal, MockResponse, mockMetricsServer, mockPortal, readAll } from '~/testing/index.js'
 
 import * as tokenProgram from './abi/tokenProgram/index.js'
 
@@ -102,5 +102,102 @@ describe('solanaInstructionDecoder transform', () => {
 
     expect(valid).toHaveLength(1)
     expect(invalid).toHaveLength(0)
+  })
+})
+
+describe('solanaInstructionDecoder decode errors', () => {
+  const PROGRAM_ID = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+  const ACCOUNTS = [
+    '98vhGWL5CtK61KSKCJjJn2PVfkjzaw9QF6sRLptBWZvZ',
+    '49gyyvxzf61PknHoTg2cFGYQCJRnUrC7Web8h8go7ceM',
+    'EDMGEpKKGKS7nxpu1gjLmuHHWAmvLNy3BZWDxNC3nhAt',
+  ]
+
+  let portal: MockPortal
+
+  beforeEach(async () => {
+    // A decodable transfer followed by one whose data is the discriminator byte only
+    // (`'4'` = 0x03) — it matches d1 routing but `amount` (u64) cannot be read, so
+    // `decode` throws.
+    portal = await mockPortal([
+      {
+        statusCode: 200,
+        data: [
+          {
+            header: { number: 1, hash: 'ooooooooooooooooooooooooooooooooooooooooooo1', timestamp: 2000 },
+            instructions: [
+              {
+                transactionIndex: 85,
+                instructionAddress: [2, 0, 0],
+                programId: PROGRAM_ID,
+                accounts: ACCOUNTS,
+                data: '3DXy58UDhJuu',
+              },
+              {
+                transactionIndex: 86,
+                instructionAddress: [3, 0, 0],
+                programId: PROGRAM_ID,
+                accounts: ACCOUNTS,
+                data: '4',
+              },
+            ],
+          },
+        ],
+      },
+    ])
+  })
+
+  afterEach(async () => {
+    await portal?.close()
+  })
+
+  function stream(metrics: ReturnType<typeof mockMetricsServer>, onError?: (ctx: any, error: any) => unknown) {
+    return solanaPortalStream({
+      id: 'test',
+      portal: portal.url,
+      logger: false,
+      metrics: metrics.server,
+      outputs: solanaInstructionDecoder({
+        range: { from: 0, to: 1 },
+        programId: PROGRAM_ID,
+        instructions: { transfers: tokenProgram.instructions.transfer },
+        onError,
+      }).pipe((e) => e.transfers),
+    })
+  }
+
+  it('is fatal by default — no hook re-throws the decode error', async () => {
+    const metrics = mockMetricsServer()
+
+    await expect(readAll(stream(metrics))).rejects.toThrow()
+    expect(metrics.counter('sqd_decode_errors_skipped_total')).toBeUndefined()
+  })
+
+  it('a returning hook suppresses the record and counts the skip', async () => {
+    const metrics = mockMetricsServer()
+    const seen: any[] = []
+
+    const res = await readAll(stream(metrics, (_ctx, error) => seen.push(error)))
+
+    expect(res).toHaveLength(1)
+    expect(res[0].instruction.data.amount).toBe(50000000000n)
+    expect(seen).toHaveLength(1)
+
+    const skipped = metrics.counter('sqd_decode_errors_skipped_total')
+    expect(skipped.total).toBe(1)
+    expect(skipped.calls[0].labels).toEqual({ id: 'test' })
+  })
+
+  it('a re-throwing hook stays fatal and records no skip', async () => {
+    const metrics = mockMetricsServer()
+
+    await expect(
+      readAll(
+        stream(metrics, (_ctx, error) => {
+          throw error
+        }),
+      ),
+    ).rejects.toThrow()
+    expect(metrics.counter('sqd_decode_errors_skipped_total')).toBeUndefined()
   })
 })

--- a/packages/pipes/src/solana/solana-instruction-decoder.ts
+++ b/packages/pipes/src/solana/solana-instruction-decoder.ts
@@ -1,4 +1,11 @@
-import { BatchContext, PortalRange, ProfilerOptions, parsePortalRange } from '~/core/index.js'
+import {
+  DecodeErrorHook,
+  PortalRange,
+  ProfilerOptions,
+  defaultDecodeError,
+  parsePortalRange,
+  recordSuppressedDecode,
+} from '~/core/index.js'
 import { arrayify } from '~/internal/array.js'
 import { FieldSelection, Instruction, TokenBalance, Transaction } from '~/portal-client/query/solana.js'
 
@@ -69,22 +76,18 @@ export type EventResponse<T extends Instructions> = {
   [K in keyof T]: AbiDecodeInstruction<T[K]>[]
 }
 
-const defaultError = (ctx: BatchContext, error: any) => {
-  throw error
-}
-
 type DecodedEventPipeArgs<T extends Instructions> = {
   range: PortalRange
   programId: string | string[]
   instructions: InstructionsArgs<T>
   profiler?: ProfilerOptions
-  onError?: (ctx: BatchContext, error: any) => unknown | Promise<unknown>
+  onError?: DecodeErrorHook
 }
 
 export function solanaInstructionDecoder<T extends Instructions>(opts: DecodedEventPipeArgs<T>) {
   const range = parsePortalRange(opts.range)
   const programId = arrayify(opts.programId)
-  const onError = opts.onError || defaultError
+  const onError = opts.onError || defaultDecodeError
 
   const query = solanaQuery().addFields(decodedEventFields)
 
@@ -226,6 +229,7 @@ export function solanaInstructionDecoder<T extends Instructions>(opts: DecodedEv
               result[eventName as keyof T].push(res as any)
             } catch (error) {
               await onError(ctx, error)
+              recordSuppressedDecode(ctx)
             }
           }
         }

--- a/spec/02-requirements.md
+++ b/spec/02-requirements.md
@@ -142,7 +142,6 @@ Deliberately left open — conformance tests MUST NOT pin these:
 
 | # | Question | Owner |
 |---|---|---|
-| OQ-1 | Should decode-error hooks be observe-only or suppression hooks? Two current behaviors conflict (GAP-1, ADR-12 proposed). | SDK team |
 | OQ-2 | Defined behavior for a fork reaching below the finalized floor (currently a coded fatal; is halt the intent?) — GAP-6. | SDK team |
 | OQ-3 | Are append-lagged sinks (CN-13) allowed to keep the repair hook optional, or does REQ-3 force it mandatory? (GAP-3, ADR-15 proposed). | SDK team |
 | OQ-4 | SLO targets for SLI-1…SLI-7 are unratified (⚠ in 15-parameters). | SDK team |

--- a/spec/03-data-model.md
+++ b/spec/03-data-model.md
@@ -113,7 +113,7 @@ consumers is per durability class (CN-20…CN-24).
 | Durability class | `T` transactional · `W` write-ahead · `K` checkpointed-immutable · `A` append-lagged · `∅` ephemeral | per sink family, CN-10…CN-14; ADR-5 |
 | Finality mode | finalizing dataset · no-finality dataset | per dataset, DEF-3 |
 | Visibility | immediate (T/W/A) · deferred-to-finality (K/∅) | per class, CN-20…CN-24 |
-| Decode-error policy | fatal · skip-with-hook (divergent today — GAP-1) | per network module, WP-23 |
+| Decode-error policy | fatal-by-default, hook may skip-with-count (uniform, ADR-12) | all network modules, WP-23 |
 | Stream mode | full (unfinalized included) · finalized-only | per pipe, IB-2 |
 | Cache | off · local finalized-batch cache | per pipe, RS-20 |
 

--- a/spec/04-ingestion.md
+++ b/spec/04-ingestion.md
@@ -109,11 +109,12 @@ collections read as empty collections, unselected fields are absent (INV-23).
 normalization, discriminator match) and drop portal over-returns silently; a record
 matching no declared output is not an error.
 
-**WP-23 — Decode-error policy.** [MUST] Each network module declares one of: *fatal*
-(decode failure halts the pipe; hook observes only) or *skip-with-hook* (hook may
-suppress; suppressed records are skipped and counted). The declared policy is part of
-the module's conformance surface. *(Current modules disagree with each other, and
-neither counts suppressed records — GAP-1; unification is OQ-1/ADR-12.)*
+**WP-23 — Decode-error policy.** [MUST] One uniform rule across every network module
+(ADR-12): a decode failure is *fatal by default* (it halts the pipe). A user-supplied
+`onError` hook that returns without throwing *suppresses* the offending record; the hook
+re-throwing keeps the failure fatal. Suppressed records are skipped and counted in
+`sqd_decode_errors_skipped_total`, labelled by pipe id (INV-31). The hook shape and these
+semantics are part of the shared conformance surface.
 
 **WP-24 — Attribution uniqueness.** [MUST] Within one module, each input record maps to
 at most one output key. Declaring two outputs with an indistinguishable signature is

--- a/spec/07-invariants.md
+++ b/spec/07-invariants.md
@@ -155,8 +155,12 @@ lies is a conformance failure (12 §harness rule).
 **INV-31 — Error soundness.** [response]
 Every terminal failure surfaces exactly one coded error from the closed taxonomy
 (IB-50); no partial batch is delivered alongside a terminal error; retried transients
-are not surfaced as errors (they are signals, OB-13).
-*Check:* CT-4 fault corpus: every injected fault maps to its FM-required code/signal.
+are not surfaced as errors (they are signals, OB-13). A decode record suppressed by an
+`onError` hook (WP-23) is not a terminal failure: it is skipped, counted in
+`sqd_decode_errors_skipped_total`, and never delivered — a suppression that goes
+uncounted is a conformance failure.
+*Check:* CT-4 fault corpus: every injected fault maps to its FM-required code/signal;
+suppress-hook fixture asserts skip + counter, not a delivered record or an error.
 
 **INV-32 — Progress heartbeat.** [state]
 The observability surface always distinguishes: progressing / idle-at-head /

--- a/spec/13-conformance-tdd.md
+++ b/spec/13-conformance-tdd.md
@@ -123,7 +123,7 @@ known-suspect in the current implementation (see gap register).
 | WP-14 (transport retry) | CT-4 | P | counts tested; reconnect-mid-stream, 529 unmerged |
 | WP-16, FM-11 (malformed input) | CT-9 | U ⚠ | partial-line FIXME open (GAP-5); validation errors uncoded (GAP-25) |
 | WP-20…WP-22 (compose, validate, filter) | CT-1/5 | C | decoder + portal-source suites |
-| WP-23 (decode-error policy) | CT-5 | P ⚠ | behaviors diverge across modules (GAP-1) |
+| WP-23 (decode-error policy) | CT-5 | C | unified via `core/decode-error.ts` (ADR-12); fatal-default + suppress-and-count asserted on both modules |
 | WP-24 (attribution uniqueness) | CT-5 | P ⚠ | collision only logged in evm, undetected in solana (GAP-15, OQ-6) |
 | WP-25 (query union) | CT-1 | C | merge/heap tests + multi-output isolation |
 | WP-30…WP-32 (lifecycle) | CT-1 | P ⚠ | stop-once + partial-start tested; fork path re-fires start/stop per segment (GAP-22) |
@@ -168,7 +168,6 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
 
 | GAP | Statement | Violated | Pri | First test |
 |---|---|---|---|---|
-| GAP-1 | Decode-error hook semantics diverge between network modules: evm re-throws unconditionally (hook observe-only), solana lets a non-throwing hook suppress the record — and neither counts suppressed records | WP-23, INV-31 | P1 | same throwing-decode fixture against both modules; assert one declared policy + a skip counter (blocked on OQ-1/ADR-12) |
 | GAP-2 | Discriminator-width selection picks a single width per decoder; mixing widths silently omits the others from the portal query — records never fetched; wire-supported d0 is entirely unreachable through the decoder | INV-24, REQ-2, IB-8 | P1 | decoder with 1-byte + 8-byte discriminator instructions; assert both streams arrive |
 | GAP-3 | Class-A repair hook is optional; without it recovery and fork cleanup are silent no-ops while the cursor advances (silent divergence) | RP-42, CN-13, REQ-3 | P1 | crash between data append and cursor append, restart without hook; assert refusal or repair, not divergence (ADR-15) |
 | GAP-4 | Blank-pipe-id guard throws an uncoded error; the documented code exists but is dead | REQ-13, WP-3 | P3 | blank id + sink → assert the coded configuration error |
@@ -217,7 +216,7 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
   class (K — cheapest, file-based; the only crash imitation today is a pre-commit
   abort, one point of the CT-2 matrix). Exit: CT-1 green on the reference
   implementation for S1, ledger mode answering post-restart re-requests.
-- **Phase 1 — P1 gaps**: GAP-1 (needs ADR-12 decision), GAP-2, GAP-3 (needs ADR-15),
+- **Phase 1 — P1 gaps**: GAP-2, GAP-3 (needs ADR-15),
   GAP-11 (range anchors), GAP-17 (land the coverage PR),
   GAP-14 kill-point harness for class T. Exit: register updated, fixes landed or
   accepted as documented deviations.

--- a/spec/decisions/ADR-12-unify-decode-error-hooks.md
+++ b/spec/decisions/ADR-12-unify-decode-error-hooks.md
@@ -1,16 +1,16 @@
 # ADR-12 — Unify decode-error hook semantics across network modules
 
-Status: Proposed
+Status: Accepted
 
 ## Context
 
-The two decoder-bearing network modules disagree on what the decode-error hook means
-(GAP-1): in one, the hook observes and the failure is always fatal; in the other, a
-hook that returns without throwing suppresses the record silently. Same hook shape,
-opposite semantics — a conformance suite cannot encode both as intended behavior, and
-a second-language implementation must know which to copy.
+The two decoder-bearing network modules disagreed on what the decode-error hook means:
+in one, the hook observed and the failure was always fatal; in the other, a hook that
+returned without throwing suppressed the record silently. Same hook shape, opposite
+semantics — a conformance suite cannot encode both as intended behavior, and a
+second-language implementation must know which to copy.
 
-## Decision (proposed)
+## Decision
 
 Adopt **skip-with-hook** as the single policy: the default hook re-throws (fatal by
 default), but a user-supplied hook that returns suppresses the record, which is then
@@ -18,8 +18,13 @@ counted in an observable skip metric. Fatal-only modules migrate by keeping thei
 default; authors who relied on observe-only behavior see no change unless their hook
 already swallowed (currently a no-op bug on the fatal module).
 
+Both decoders now share one `defaultDecodeError` + `recordSuppressedDecode` helper
+(`core/decode-error.ts`): the evm decoder's unconditional trailing `throw` is gone, and
+suppressions on both increment `sqd_decode_errors_skipped_total{id}`.
+
 ## Consequences
 
 WP-23 collapses from "declared per module" to one uniform rule; INV-31 gains a skip
 counter; the fatal module's behavior changes for non-throwing hooks (breaking, minor).
-Blocked on: OQ-1 ratification.
+Ratification and implementation landed together, closing the earlier per-module
+divergence.


### PR DESCRIPTION
## What & why

The two decoder-bearing network modules disagreed on what the `onError` decode hook means (spec **GAP-1**):

- **evm** re-threw unconditionally *after* calling `onError` — the hook could only observe; a hook that returned to suppress a record was a silent no-op.
- **solana** let a returning hook suppress the record and continued.
- **Neither** counted suppressed records.

This ratifies **ADR-12 (skip-with-hook)** and makes the policy uniform:

- **fatal by default** — no hook (or a re-throwing hook) halts the pipe;
- a **returning `onError` suppresses** the offending record;
- every suppression increments `sqd_decode_errors_skipped_total{id}`.

Both decoders now share one `core/decode-error.ts` (`defaultDecodeError` + `recordSuppressedDecode`) and one `DecodeErrorHook` type; the evm decoder's unconditional trailing `throw` is gone. Every decode site — evm child events, evm factory events, and solana instructions — now runs the same wrapper (`await onError(ctx, error)` then `recordSuppressedDecode(ctx)`).

The evm **factory-event** decode was the last path outside the policy: it ran `contracts.decode()` *unawaited* and outside the hook, so a malformed factory event floated an unhandled rejection instead of going fatal or being suppressed. It now goes through the shared wrapper too, so factory decodes obey the same rule as everything else.

## Behavioral change

Breaking (minor): on the evm module a **non-throwing** `onError` now suppresses-and-counts instead of being ignored. Default behavior (no hook) is unchanged — still fatal. Authors who relied on evm's observe-only-then-throw see no change unless their hook was already swallowing (previously a no-op bug).

Also fixed: a malformed **factory** event on the evm module previously escaped as a floating unhandled rejection — neither a deterministic fatal nor suppressible. It now follows the uniform policy: fatal by default, suppressible via `onError`, counted when suppressed.

## Tests (internal `~/testing` framework)

Symmetric suites on both modules + a unit test for the shared helper. Fixtures were verified to pass routing (`is()` / `d1`) and fail only at `decode()`:

- **fatal by default** → stream rejects, counter absent;
- **returning hook** → record suppressed, sibling record still emitted, `sqd_decode_errors_skipped_total{id}` +1;
- **re-throwing hook** → stays fatal, no skip counted.

Plus an evm **factory** decode-error suite exercising the same triad on the factory path: a valid `PoolCreated` registers the child pool, a sibling with the same topics but empty `data` fails factory `decode()`, and a `Swap` from the registered pool must still survive. Verified to fail before the fix — reverting the wrapper makes vitest catch the unhandled rejection out of `Factory.decode`.

`core` + `evm` + `solana` suites: **254 passed**. Biome clean, `tsc --noEmit` clean.

## Coverage diff (base `main` → head), changed files

| File | Stmts | Branch | Funcs |
|---|---|---|---|
| `core/decode-error.ts` *(new)* | — → **100%** | — → **100%** | — → **100%** |
| `evm/evm-decoder.ts` | 87.83 → **99.25** | 84.28 → **93.61** | 92.30 → **100** |
| `solana/solana-instruction-decoder.ts` | 62.13 → **64.07** | 33.33 → **51.51** | 66.66 → **100** |

All changed files improve; no file regresses. The evm factory suite lifts `evm-decoder.ts` further by covering the previously-untested factory decode path.

## Spec

- **ADR-12** → Accepted (records the closure of GAP-1 / OQ-1).
- **WP-23** rewritten to one uniform rule; **INV-31** gains the skip counter; `03-data-model` policy row unified.
- Closed **GAP-1** removed from the gap register and **OQ-1** removed from the open-questions list — both now live only in ADR-12, keeping the live trackers to open items only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
