### PR TITLE
fix(solana): a decoder covers one program/ABI

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -61,6 +61,63 @@ invalid date, or a timestamp that can't be resolved to a block. The message name
 **Fix** — ensure `from ≤ to` and use a resolvable bound: `'latest'`, a block number (`'12,000,000'`),
 an ISO date (`'2024-01-01'`), or a `Date`.
 
+### E0003 · Unusable instruction discriminator set
+
+A `solanaInstructionDecoder` was built with a discriminator set it can't use: an instruction with no
+discriminator or with more than one, discriminators of mixed widths across the decoder
+(`d1`/`d2`/`d4`/`d8`), or two instructions sharing a discriminator. A decoder covers a single
+program/ABI — one width, distinct discriminators — because Anchor discriminators are
+program-independent, so a shared one would decode the same raw instruction under both keys.
+
+**Fix** — give each instruction exactly one discriminator, keep a single width per decoder, and split
+unrelated programs into separate `solanaInstructionDecoder()` calls. If the mixed widths really do
+belong to one program — an ABI whose extension instructions carry a wider discriminator than its base
+ones — split it by width instead: one decoder per width, the same `programId`.
+
+**Wrong** — two different programs in one decoder. Their `swap` instructions are unrelated, but Anchor
+derives both discriminators from `sha256("global:swap")`, so they collide and each would decode the
+other's data:
+
+```ts
+solanaInstructionDecoder({
+  range: { from: 'latest' },
+  programId: [jupiter.programId, raydium.programId],
+  instructions: {
+    jupSwap: jupiter.instructions.swap,
+    raySwap: raydium.instructions.swap, // same discriminator as jupSwap → E0003
+  },
+})
+```
+
+**Right** — one decoder per program/ABI:
+
+```ts
+const jup = solanaInstructionDecoder({
+  range: { from: 'latest' },
+  programId: jupiter.programId,
+  instructions: { swap: jupiter.instructions.swap },
+})
+
+const ray = solanaInstructionDecoder({
+  range: { from: 'latest' },
+  programId: raydium.programId,
+  instructions: { swap: raydium.instructions.swap },
+})
+```
+
+**Also right** — one ABI covering several addresses. This is the legitimate array case: the
+instruction has the same discriminator, arguments and account layout at every address, so one
+definition decodes it across all of them. Token and Token-2022 are distinct programs, but Token-2022
+implements Token's instruction set — `transfer` is identical on both:
+
+```ts
+solanaInstructionDecoder({
+  range: { from: 'latest' },
+  programId: [TOKEN_PROGRAM, TOKEN_2022_PROGRAM],
+  instructions: { transfer: tokenProgram.instructions.transfer },
+})
+```
+
 ---
 
 ## Fork handling

--- a/docs/examples/solana/02.swaps.example.ts
+++ b/docs/examples/solana/02.swaps.example.ts
@@ -31,7 +31,7 @@ async function cli() {
       }),
       meteoraDlmm: solanaInstructionDecoder({
         range: { from },
-        programId: meteoraDamm.programId,
+        programId: meteoraDlmm.programId,
         instructions: {
           swaps: meteoraDlmm.instructions.swap,
           swapExactOut: meteoraDlmm.instructions.swapExactOut,

--- a/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/template.config.ts
+++ b/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/template.config.ts
@@ -1,10 +1,10 @@
-import { toSnakeCase } from 'drizzle-orm/casing'
 import { z } from 'zod'
 
 import { ContractSchema } from '../../../contract-params.js'
 import { customContractsPrompt, customTypegenPostSetup } from '../../../custom-template-shared.js'
 import { defineTemplate } from '../../../define-template.js'
 import { renderClickhouse } from './templates/clickhouse-table.sql.js'
+import { programTables } from './templates/naming.js'
 import { renderSchema } from './templates/pg-table.js'
 import { buildDecoderGroups, renderTransformer } from './templates/transformer.js'
 
@@ -30,6 +30,13 @@ export const customTemplate = defineTemplate({
   postSetup: customTypegenPostSetup('svm'),
   render(params) {
     const groups = buildDecoderGroups(params)
+
+    // Same derivation the schema and DDL use, keyed by program identity — a decoder's
+    // insert target must be a table the generated schema actually declares.
+    const tableByInstruction = new Map(
+      programTables(params.contracts).map((t) => [`${t.typegenAddress}|${t.instruction.name}`, t.table]),
+    )
+
     return {
       transformer: renderTransformer(params),
       postgresSchema: renderSchema(params),
@@ -38,7 +45,7 @@ export const customTemplate = defineTemplate({
       tables: groups.flatMap((group) =>
         group.instructions.map((instruction) => ({
           decoderId: group.decoderId,
-          table: toSnakeCase(`${instruction.contractName}_${instruction.name}`),
+          table: tableByInstruction.get(`${group.programs[0]!.typegenAddress}|${instruction.name}`)!,
           event: instruction.uniqueKey,
         })),
       ),

--- a/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/templates/clickhouse-table.sql.ts
+++ b/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/templates/clickhouse-table.sql.ts
@@ -1,11 +1,10 @@
 import { toSnakeCase } from 'drizzle-orm/casing'
 import Mustache from 'mustache'
 
-import { ContractMetadata } from '~/services/sqd-abi.js'
 import { svmToClickhouseType } from '~/utils/db-type-map.js'
 
-import { referenceAddress } from '../../../../contract-params.js'
 import { CustomTemplateParams } from '../template.config.js'
+import { ProgramTable, programTables } from './naming.js'
 
 export const customContractChTemplate = `
 {{#contracts}}
@@ -29,29 +28,19 @@ ORDER BY (block_number, transaction_index, instruction_address);
 {{/contracts}}
 `
 
-export function renderClickhouse({ contracts: contractEntries }: CustomTemplateParams) {
-  // Tables are contract-level (shaped by the event set); deployments share them.
-  const contracts = contractEntries.map((c) => ({
-    contractName: c.contractName,
-    contractEvents: c.contractEvents,
-    contractAddress: referenceAddress(c),
-  }))
-  const contractsWithDbTypes = getContractWithDbTypes(contracts)
-
+export function renderClickhouse({ contracts }: CustomTemplateParams) {
   return Mustache.render(customContractChTemplate, {
-    contracts: contractsWithDbTypes,
+    contracts: getContractWithDbTypes(programTables(contracts)),
   })
 }
 
-function getContractWithDbTypes(contracts: ContractMetadata[]) {
-  return contracts.flatMap((c) =>
-    c.contractEvents.map((e) => ({
-      event: e.name,
-      tableName: toSnakeCase(`${c.contractName}_${e.name}`),
-      inputs: e.inputs.map((i) => ({
-        name: toSnakeCase(i.name),
-        dbType: svmToClickhouseType(i.type),
-      })),
+function getContractWithDbTypes(tables: ProgramTable[]) {
+  return tables.map(({ instruction, table }) => ({
+    event: instruction.name,
+    tableName: table,
+    inputs: instruction.inputs.map((i) => ({
+      name: toSnakeCase(i.name),
+      dbType: svmToClickhouseType(i.type),
     })),
-  )
+  }))
 }

--- a/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/templates/naming.test.ts
+++ b/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/templates/naming.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+
+import { tableToSchemaName } from '../../../../../builders/schema-builder/index.js'
+import { extractCreateTableNames, extractExportConstNames } from '../../../../../builders/target-builder/shared.js'
+import { CustomTemplateParams, customTemplate } from '../template.config.js'
+
+const swap = { name: 'Swap', type: 'event', inputs: [{ name: 'user', type: 'publicKey' }] }
+const claim = { name: 'Claim', type: 'event', inputs: [{ name: 'user', type: 'publicKey' }] }
+
+const jupiterAddress = 'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4'
+const raydiumAddress = 'CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK'
+
+function render(contracts: CustomTemplateParams['contracts']) {
+  return customTemplate.render({ contracts }, {} as any)
+}
+
+/**
+ * The insert targets, the Drizzle schema and the ClickHouse DDL are three renderings of
+ * one set of names. They were derived independently and drifted: a program named
+ * "Raydium AMM v4" inserted into `raydium_ammv_4_swap` while the DDL created
+ * `raydium_amm_v4_swap`, so the generated project neither compiled nor wrote anywhere.
+ */
+describe('SVM custom table naming', () => {
+  it('agrees across insert targets, Drizzle schema and ClickHouse DDL', () => {
+    const artifacts = render([
+      {
+        contractName: 'Raydium AMM v4',
+        contractEvents: [swap],
+        deployments: [{ address: raydiumAddress, range: { from: '1' } }],
+      },
+    ])
+
+    expect(artifacts.tables.map((t) => t.table)).toEqual(['raydium_amm_v4_swap'])
+    expect(extractCreateTableNames(artifacts.clickhouseTable)).toEqual(['raydium_amm_v4_swap'])
+    expect(extractExportConstNames(artifacts.postgresSchema)).toEqual(
+      artifacts.tables.map((t) => tableToSchemaName(t.table)),
+    )
+  })
+
+  it('keeps programs whose names normalize alike on separate tables', () => {
+    const artifacts = render([
+      {
+        contractName: 'Foo Bar',
+        contractEvents: [swap],
+        deployments: [{ address: jupiterAddress, range: { from: '10' } }],
+      },
+      {
+        contractName: 'foo_bar',
+        contractEvents: [swap],
+        deployments: [{ address: raydiumAddress, range: { from: '10' } }],
+      },
+    ])
+
+    expect(artifacts.tables.map((t) => t.table)).toEqual(['foo_bar_swap', 'foo_bar_swap_2'])
+    expect(extractCreateTableNames(artifacts.clickhouseTable)).toEqual(['foo_bar_swap', 'foo_bar_swap_2'])
+    expect(extractExportConstNames(artifacts.postgresSchema)).toHaveLength(2)
+  })
+
+  it('shares one table between the per-range decoders of a single program', () => {
+    const artifacts = render([
+      {
+        contractName: 'Jupiter',
+        contractEvents: [swap, claim],
+        deployments: [
+          { address: jupiterAddress, range: { from: '10' } },
+          { address: raydiumAddress, range: { from: '20' } },
+        ],
+      },
+    ])
+
+    expect(artifacts.decoderIds).toHaveLength(2)
+    expect(extractCreateTableNames(artifacts.clickhouseTable)).toEqual(['jupiter_swap', 'jupiter_claim'])
+    expect(artifacts.tables.map((t) => `${t.decoderId}:${t.table}`)).toEqual([
+      'customJupiter:jupiter_swap',
+      'customJupiter:jupiter_claim',
+      'customJupiter2:jupiter_swap',
+      'customJupiter2:jupiter_claim',
+    ])
+  })
+})

--- a/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/templates/naming.ts
+++ b/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/templates/naming.ts
@@ -1,0 +1,80 @@
+import { toCamelCase, toSnakeCase } from 'drizzle-orm/casing'
+
+import { RawAbiEvent } from '~/services/sqd-abi.js'
+
+import { referenceAddress } from '../../../../contract-params.js'
+import { CustomTemplateParams } from '../template.config.js'
+
+type Contract = CustomTemplateParams['contracts'][number]
+
+/**
+ * A program's identity is its reference-deployment address, not its display name: two
+ * configured names can normalise to the same identifier ("Foo Bar" / "foo_bar"), and
+ * collapsing them would merge unrelated programs into one decoder, one typegen import
+ * and one table.
+ */
+export function programIdentifiers(programs: { contractName: string; typegenAddress: string }[]): Map<string, string> {
+  const identifiers = new Map<string, string>()
+  const used = new Set<string>()
+  for (const p of programs) {
+    if (identifiers.has(p.typegenAddress)) {
+      continue
+    }
+
+    identifiers.set(p.typegenAddress, uniquify(toCamelCase(p.contractName), used, ''))
+  }
+
+  return identifiers
+}
+
+export interface ProgramTable {
+  typegenAddress: string
+  /** camelCase program identifier — typegen import alias and decoder-id suffix. */
+  program: string
+  instruction: RawAbiEvent
+  table: string
+}
+
+/**
+ * The insert surface, derived once. Tables are program-level: deployments and the
+ * per-range decoders of one program share them. All three renderers (transformer
+ * insert targets, Drizzle schema, ClickHouse DDL) read the names from here — deriving
+ * them independently is how they drifted apart, emitting a schema whose table names
+ * the pipeline never writes to.
+ */
+export function programTables(contracts: Contract[]): ProgramTable[] {
+  const identifiers = programIdentifiers(
+    contracts.map((c) => ({ contractName: c.contractName, typegenAddress: referenceAddress(c) })),
+  )
+  const used = new Set<string>()
+  const seen = new Set<string>()
+
+  return contracts.flatMap((c) => {
+    const typegenAddress = referenceAddress(c)
+    if (seen.has(typegenAddress)) {
+      return []
+    }
+
+    seen.add(typegenAddress)
+
+    return c.contractEvents.map((instruction) => ({
+      typegenAddress,
+      program: identifiers.get(typegenAddress)!,
+      instruction,
+      // Snake-cased from the joined display name, as the generated DDL always has;
+      // re-casing the camelCase identifier instead mangles digits ("Raydium AMM v4"
+      // → raydium_ammv_4 rather than raydium_amm_v4).
+      table: uniquify(toSnakeCase(`${c.contractName}_${instruction.name}`), used, '_'),
+    }))
+  })
+}
+
+function uniquify(base: string, used: Set<string>, separator: string): string {
+  let name = base
+  for (let n = 2; used.has(name); n++) {
+    name = `${base}${separator}${n}`
+  }
+  used.add(name)
+
+  return name
+}

--- a/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/templates/pg-table.ts
+++ b/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/templates/pg-table.ts
@@ -1,12 +1,10 @@
-import { toSnakeCase } from 'drizzle-orm/casing'
 import Mustache from 'mustache'
 
-import { ContractMetadata, RawAbiItem } from '~/services/sqd-abi.js'
 import { svmToPostgresType } from '~/utils/db-type-map.js'
 
 import { tableToSchemaName } from '../../../../../builders/schema-builder/index.js'
-import { referenceAddress } from '../../../../contract-params.js'
 import { CustomTemplateParams } from '../template.config.js'
+import { ProgramTable, programTables } from './naming.js'
 
 export const customContractPgTemplate = `
 import {
@@ -45,17 +43,8 @@ export const {{schemaName}} = pgTable(
 {{/contracts}}
 `
 
-export const eventTableName = (contract: ContractMetadata, event: RawAbiItem) =>
-  toSnakeCase(`${contract.contractName}_${event.name}`)
-
-export function renderSchema({ contracts: contractEntries }: CustomTemplateParams) {
-  // Tables are contract-level (shaped by the event set); deployments share them.
-  const contracts = contractEntries.map((c) => ({
-    contractName: c.contractName,
-    contractEvents: c.contractEvents,
-    contractAddress: referenceAddress(c),
-  }))
-  const contractsWithDbTypes = getContractWithDbTypes(contracts)
+export function renderSchema({ contracts }: CustomTemplateParams) {
+  const contractsWithDbTypes = getContractWithDbTypes(programTables(contracts))
 
   return Mustache.render(customContractPgTemplate, {
     typeImports: generateDrizzleImports(contractsWithDbTypes),
@@ -63,25 +52,20 @@ export function renderSchema({ contracts: contractEntries }: CustomTemplateParam
   })
 }
 
-export function getContractWithDbTypes(contracts: ContractMetadata[]) {
-  return contracts.flatMap((c) =>
-    c.contractEvents.map((e) => {
-      const tableName = eventTableName(c, e)
-      return {
-        event: e.name,
-        schemaName: tableToSchemaName(tableName),
-        tableName,
-        inputs: e.inputs.map((i) => ({
-          ...i,
-          dbType: svmToPostgresType(i.type),
-        })),
-      }
-    }),
-  )
+export function getContractWithDbTypes(tables: ProgramTable[]) {
+  return tables.map(({ instruction, table }) => ({
+    event: instruction.name,
+    schemaName: tableToSchemaName(table),
+    tableName: table,
+    inputs: instruction.inputs.map((i) => ({
+      ...i,
+      dbType: svmToPostgresType(i.type),
+    })),
+  }))
 }
 
 function generateDrizzleImports(contracts: ReturnType<typeof getContractWithDbTypes>) {
-  return contracts.flatMap((c) => c.inputs.map((i) => extractDrizzleType(i.dbType)))
+  return [...new Set(contracts.flatMap((c) => c.inputs.map((i) => extractDrizzleType(i.dbType))))]
 }
 
 const TYPE_REGEX = /^\s*([A-Za-z_$][\w$]*)\s*(?=\()/

--- a/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/templates/transformer.test.ts
+++ b/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/templates/transformer.test.ts
@@ -30,12 +30,10 @@ function params(contracts: CustomTemplateParams['contracts']): CustomTemplatePar
 }
 
 describe('SVM custom transformer', () => {
-  it('emits a single decoder when all programs share a range', () => {
+  it('emits one decoder per program even when ranges match (never merges programs)', () => {
     const groups = buildDecoderGroups(params([jupiter({ from: '200000000' }), raydium({ from: '200000000' })]))
-    expect(groups).toHaveLength(1)
-    expect(groups[0]!.decoderId).toBe('custom')
-    expect(groups[0]!.rangeFrom).toBe('200000000')
-    expect(groups[0]!.programs).toHaveLength(2)
+    expect(groups.map((g) => g.decoderId)).toEqual(['customJupiter', 'customRaydium'])
+    expect(groups.every((g) => g.programs.length === 1)).toBe(true)
   })
 
   it('emits per-program decoders when ranges diverge', () => {
@@ -82,18 +80,47 @@ describe('SVM custom transformer', () => {
     ])
   })
 
-  it('disambiguates duplicate instruction names across programs in a shared decoder', () => {
+  it('keeps same-named instructions in separate per-program decoders (no cross-decode)', () => {
     const groups = buildDecoderGroups(params([jupiter({ from: '200000000' }), raydium({ from: '200000000' })]))
-    const keys = groups[0]!.instructions.map((i) => i.uniqueKey)
-    expect(keys).toEqual(['jupiterSwap', 'raydiumSwap'])
+    expect(groups).toHaveLength(2)
+    expect(groups.map((g) => g.instructions.map((i) => i.uniqueKey))).toEqual([['Swap'], ['Swap']])
   })
 
-  it('keeps bare instruction names when no collision exists in the group', () => {
+  it('gives each program its own decoder with its own instructions', () => {
     const groups = buildDecoderGroups(
       params([jupiter({ from: '200000000' }, [swap]), raydium({ from: '200000000' }, [claim])]),
     )
-    const keys = groups[0]!.instructions.map((i) => i.uniqueKey)
-    expect(keys).toEqual(['Swap', 'Claim'])
+    const byId = Object.fromEntries(groups.map((g) => [g.decoderId, g.instructions.map((i) => i.uniqueKey)]))
+    expect(byId).toEqual({ customJupiter: ['Swap'], customRaydium: ['Claim'] })
+  })
+
+  it('never merges distinct programs whose names normalize alike', () => {
+    const contracts = [
+      {
+        contractName: 'Foo Bar',
+        contractEvents: [swap],
+        deployments: [{ address: jupiterAddress, range: { from: '10' } }],
+      },
+      {
+        contractName: 'foo_bar',
+        contractEvents: [claim],
+        deployments: [{ address: raydiumAddress, range: { from: '10' } }],
+      },
+    ]
+    const groups = buildDecoderGroups(params(contracts))
+
+    expect(groups).toHaveLength(2)
+    expect(groups.every((g) => g.programs.length === 1)).toBe(true)
+    expect(new Set(groups.map((g) => g.decoderId)).size).toBe(2)
+    expect(groups.flatMap((g) => g.instructions.map((i) => i.name)).sort()).toEqual(['Claim', 'Swap'])
+
+    // each program keeps its own typegen import, at its own address
+    const importLines = renderTransformer(params(contracts))
+      .split('\n')
+      .filter((l) => l.includes('from "./contracts/'))
+    expect(importLines).toHaveLength(2)
+    expect(importLines.some((l) => l.includes(jupiterAddress))).toBe(true)
+    expect(importLines.some((l) => l.includes(raydiumAddress))).toBe(true)
   })
 })
 

--- a/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/templates/transformer.ts
+++ b/packages/pipes-cli/src/commands/init/templates/pipes/svm/custom/templates/transformer.ts
@@ -1,8 +1,8 @@
-import { toCamelCase } from 'drizzle-orm/casing'
 import Mustache from 'mustache'
 
 import { flattenContracts } from '../../../../contract-params.js'
 import { CustomTemplateParams } from '../template.config.js'
+import { programIdentifiers } from './naming.js'
 
 interface Program {
   contractName: string
@@ -51,33 +51,51 @@ const {{{decoderId}}} = solanaInstructionDecoder({
 `
 
 export function buildDecoderGroups(params: CustomTemplateParams): DecoderGroup[] {
-  const programs: Program[] = flattenContracts(params.contracts).map((c) => ({
-    contractName: toCamelCase(c.contractName),
+  const flat = flattenContracts(params.contracts)
+  if (flat.length === 0) {
+    return []
+  }
+
+  const identifiers = programIdentifiers(flat)
+
+  const programs: Program[] = flat.map((c) => ({
+    contractName: identifiers.get(c.typegenAddress)!,
     contractAddress: c.contractAddress,
     typegenAddress: c.typegenAddress,
     contractEvents: c.contractEvents,
     range: c.range ?? { from: 'latest' },
   }))
 
-  if (programs.length === 0) return []
-
-  const allSameRange = programs.every(
-    (p) => p.range.from === programs[0]!.range.from && p.range.to === programs[0]!.range.to,
-  )
-
-  if (allSameRange && programs.length > 0) {
-    return [makeGroup('custom', programs)]
+  // One decoder per (program, range). Deployments of the same program share its IDL and
+  // discriminators, so they belong together in one decoder's programId array. Different
+  // programs must never share a decoder: Solana discriminators are program-independent, so
+  // two programs with a same-named instruction would decode each other's data (the decoder
+  // now rejects that config at runtime). Keyed by typegen address so name normalization can't
+  // merge distinct programs.
+  const groups = new Map<string, Program[]>()
+  for (const p of programs) {
+    const key = `${p.typegenAddress}|${p.range.from}|${p.range.to ?? ''}`
+    const list = groups.get(key) ?? []
+    list.push(p)
+    groups.set(key, list)
   }
 
-  // One decoder per (program, deployment); same-name deployments get numeric suffixes.
+  const groupList = [...groups.values()]
+  if (groupList.length === 1) {
+    return [makeGroup('custom', groupList[0]!)]
+  }
+
   const usedIds = new Set<string>()
-  return programs.map((p) => {
-    const suffix = p.contractName.charAt(0).toUpperCase() + p.contractName.slice(1)
+  return groupList.map((deployments) => {
+    const name = deployments[0]!.contractName
+    const suffix = name.charAt(0).toUpperCase() + name.slice(1)
     let decoderId = `custom${suffix}`
-    for (let n = 2; usedIds.has(decoderId); n++) decoderId = `custom${suffix}${n}`
+    for (let n = 2; usedIds.has(decoderId); n++) {
+      decoderId = `custom${suffix}${n}`
+    }
     usedIds.add(decoderId)
 
-    return makeGroup(decoderId, [p])
+    return makeGroup(decoderId, deployments)
   })
 }
 

--- a/packages/pipes/src/core/errors.ts
+++ b/packages/pipes/src/core/errors.ts
@@ -46,6 +46,20 @@ export class BlockRangeConfigurationError extends PipeError {
   }
 }
 
+/**
+ * E0003: Thrown when an instruction decoder is built with an unusable discriminator set:
+ * an instruction with no discriminator (it would match every instruction of the program) or
+ * with more than one (a malformed ABI entry — an instruction has exactly one), discriminators
+ * of mixed widths across the decoder (a decoder covers one ABI, which is single-width), or two
+ * instructions sharing a discriminator (Anchor discriminators are program-independent, so a
+ * shared one decodes the same raw instruction under both keys).
+ */
+export class InstructionDecoderConfigurationError extends PipeError {
+  constructor(message: string | string[]) {
+    super('E0003', SdkErrorName.PipeConfiguration, message)
+  }
+}
+
 // ─── Fork handling errors (E1xxx) ─────────────────────────────────────────────
 
 /**

--- a/packages/pipes/src/portal-client/query/solana.ts
+++ b/packages/pipes/src/portal-client/query/solana.ts
@@ -230,7 +230,6 @@ export type Discriminator = Hex
 
 export type InstructionRequest = {
   programId?: Base58[]
-  d0?: Discriminator[]
   d1?: Discriminator[]
   d2?: Discriminator[]
   d4?: Discriminator[]

--- a/packages/pipes/src/solana/solana-instruction-decoder.test.ts
+++ b/packages/pipes/src/solana/solana-instruction-decoder.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { InstructionDecoderConfigurationError } from '~/core/index.js'
 import { solanaInstructionDecoder } from '~/solana/solana-instruction-decoder.js'
 import { solanaPortalStream } from '~/solana/solana-portal-source.js'
 import { MockPortal, MockResponse, mockMetricsServer, mockPortal, readAll } from '~/testing/index.js'
@@ -67,6 +68,64 @@ describe('solanaInstructionDecoder transform', () => {
       data: {
         amount: 50000000000n,
       },
+    })
+  })
+
+  it('decodes one ABI across multiple deployment addresses in a single request', async () => {
+    const TOKEN = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+    const TOKEN_2022 = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'
+    const accounts = [
+      '98vhGWL5CtK61KSKCJjJn2PVfkjzaw9QF6sRLptBWZvZ',
+      '49gyyvxzf61PknHoTg2cFGYQCJRnUrC7Web8h8go7ceM',
+      'EDMGEpKKGKS7nxpu1gjLmuHHWAmvLNy3BZWDxNC3nhAt',
+    ]
+
+    let requestBody: any
+    await portal?.close()
+    portal = await mockPortal([
+      {
+        statusCode: 200,
+        validateRequest: (body) => {
+          requestBody = body
+        },
+        data: [
+          {
+            header: { number: 1, hash: 'ooooooooooooooooooooooooooooooooooooooooooo1', timestamp: 2000 },
+            instructions: [
+              { transactionIndex: 85, instructionAddress: [2, 0, 0], programId: TOKEN, accounts, data: '3DXy58UDhJuu' },
+              {
+                transactionIndex: 86,
+                instructionAddress: [3, 0, 0],
+                programId: TOKEN_2022,
+                accounts,
+                data: '3DXy58UDhJuu',
+              },
+            ],
+          },
+        ],
+      },
+    ])
+
+    const stream = solanaPortalStream({
+      id: 'test',
+      portal: portal.url,
+      logger: false,
+      outputs: solanaInstructionDecoder({
+        range: { from: 0, to: 1 },
+        programId: [TOKEN, TOKEN_2022],
+        instructions: { transfers: tokenProgram.instructions.transfer },
+      }).pipe((e) => e.transfers),
+    })
+
+    const res = await readAll(stream)
+
+    expect(res.map((r) => r.programId)).toEqual([TOKEN, TOKEN_2022])
+    expect(res.map((r) => r.rawInstruction.programId)).toEqual([TOKEN, TOKEN_2022])
+
+    expect(requestBody.instructions).toHaveLength(1)
+    expect(requestBody.instructions[0]).toMatchObject({
+      programId: [TOKEN, TOKEN_2022],
+      d1: ['0x03'],
     })
   })
 
@@ -199,5 +258,78 @@ describe('solanaInstructionDecoder decode errors', () => {
       ),
     ).rejects.toThrow()
     expect(metrics.counter('sqd_decode_errors_skipped_total')).toBeUndefined()
+  })
+})
+
+describe('solanaInstructionDecoder configuration guards', () => {
+  const PROGRAM_ID = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+  const anchorSwap = { d8: '0xf8c69e91e17587c8', decode: () => ({ accounts: {}, data: {} }) }
+
+  it('rejects mixing discriminator widths in one decoder', () => {
+    expect(() =>
+      solanaInstructionDecoder({
+        range: { from: 0, to: 1 },
+        programId: PROGRAM_ID,
+        instructions: { transfers: tokenProgram.instructions.transfer, swap: anchorSwap },
+      }),
+    ).toThrow(InstructionDecoderConfigurationError)
+  })
+
+  it('rejects two instructions sharing a discriminator', () => {
+    expect(() =>
+      solanaInstructionDecoder({
+        range: { from: 0, to: 1 },
+        programId: PROGRAM_ID,
+        instructions: { transfers: tokenProgram.instructions.transfer, alias: tokenProgram.instructions.transfer },
+      }),
+    ).toThrow(InstructionDecoderConfigurationError)
+  })
+
+  it('rejects a decoder with no discriminators', () => {
+    expect(() =>
+      solanaInstructionDecoder({
+        range: { from: 0, to: 1 },
+        programId: PROGRAM_ID,
+        instructions: { noop: { decode: () => ({ accounts: {}, data: {} }) } },
+      }),
+    ).toThrow(InstructionDecoderConfigurationError)
+  })
+
+  it('rejects an instruction that sets multiple discriminator widths', () => {
+    expect(() =>
+      solanaInstructionDecoder({
+        range: { from: 0, to: 1 },
+        programId: PROGRAM_ID,
+        instructions: {
+          transfers: { d1: '0x03', d8: '0xf8c69e91e17587c8', decode: () => ({ accounts: {}, data: {} }) },
+        },
+      }),
+    ).toThrow(InstructionDecoderConfigurationError)
+  })
+
+  it('names the offending instructions when every entry lacks a discriminator', () => {
+    expect(() =>
+      solanaInstructionDecoder({
+        range: { from: 0, to: 1 },
+        programId: PROGRAM_ID,
+        instructions: {
+          swap: { decode: () => ({ accounts: {}, data: {} }) },
+          claim: { decode: () => ({ accounts: {}, data: {} }) },
+        },
+      }),
+    ).toThrow(/"swap", "claim"/)
+  })
+
+  it('rejects a discriminator-less instruction alongside a valid one', () => {
+    expect(() =>
+      solanaInstructionDecoder({
+        range: { from: 0, to: 1 },
+        programId: PROGRAM_ID,
+        instructions: {
+          transfers: tokenProgram.instructions.transfer,
+          noop: { decode: () => ({ accounts: {}, data: {} }) },
+        },
+      }),
+    ).toThrow(InstructionDecoderConfigurationError)
   })
 })

--- a/packages/pipes/src/solana/solana-instruction-decoder.ts
+++ b/packages/pipes/src/solana/solana-instruction-decoder.ts
@@ -1,5 +1,6 @@
 import {
   DecodeErrorHook,
+  InstructionDecoderConfigurationError,
   PortalRange,
   ProfilerOptions,
   defaultDecodeError,
@@ -56,13 +57,15 @@ export type DecodedInstruction<D> = {
 }
 
 interface AbiInstruction<A, D> {
-  d0?: string
   d1?: string
   d2?: string
   d4?: string
   d8?: string
   decode(event: any): { accounts: A; data: D }
 }
+
+const DISCRIMINATOR_WIDTHS = ['d1', 'd2', 'd4', 'd8'] as const
+type DiscriminatorWidth = (typeof DISCRIMINATOR_WIDTHS)[number]
 
 export type Instructions = Record<string, AbiInstruction<any, any>>
 
@@ -91,97 +94,99 @@ export function solanaInstructionDecoder<T extends Instructions>(opts: DecodedEv
 
   const query = solanaQuery().addFields(decodedEventFields)
 
-  const d1: string[] = []
-  const d2: string[] = []
-  const d4: string[] = []
-  const d8: string[] = []
+  const byWidth: Record<DiscriminatorWidth, string[]> = { d1: [], d2: [], d4: [], d8: [] }
+  const seen = new Map<string, string>()
+  const missing: string[] = []
   for (const name in opts.instructions) {
     const i = opts.instructions[name]
+    const widths = DISCRIMINATOR_WIDTHS.filter((w) => i[w])
+    if (widths.length === 0) {
+      missing.push(name)
+      continue
+    }
 
-    if (i.d1) d1.push(i.d1)
-    if (i.d2) d2.push(i.d2)
-    if (i.d4) d4.push(i.d4)
-    if (i.d8) d8.push(i.d8)
+    if (widths.length > 1) {
+      throw new InstructionDecoderConfigurationError([
+        `Instruction "${name}" sets multiple discriminators (${widths.join(', ')}).`,
+        'An instruction is identified by exactly one discriminator; several mean a malformed ABI',
+        'entry. Pass a single instruction definition carrying one discriminator width.',
+      ])
+    }
+
+    const width = widths[0]
+    const value = i[width]!
+    const previous = seen.get(`${width}:${value}`)
+    if (previous) {
+      throw new InstructionDecoderConfigurationError([
+        `Instructions "${previous}" and "${name}" share the discriminator ${value} (${width}).`,
+        'Solana discriminators are program-independent, so a shared one would decode the same raw',
+        'instruction under both keys. A decoder covers a single program/ABI — split unrelated',
+        'programs into separate solanaInstructionDecoder() calls.',
+      ])
+    }
+
+    seen.set(`${width}:${value}`, name)
+    byWidth[width].push(value)
   }
 
-  if (!d1.length && !d2.length && !d4.length && !d8.length) {
-    throw new Error(
-      [
-        'No valid instruction discriminators found. It looks like one or more instructions in your ABI are missing their decoder configuration.',
-        'This usually happens when you accidentally pass an event instead of an instruction, or when your ABI instruction definitions are incomplete.',
-        'Please check that you are passing correct instruction definitions to "solanaInstructionDecoder":',
-        '--------------------------------------------------',
-        'Example',
-        '',
+  const widthsPresent = DISCRIMINATOR_WIDTHS.filter((w) => byWidth[w].length > 0)
 
-        'import { events as orcaWhirlpool } from "./orca_abi";',
-
-        '',
-        ' // ... omitted logic ....',
-        '',
-
-        'solanaInstructionDecoder({',
-        '  range: { from: 371602677 },',
-        '  programId: orcaWhirlpool.programId,',
-        '  instructions: {',
-        '    initializeConfig: abi.instructions.InitializeConfig,',
-        '    swap: abi.instructions.Swap,',
-        '  },',
-        '})',
-        // TODO add docs link
-      ].join('\n'),
-    )
+  // Ordered before the empty-set message below: when every entry lacks a discriminator
+  // both apply, and only this one names the offending keys.
+  if (missing.length > 0) {
+    throw new InstructionDecoderConfigurationError([
+      `Instruction(s) ${missing.map((n) => `"${n}"`).join(', ')} have no discriminator (d1/d2/d4/d8).`,
+      'An instruction without a discriminator matches every instruction of the program and would',
+      'decode foreign data under its key. Every entry must carry exactly one discriminator — check',
+      'you passed an instruction definition, not an event.',
+    ])
   }
 
-  if (d1.length) {
-    query.addInstructionRequest({
-      range,
-      request: {
-        programId,
-        d1,
-        isCommitted: true,
-        innerInstructions: true,
-        transaction: true,
-        transactionTokenBalances: true,
-      },
-    })
-  } else if (d2.length) {
-    query.addInstructionRequest({
-      range,
-      request: {
-        programId,
-        d2,
-        isCommitted: true,
-        innerInstructions: true,
-        transaction: true,
-        transactionTokenBalances: true,
-      },
-    })
-  } else if (d4.length) {
-    query.addInstructionRequest({
-      range,
-      request: {
-        programId,
-        d4,
-        isCommitted: true,
-        innerInstructions: true,
-        transaction: true,
-        transactionTokenBalances: true,
-      },
-    })
-  } else if (d8.length) {
-    query.addInstructionRequest({
-      range,
-      request: {
-        programId,
-        d8,
-        isCommitted: true,
-        innerInstructions: true,
-        transaction: true,
-        transactionTokenBalances: true,
-      },
-    })
+  if (widthsPresent.length === 0) {
+    throw new InstructionDecoderConfigurationError([
+      'No valid instruction discriminators found. It looks like one or more instructions in your ABI are missing their decoder configuration.',
+      'This usually happens when you accidentally pass an event instead of an instruction, or when your ABI instruction definitions are incomplete.',
+      'Please check that you are passing correct instruction definitions to "solanaInstructionDecoder":',
+      '--------------------------------------------------',
+      'Example',
+      '',
+      'import { events as orcaWhirlpool } from "./orca_abi";',
+      '',
+      ' // ... omitted logic ....',
+      '',
+      'solanaInstructionDecoder({',
+      '  range: { from: 371602677 },',
+      '  programId: orcaWhirlpool.programId,',
+      '  instructions: {',
+      '    initializeConfig: abi.instructions.InitializeConfig,',
+      '    swap: abi.instructions.Swap,',
+      '  },',
+      '})',
+    ])
   }
+
+  if (widthsPresent.length > 1) {
+    throw new InstructionDecoderConfigurationError([
+      `A decoder mixes discriminator widths (${widthsPresent.join(', ')}); the portal rejects more than one width per request.`,
+      'Usually this means unrelated programs were combined into one decoder — a decoder covers a',
+      'single program/ABI, so split them into separate solanaInstructionDecoder() calls. If these',
+      'instructions really are one program (an ABI whose extension instructions carry a wider',
+      'discriminator), split it by width instead: one decoder per width, same programId.',
+    ])
+  }
+
+  const width = widthsPresent[0]
+  query.addInstructionRequest({
+    range,
+    request: {
+      programId,
+      [width]: byWidth[width],
+      isCommitted: true,
+      innerInstructions: true,
+      transaction: true,
+      transactionTokenBalances: true,
+    },
+  })
 
   return query.build().pipe({
     profiler: opts.profiler || { name: 'instruction decoder' },
@@ -212,6 +217,8 @@ export function solanaInstructionDecoder<T extends Instructions>(opts: DecodedEv
 
               const res = {
                 instruction: decoded,
+                // The emitting deployment: a decoder may cover several addresses of one ABI.
+                programId: instruction.programId,
                 rawInstruction: instruction,
                 block: { number: block.header.number, hash: block.header.hash },
                 transaction,

--- a/spec/13-conformance-tdd.md
+++ b/spec/13-conformance-tdd.md
@@ -168,7 +168,6 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
 
 | GAP | Statement | Violated | Pri | First test |
 |---|---|---|---|---|
-| GAP-2 | Discriminator-width selection picks a single width per decoder; mixing widths silently omits the others from the portal query — records never fetched; wire-supported d0 is entirely unreachable through the decoder | INV-24, REQ-2, IB-8 | P1 | decoder with 1-byte + 8-byte discriminator instructions; assert both streams arrive |
 | GAP-3 | Class-A repair hook is optional; without it recovery and fork cleanup are silent no-ops while the cursor advances (silent divergence) | RP-42, CN-13, REQ-3 | P1 | crash between data append and cursor append, restart without hook; assert refusal or repair, not divergence (ADR-15) |
 | GAP-4 | Blank-pipe-id guard throws an uncoded error; the documented code exists but is dead | REQ-13, WP-3 | P3 | blank id + sink → assert the coded configuration error |
 | GAP-5 | Malformed NDJSON line vs incomplete line are not discriminated; a partial line can surface as a raw parse crash | WP-16, FM-11 | P2 | simulator splits a line across chunks (must continue) and sends one malformed line (must fail coded) |
@@ -199,6 +198,7 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
 | GAP-32 | Dev-runner coerces `retry: 0` to the default 5 via a falsy-default — fail-fast intent silently ignored (open fix PR #70) | FM-40 | P3 | retry: 0 → assert a single attempt |
 | GAP-33 | Profiling-surface defects: batch spans leak on empty batches and stream end (open fix PR #71); transformer-id dedup collides for 3+ same-id transformers (open fix PR #73) | OB-22 | P3 | span onStart count = onEnd count across empty batches; three same-id transformers get distinct ids |
 | GAP-34 | Observability-server hygiene: CORS accepts any origin containing "localhost" as a substring (and rejects 127.0.0.1); stop() clears the global metrics registry; /profiler hardcodes `enabled: true` | IB-40, IB-43 | P3 | origin `http://localhost.evil.com` → assert rejected |
+| GAP-36 | One-program-per-decoder (ADR-17) is enforced by proxy: `programId` is decoder-level, so nothing binds an instruction definition to its program, and the guards only reject collisions visible in the discriminator set. Two programs with disjoint tracked discriminators still pass and cross-decode | INV-24, REQ-2 | P2 | decoder over `[A, B]` with `{ aSwap: A.swap, bDeposit: B.deposit }`; feed B's on-chain `swap` → assert refusal or no emission under `aSwap`, not a decode |
 | GAP-35 | Parquet data files are named by block window with no pipe-id namespacing while the state sidecar is namespaced (`_sqd_parquet_state.<id>.json`): two pipes covering overlapping ranges in one directory collide on filename and the second fails E2309 — sharing a directory is refused by accident of naming rather than declared policy, and coverage-window naming (GAP-17) collides identically | IB-22, IB-27, INV-35 | P2 | two pipe ids, one directory, overlapping ranges → assert the declared outcome (namespaced files or a coded exclusivity refusal), not a publish collision |
 
 ## Build order
@@ -206,7 +206,7 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
 - **Phase 0 — harness skeleton**: the reference implementation already serves the
   simulator's wire surface from an HTTP fixture (200 NDJSON · 204 · 409 with canonical
   chain · 5xx · head headers, IB-4/IB-5) with a per-request assertion hook — sufficient
-  as-is for request-shape work (GAP-2, GAP-11). The Phase-0 delta is **ledger mode**:
+  as-is for request-shape work (GAP-11). The Phase-0 delta is **ledger mode**:
   derive responses from the request anchor (IB-3) against a held chain instead of
   selecting them by request ordinal. An ordinal script has no answer for the re-request
   a restarted SUT issues from its recovered cursor, so this gates the entire CT-2
@@ -216,7 +216,7 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
   class (K — cheapest, file-based; the only crash imitation today is a pre-commit
   abort, one point of the CT-2 matrix). Exit: CT-1 green on the reference
   implementation for S1, ledger mode answering post-restart re-requests.
-- **Phase 1 — P1 gaps**: GAP-2, GAP-3 (needs ADR-15),
+- **Phase 1 — P1 gaps**: GAP-3 (needs ADR-15),
   GAP-11 (range anchors), GAP-17 (land the coverage PR),
   GAP-14 kill-point harness for class T. Exit: register updated, fixes landed or
   accepted as documented deviations.

--- a/spec/14-interface-binding.md
+++ b/spec/14-interface-binding.md
@@ -47,8 +47,8 @@ local schedule P-RETRY-SCHEDULE-MS).
 (address, topic0–3, relational inclusions `transaction`/`transactionTraces`/
 `transactionLogs`/`transactionStateDiffs`), `transactions` (to/from/sighash/type),
 `traces`, `stateDiffs`, `includeAllBlocks`; solana — `instructions` (programId,
-discriminators d0/d1/d2/d4/d8 *(d0 unreachable through the reference decoder —
-GAP-2)*, account slots a0–a9), `transactions`, `logs`, `balances`,
+discriminators d1/d2/d4/d8 — one width per instruction request, an ABI is single-width
+(ADR-17); the wire has no d0 — account slots a0–a9), `transactions`, `logs`, `balances`,
 `tokenBalances`, `rewards`; bitcoin/tron/hyperliquidFills — their reference sets.
 A conforming implementation reproduces these request JSON shapes byte-compatibly.
 
@@ -208,7 +208,7 @@ consumers MUST NOT read it as a block number.
 
 | Band | Area | Codes in use |
 |---|---|---|
-| E0xxx | pipe configuration | E0001 blank/default pipe id *(currently dead — GAP-4)*, E0002 invalid range/date |
+| E0xxx | pipe configuration | E0001 blank/default pipe id *(currently dead — GAP-4)*, E0002 invalid range/date, E0003 unusable instruction discriminator set (mixed widths across the decoder, shared discriminator, or an instruction with none or several) |
 | E1xxx | fork handling | E1001 sink lacks fork support, E1002 empty canonical chain, E1003 ancestor unresolvable, E1004 portal contract violation (canonical below cursor) |
 | E20xx | ClickHouse binding | E2001–E2006 (retention, table name, distributed-rollback, collapse-column, missing sign, rollback-index) |
 | E21xx | Postgres binding | E2101–E2106 (client, config, advisory lock, untracked table, missing PK, FK cycle) |

--- a/spec/check-spec.mjs
+++ b/spec/check-spec.mjs
@@ -5,8 +5,10 @@
  * Validates the banded ID system of spec/: every individually referenced ID must be
  * defined somewhere; range references (WP-10…WP-16) may span banded gaps by design,
  * but their band prefix must exist. Also validates every relative markdown link: the
- * target file must exist, and an anchor must match a heading there. Exit 1 on any
- * dangling reference or broken link.
+ * target file must exist, and an anchor must match a heading there. Finally, checks that
+ * docs/errors.md stays in sync with the codes the SDK actually throws — every thrown
+ * E-code has a documented section, and every documented code is still thrown. Exit 1 on
+ * any dangling reference, broken link, or errors.md drift.
  *
  * Run: node spec/check-spec.mjs
  */
@@ -162,6 +164,58 @@ for (const [f, t] of text) {
   }
 }
 
+// ─── docs/errors.md ↔ thrown-code sync ───────────────────────────────────────
+// docs/errors.md is the user-facing registry every SDK error message links to. Authority
+// is the code: the same error-class sources docs/errors.md names in its header comment.
+// Every code thrown there must have a section, and every documented code must still be
+// thrown — otherwise the reference drifts from reality (as E0003 once did).
+const REPO = resolve(SPEC, '..')
+
+// Discovered, not listed: a hardcoded roster fails open — a new target's errors.ts is
+// simply not scanned, and the check passes while the reference drifts.
+function errorSources(dir) {
+  const found = []
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    if (e.isDirectory()) {
+      if (e.name === 'node_modules' || e.name === 'dist') continue
+      found.push(...errorSources(join(dir, e.name)))
+    } else if (e.name === 'errors.ts') {
+      found.push(join(dir, e.name))
+    }
+  }
+
+  return found
+}
+
+const sources = errorSources(join(REPO, 'packages'))
+if (sources.length === 0) {
+  errors.push('errors.md sync: no errors.ts sources found under packages/')
+}
+
+const thrownCodes = new Set()
+for (const p of sources) {
+  for (const m of readFileSync(p, 'utf8').matchAll(/'(E\d{4})'/g)) thrownCodes.add(m[1])
+}
+
+const errorsDoc = join(REPO, 'docs/errors.md')
+const documentedCodes = new Set()
+if (!existsSync(errorsDoc)) {
+  errors.push('errors.md sync: docs/errors.md not found')
+} else {
+  for (const m of readFileSync(errorsDoc, 'utf8').matchAll(/^#{2,4}\s+(E\d{4})\b/gm)) documentedCodes.add(m[1])
+}
+
+for (const c of [...thrownCodes].sort()) {
+  if (!documentedCodes.has(c)) {
+    errors.push(`errors.md missing ${c}: thrown in code but has no section in docs/errors.md`)
+  }
+}
+for (const c of [...documentedCodes].sort()) {
+  if (!thrownCodes.has(c)) {
+    errors.push(`errors.md stale ${c}: documented but no source throws it`)
+  }
+}
+
 let total = 0
 const parts = []
 for (const kind of [...definedByKind.keys()].sort()) {
@@ -172,6 +226,7 @@ for (const kind of [...definedByKind.keys()].sort()) {
 console.log(`spec IDs defined: ${total} (${parts.join(' ')})`)
 console.log(`individual references checked: ${individual.size}; range references: ${rangeRefs.length}`)
 console.log(`relative links checked: ${linkCount}`)
+console.log(`error codes: ${thrownCodes.size} thrown, ${documentedCodes.size} documented`)
 
 if (errors.length) {
   console.error(`\n${errors.length} error(s):`)

--- a/spec/decisions/ADR-17-decoder-covers-one-program.md
+++ b/spec/decisions/ADR-17-decoder-covers-one-program.md
@@ -1,0 +1,81 @@
+# ADR-17 — An instruction decoder covers one program/ABI
+
+Status: Accepted
+
+## Context
+
+A Solana instruction is identified by a discriminator — the leading bytes of its data.
+The width is a property of the program, not the instruction: Anchor programs use an
+8-byte discriminator derived as `sha256("global:<name>")`, native/SPL programs a single
+byte. Crucially the derivation is **program-independent** — every Anchor `swap` shares
+the same 8-byte discriminator regardless of which program emitted it.
+
+The portal's instruction request carries the discriminator in a width-tagged field
+(`d1`/`d2`/`d4`/`d8`). Two constraints hold on the wire, both confirmed against a live
+portal: a single request MAY NOT set more than one width (`400`, "filters can't be
+specified simultaneously"); and the `instructions` array ORs across its elements, so
+multiple widths are expressed as multiple elements. There is no `d0` field — the portal
+rejects it as unknown — though the SDK's request type and the ABI-instruction type both
+declared one, a dead, `400`-triggering footgun.
+
+The reference decoder mishandled this on both sides. It collapsed all widths to the
+first non-empty one through an `else if` chain, so a decoder carrying mixed widths
+silently under-fetched. And its local re-check matched the program-id list as a whole
+and then the discriminator, so two instructions sharing a discriminator — two Anchor
+programs each with a `swap` — both decoded the *same* raw instruction, emitting it under
+both output keys with the wrong codec and account layout. The generator compounded it:
+same-range programs were merged into one decoder, manufacturing exactly this collision.
+
+The array in `programId` is not the cause. Its legitimate use is several **deployments
+of one program** (Token / Token-2022, a redeployed address) sharing one ABI; the
+program-independent discriminator identifies the instruction correctly across all of
+them.
+
+## Decision
+
+A decoder covers a single program/ABI. From that, one width and mutually distinct
+discriminators follow, and the decoder enforces both at construction, refusing with a
+coded configuration error (E0003, per ADR-4) when:
+
+- discriminators span more than one width (the portal forbids it, and mixed widths mean
+  unrelated programs were combined);
+- two instructions share a discriminator (they would decode each other's data);
+- any instruction carries no discriminator (with none it matches every instruction of the
+  program and decodes foreign data under its key), or more than one (an instruction is
+  identified by exactly one — several are a malformed ABI entry).
+
+`programId` stays an array — for the multi-deployment case above, emitted as one
+instruction request of the single width over all addresses. The dead `d0` field is
+removed from the wire request type and the ABI-instruction type. The `sqd init`
+generator groups by program identity (the reference-deployment address, not the display
+name) and range, so it emits one decoder per (program, range) and never merges distinct
+programs — including two whose names normalise to the same identifier.
+
+## Alternatives considered
+
+*Accommodate mixed widths* by emitting one request per width and letting both streams
+arrive — rejected. It treats the symptom (under-fetch) and leaves the disease: within
+one decoder, mixed widths still mean unrelated programs, cross-width prefix overlap and
+shared-name discriminators make the decode ambiguous no matter what is fetched. The
+sound unit is one decoder per program.
+
+*Keep `d0` for forward compatibility* — rejected. The portal returns `400` on it today;
+a field that cannot be sent is a trap, not a reserve.
+
+## Consequences
+
+The mixed-program decoders the generator itself could produce — previously a silent
+corruption — now fail loudly at startup (REQ-2, ADR-9's fail-at-startup posture). The
+Token / Token-2022 multi-deployment configuration remains a single decoder. IB-8 no
+longer lists `d0`, and IB-50 registers E0003.
+
+INV-24 is **not** mechanically enforced by this decision. `programId` is decoder-level,
+so nothing binds an instruction definition to the program it was generated from; the
+guards reject only what is visible in the discriminator set, which is a proxy, not a
+proof. A decoder over `[JUP, RAY]` with `{ jupSwap: jupiter.swap, rayDeposit:
+raydium.deposit }` passes — one width, distinct discriminators — yet Raydium's on-chain
+`swap` matches `jupSwap`'s discriminator and decodes under Jupiter's codec. The
+collisions that *are* caught are the likely ones (two programs tracked for the same
+instruction name derive the same discriminator), so the guard covers the accident this
+ADR came from; the general case stays the caller's contract. Closing it means binding
+`programId` per instruction — an API change, tracked as GAP-36.


### PR DESCRIPTION
## Summary

- **A Solana instruction decoder now covers exactly one program/ABI.** Discriminators are program-independent (Anchor derives them as `sha256("global:<name>")`), so two programs with a same-named instruction share a discriminator. The decoder matched the whole `programId` list and then the discriminator, so one program's instruction was decoded under another program's key — silent cross-decoding into the wrong output. It also fetched only the first discriminator width present, and carried a dead `d0` field the portal rejects with a `400`.
- The decoder enforces the invariant at construction with a coded error (**E0003**): it rejects mixed discriminator widths, two instructions sharing a discriminator, and empty or discriminator-less instruction sets. `programId` stays an array for the legitimate case — several addresses covered by *one* ABI (Token / Token-2022). `d0` is removed from the wire request type. `DecodedInstruction.programId`, typed but never assigned, is now populated: with a multi-address decoder it is the field that tells deployments apart.
- **The `sqd init` generator no longer merges different programs into one decoder** — it grouped same-range programs together, manufacturing exactly the config now rejected. It groups by `(program, range)`; several addresses of one program stay together in its `programId` array.
- **The generator's table names now come from one derivation.** The insert targets, the Drizzle schema and the ClickHouse DDL each built them independently and disagreed whenever snake-casing the camelCase identifier differed from snake-casing the display name: a program named `Raydium AMM v4` inserted into `raydium_ammv_4_swap` while the DDL created `raydium_amm_v4_swap` and Postgres exported `raydiumAmmV4SwapTable` against the imported `raydiumAmmv4SwapTable` — the generated project neither compiled nor wrote anywhere. Pre-existing on `main`; surfaced by the grouping change and fixed here.
- Spec: **ADR-17** records the decision, IB-50 registers E0003, IB-8 is corrected (the wire has no `d0`), and **GAP-2 leaves the register** per the resolved-gaps-live-in-ADRs convention.

Portal behavior was verified against a live portal: a single instruction request rejects more than one width (`400`), the `instructions` array ORs across elements, and `d0` is an unknown field.

### Known limitation — GAP-36

The guards are a proxy, not a proof. `programId` is decoder-level, so nothing binds an instruction definition to the program it was generated from, and the checks reject only collisions visible in the discriminator set. A decoder over `[JUP, RAY]` with `{ jupSwap: jupiter.swap, rayDeposit: raydium.deposit }` passes — one width, distinct discriminators — yet Raydium's on-chain `swap` matches `jupSwap` and decodes under Jupiter's codec. The collisions that *are* caught are the likely ones (two programs tracked for the same instruction name derive the same discriminator), so the guard covers the accident this PR came from; the general case stays the caller's contract. Closing it means binding `programId` per instruction — an API change, registered as **GAP-36**, not attempted here.

`docs/examples/solana/02.swaps.example.ts` was one live instance: the Meteora DLMM decoder carried `meteoraDamm.programId`, and since DAMM and DLMM both define `swap` with `d8 0xf8c69e91e17587c8` over two `u64`s, DAMM's swaps decoded cleanly under DLMM's account layout. Fixed; it is the shape GAP-36 describes, which E0003 cannot catch.

## Coverage

Measured on `packages/pipes` (base `main` vs head), integration suites included; a pre-existing broken WIP suite (`src/targets/delta-db`) was excluded on both sides.

| Module | Stmts | Δ | Branch | Δ |
|--------|-------|---|--------|---|
| **All files** | 85.8% | +0.4 | 86.7% | +0.3 |
| src/solana | 88.1% | +11.1 | 75.7% | +14.1 |

The `src/solana` directory total is held down by unchanged files (`index.ts` at 0%, `solana-query-builder.ts` at 77.9%). The file this PR changes, `solana-instruction-decoder.ts`, goes **64.1% → 86.9%**.

`packages/pipes-cli` is not in the table — it has no coverage baseline in this repo — but the generator changes are covered by the suites below.

## Test plan

- `packages/pipes` — `solana-instruction-decoder.test.ts` (12):
  - positive: one ABI across two addresses decodes in a single instruction request (asserts request body: one element, `d1: ['0x03']`, both program ids) and reports the emitting `programId` per record;
  - guards: mixed widths / shared discriminator / no discriminators / multiple widths on one instruction each throw `InstructionDecoderConfigurationError` (E0003);
  - the discriminator-less guard names the offending instructions — it is ordered ahead of the empty-set message, which names nothing;
  - existing transform + decode-error-hook tests still pass.
- `packages/pipes-cli` — `transformer.test.ts` (9): different programs get separate decoders even at the same range; same-named instructions stay in separate per-program decoders (no cross-decode).
- `packages/pipes-cli` — `naming.test.ts` (3, new): insert targets, Drizzle schema and ClickHouse DDL agree on table names for a digit-bearing program name; programs whose names normalize alike keep separate tables; the per-range decoders of one program share one table. Two of the three fail against the pre-fix tree.
- `svm-transformer-builder.test.ts` snapshot unchanged (single-program project still names its decoder `custom`).
- Full suites green: 666 tests in `packages/pipes`, 299 in `packages/pipes-cli`.
- `node spec/check-spec.mjs` — 0 dangling references, 0 broken links, 47/47 error codes in sync. The check now discovers `errors.ts` sources by walking `packages/`, rather than from a hardcoded roster that failed open on a new target.
- Typecheck (`tsc --noEmit`) and Biome clean on both packages and on `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
