### PR TITLE
refactor(parquet): structurally enforced engine seam with engine-owned encoding options

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -474,3 +474,15 @@ furthest block a file could consistently cover from for the resume cursor, it is
 that block and logged as a warning. The usual cause is an edit to the configured query ranges
 (a gap the recorded start referred to no longer exists), and clamping keeps the blocks after the
 cursor claimed by a file.
+
+### E2320 · Engine output is not a Parquet file
+
+A segment writer engine (`settings.engine`) finished a segment file that fails the Parquet
+magic-bytes check — the file does not start and end with `PAR1`, or is smaller than any valid
+Parquet file. The target refuses to publish it at the checkpoint, before the file gets a
+published name, so downstream readers never see it and the run is fully recoverable (the cursor
+never advanced past the affected rows).
+
+**Fix** — the engine implementation is broken: it must write a complete Parquet file (including
+the footer) to the temp path it was given before resolving `finish()`. The built-in
+`parquetjsEngine` cannot produce this error.

--- a/docs/examples/evm/17.parquet.example.ts
+++ b/docs/examples/evm/17.parquet.example.ts
@@ -12,8 +12,8 @@
  *     already-finalized range, so every row is written immediately; on a live `from: 'latest'`
  *     range the unfinalized tail is held in memory until it finalizes.
  *   - **Constant memory.** Rows stream to a temp file that rotates by byte size
- *     (`rollover.maxBytes`), so a multi-GB backfill never lands wholly in RAM. `rowGroupSize`
- *     bounds the writer's in-memory buffer.
+ *     (`rollover.maxBytes`), so a multi-GB backfill never lands wholly in RAM. The engine's
+ *     `rowGroupSize` factory option bounds the writer's in-memory buffer.
  *   - **Crash-safe.** A durable cursor (`<OUT>/_sqd_parquet_state.json`) advances only at a
  *     checkpoint; on restart, any file above the cursor is dropped and re-fetched.
  *   - **Coverage you can read off the filename.** `<from>-<to>` is the window the file covers,
@@ -41,7 +41,7 @@
  */
 
 import { commonAbis, evmEventDecoder, evmPortalStream } from '@subsquid/pipes/evm'
-import { parquetTarget } from '@subsquid/pipes/targets/parquet'
+import { parquetTarget, parquetjsEngine } from '@subsquid/pipes/targets/parquet'
 
 const OUT = process.env['PARQUET_OUT'] ?? './parquet-out'
 
@@ -102,8 +102,10 @@ async function main() {
         // Small cap so the example rotates into several files instead of one big one. Production
         // defaults to 128 MiB. `maxBytes` is a soft cap, checked at each batch boundary.
         rollover: { maxBytes: 8 * 1024 * 1024 },
-        // SNAPPY (the default) is a good speed/ratio tradeoff; GZIP / BROTLI compress harder.
-        compression: 'SNAPPY',
+        // Encoding options belong to the engine (this is the default engine, spelled out to
+        // show where they go). SNAPPY (the default) is a good speed/ratio tradeoff; GZIP /
+        // BROTLI compress harder. `rowGroupSize` (default 100k rows) bounds staging memory.
+        engine: parquetjsEngine({ compression: 'SNAPPY' }),
       },
       onData: ({ store, data, ctx }) => {
         ctx.logger.debug(`batch: ${data.transfers.length} transfers, ${data.approvals.length} approvals`)

--- a/packages/pipes/src/targets/parquet/custom-engine.test.ts
+++ b/packages/pipes/src/targets/parquet/custom-engine.test.ts
@@ -9,52 +9,65 @@ import { type MockPortal, type MockResponse, blockDecoder, mockPortal } from '~/
 
 import type { ParquetEngine } from './engine.js'
 import { parquetTarget } from './parquet-target.js'
-import { type SegmentWriter, finalizeSegmentFile, nextTmpPath } from './segment.js'
 
 /**
- * A minimal third-party engine built ONLY from the public extension surface: it buffers rows
- * in memory and publishes them as JSON through the shared segment toolkit. (A real engine
- * must write actual Parquet — JSON keeps this test dependency-free while still exercising
- * coverage naming, fsync, collision and recovery semantics via finalizeSegmentFile.)
+ * A minimal third-party engine built ONLY from the public extension surface: it buffers rows in
+ * memory and writes them as JSON wrapped in the Parquet magic bytes at the target-assigned temp
+ * path. (A real engine must write actual Parquet — the magic-byte wrapper keeps this test
+ * dependency-free while passing the target's output verification, so it still exercises
+ * target-owned naming, publication and cursor persistence end to end.)
  */
 function jsonEngine(calls: string[]): ParquetEngine {
   return {
     name: 'json-test',
     table(table, context) {
-      calls.push(`table:${table.table}:rowGroupSize=${context.rowGroupSize}:codec=${context.codec}`)
+      calls.push(`table:${table.table}:rowGroupSize=${context.rowGroupSize}:compression=${context.defaultCompression}`)
 
       return {
-        createSegment(): SegmentWriter {
+        createSegment(tmpPath) {
           const rows: Record<string, unknown>[] = []
-          const tmpPath = nextTmpPath(context.dir)
 
           return {
-            get isOpen() {
-              return rows.length > 0
-            },
-            get rowCount() {
-              return rows.length
-            },
-            async appendRow(row) {
-              rows.push(row)
+            async append(batch) {
+              rows.push(...batch)
             },
             async size() {
               return JSON.stringify(rows).length
             },
-            async publish(range) {
-              // A zero-row publish is part of the contract (tail closing) and still writes a file.
-              await writeFile(tmpPath, JSON.stringify(rows))
-
-              return finalizeSegmentFile({
-                dir: context.dir,
-                tmpPath,
-                rows: rows.length,
-                range,
-              })
+            async finish() {
+              // A zero-row finish is part of the contract (tail closing) and still writes a file.
+              await writeFile(tmpPath, `PAR1${JSON.stringify(rows)}PAR1`)
             },
-            async discard() {
+            async abort() {
               rows.length = 0
             },
+          }
+        },
+      }
+    },
+  }
+}
+
+/** An engine that ignores the output contract: its finished file is not Parquet. */
+function brokenEngine(): ParquetEngine {
+  return {
+    name: 'broken-test',
+    table() {
+      return {
+        createSegment(tmpPath) {
+          const rows: Record<string, unknown>[] = []
+
+          return {
+            async append(batch) {
+              rows.push(...batch)
+            },
+            async size() {
+              return JSON.stringify(rows).length
+            },
+            async finish() {
+              await writeFile(tmpPath, JSON.stringify(rows))
+            },
+            async abort() {},
           }
         },
       }
@@ -108,15 +121,17 @@ describe('parquetTarget with a custom engine', () => {
     )
 
     // table() received the declared table plus resolved defaults, once, at construction.
-    expect(calls).toEqual(['table:blocks:rowGroupSize=100000:codec=SNAPPY'])
+    expect(calls).toEqual(['table:blocks:rowGroupSize=100000:compression=SNAPPY'])
 
-    // Only the finalized rows (1-3) published; the file is named for the coverage window the
-    // store passed to publish() — from the configured start (0) to the finalized boundary (3).
+    // Only the finalized rows (1-3) published; the file is named by the target for the coverage
+    // window — from the configured start (0) to the finalized boundary (3). The engine never saw
+    // the window or chose the name.
     const files = (await readdir(path.join(dir, 'blocks'))).sort()
     expect(files).toEqual(['000000000000-000000000003.parquet'])
 
     // Rows arrived in the engine-neutral plain shape, in order.
-    const content = JSON.parse(await readFile(path.join(dir, 'blocks', files[0]!), 'utf8'))
+    const raw = await readFile(path.join(dir, 'blocks', files[0]!), 'utf8')
+    const content = JSON.parse(raw.slice(4, -4))
     expect(content).toEqual([
       { blockNumber: 1, hash: '0x1' },
       { blockNumber: 2, hash: '0x2' },
@@ -126,5 +141,30 @@ describe('parquetTarget with a custom engine', () => {
     // The checkpoint that published the segment also persisted the cursor.
     const stateFiles = (await readdir(dir)).filter((f) => f.startsWith('_sqd_parquet_state.'))
     expect(stateFiles).toHaveLength(1)
+  })
+
+  it('refuses to publish an engine output that is not a Parquet file', async () => {
+    portal = await mockPortal([blocksResponse([1, 2, 3], 3)])
+
+    await expect(
+      evmPortalStream({ id: 'test', portal: portal.url, outputs: blockDecoder({ from: 0, to: 3 }) }).pipeTo(
+        parquetTarget({
+          dir,
+          tables: [{ table: 'blocks', schema: { blockNumber: { type: 'INT64' } } }],
+          settings: { engine: brokenEngine() },
+          onData: ({ store, data }) => {
+            store.insert(
+              'blocks',
+              data.map((b) => ({ blockNumber: b.number })),
+            )
+          },
+        }),
+      ),
+    ).rejects.toThrowError(/Parquet magic bytes/)
+
+    // Nothing was published, the temp file was cleaned up, and no cursor was persisted —
+    // the run is fully recoverable.
+    expect(await readdir(path.join(dir, 'blocks'))).toEqual([])
+    expect((await readdir(dir)).filter((f) => f.startsWith('_sqd_parquet_state.'))).toEqual([])
   })
 })

--- a/packages/pipes/src/targets/parquet/custom-engine.test.ts
+++ b/packages/pipes/src/targets/parquet/custom-engine.test.ts
@@ -1,7 +1,8 @@
-import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
+import { ParquetReader, ParquetSchema, ParquetWriter } from '@dsnp/parquetjs'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { evmPortalStream } from '~/evm/index.js'
@@ -11,17 +12,25 @@ import type { ParquetEngine } from './engine.js'
 import { parquetTarget } from './parquet-target.js'
 
 /**
- * A minimal third-party engine built ONLY from the public extension surface: it buffers rows in
- * memory and writes them as JSON wrapped in the Parquet magic bytes at the target-assigned temp
- * path. (A real engine must write actual Parquet — the magic-byte wrapper keeps this test
- * dependency-free while passing the target's output verification, so it still exercises
- * target-owned naming, publication and cursor persistence end to end.)
+ * A minimal third-party engine built ONLY from the SDK's public extension surface plus a
+ * Parquet library of its own choosing (`@dsnp/parquetjs` used directly here, the way an
+ * external engine would use its native writer). It buffers rows in memory and writes a real
+ * Parquet file at the target-assigned temp path on `finish()` — so the published output is
+ * readable by actual Parquet readers and passes the target's envelope verification honestly.
+ * Flat leaf schemas only; that is all this test needs.
  */
-function jsonEngine(calls: string[]): ParquetEngine {
+function tinyParquetEngine(calls: string[]): ParquetEngine {
   return {
-    name: 'json-test',
+    name: 'tiny-test',
     table(table) {
       calls.push(`table:${table.table}`)
+      const schema = new ParquetSchema(
+        // Flat leaf columns only (see the engine doc) — the SDK leaf names used here (INT64,
+        // UTF8) are also valid parquetjs type names.
+        Object.fromEntries(
+          Object.entries(table.schema).map(([name, column]) => [name, { type: column.type as 'INT64' | 'UTF8' }]),
+        ),
+      )
 
       return {
         createSegment(tmpPath) {
@@ -32,11 +41,13 @@ function jsonEngine(calls: string[]): ParquetEngine {
               rows.push(...batch)
             },
             async size() {
-              return JSON.stringify(rows).length
+              // An estimate is fine for rotation feedback — this engine stages in memory.
+              return rows.length * 64
             },
             async finish() {
-              // A zero-row finish is part of the contract (tail closing) and still writes a file.
-              await writeFile(tmpPath, `PAR1${JSON.stringify(rows)}PAR1`)
+              const writer = await ParquetWriter.openFile(schema, tmpPath)
+              for (const row of rows) await writer.appendRow(row)
+              await writer.close()
             },
             async abort() {
               rows.length = 0
@@ -48,8 +59,12 @@ function jsonEngine(calls: string[]): ParquetEngine {
   }
 }
 
-/** An engine that ignores the output contract: its finished file is not Parquet. */
-function brokenEngine(): ParquetEngine {
+/**
+ * An engine that ignores the output contract: its finished file is arbitrary JSON wrapped in
+ * the Parquet magic bytes — the exact spoof the envelope check's footer-length validation
+ * exists to refuse.
+ */
+function magicWrappedJsonEngine(): ParquetEngine {
   return {
     name: 'broken-test',
     table() {
@@ -65,7 +80,7 @@ function brokenEngine(): ParquetEngine {
               return JSON.stringify(rows).length
             },
             async finish() {
-              await writeFile(tmpPath, JSON.stringify(rows))
+              await writeFile(tmpPath, `PAR1${JSON.stringify(rows)}PAR1`)
             },
             async abort() {},
           }
@@ -73,6 +88,17 @@ function brokenEngine(): ParquetEngine {
       }
     },
   }
+}
+
+async function readAllRows(file: string): Promise<Record<string, unknown>[]> {
+  const reader = await ParquetReader.openFile(file)
+  const cursor = reader.getCursor()
+  const rows: Record<string, unknown>[] = []
+  let row: Record<string, unknown> | null
+  while ((row = (await cursor.next()) as Record<string, unknown> | null)) rows.push(row)
+  await reader.close()
+
+  return rows
 }
 
 function blocksResponse(numbers: number[], finalized?: number): MockResponse {
@@ -110,7 +136,7 @@ describe('parquetTarget with a custom engine', () => {
             schema: { blockNumber: { type: 'INT64' }, hash: { type: 'UTF8' } },
           },
         ],
-        settings: { engine: jsonEngine(calls) },
+        settings: { engine: tinyParquetEngine(calls) },
         onData: ({ store, data }) => {
           store.insert(
             'blocks',
@@ -130,13 +156,13 @@ describe('parquetTarget with a custom engine', () => {
     const files = (await readdir(path.join(dir, 'blocks'))).sort()
     expect(files).toEqual(['000000000000-000000000003.parquet'])
 
-    // Rows arrived in the engine-neutral plain shape, in order.
-    const raw = await readFile(path.join(dir, 'blocks', files[0]!), 'utf8')
-    const content = JSON.parse(raw.slice(4, -4))
-    expect(content).toEqual([
-      { blockNumber: 1, hash: '0x1' },
-      { blockNumber: 2, hash: '0x2' },
-      { blockNumber: 3, hash: '0x3' },
+    // The published file is real Parquet, readable by an actual reader, with the rows the
+    // engine received — in order, in the engine-neutral plain shape.
+    const rows = await readAllRows(path.join(dir, 'blocks', files[0]!))
+    expect(rows.map((r) => [r['blockNumber'], r['hash']])).toEqual([
+      [1n, '0x1'],
+      [2n, '0x2'],
+      [3n, '0x3'],
     ])
 
     // The checkpoint that published the segment also persisted the cursor.
@@ -144,7 +170,7 @@ describe('parquetTarget with a custom engine', () => {
     expect(stateFiles).toHaveLength(1)
   })
 
-  it('refuses to publish an engine output that is not a Parquet file', async () => {
+  it('refuses an engine output that merely wraps non-Parquet bytes in the magic', async () => {
     portal = await mockPortal([blocksResponse([1, 2, 3], 3)])
 
     await expect(
@@ -152,7 +178,7 @@ describe('parquetTarget with a custom engine', () => {
         parquetTarget({
           dir,
           tables: [{ table: 'blocks', schema: { blockNumber: { type: 'INT64' } } }],
-          settings: { engine: brokenEngine() },
+          settings: { engine: magicWrappedJsonEngine() },
           onData: ({ store, data }) => {
             store.insert(
               'blocks',
@@ -161,7 +187,7 @@ describe('parquetTarget with a custom engine', () => {
           },
         }),
       ),
-    ).rejects.toThrowError(/Parquet magic bytes/)
+    ).rejects.toThrowError(/complete Parquet files/)
 
     // Nothing was published, the temp file was cleaned up, and no cursor was persisted —
     // the run is fully recoverable.

--- a/packages/pipes/src/targets/parquet/custom-engine.test.ts
+++ b/packages/pipes/src/targets/parquet/custom-engine.test.ts
@@ -20,8 +20,8 @@ import { parquetTarget } from './parquet-target.js'
 function jsonEngine(calls: string[]): ParquetEngine {
   return {
     name: 'json-test',
-    table(table, context) {
-      calls.push(`table:${table.table}:rowGroupSize=${context.rowGroupSize}:compression=${context.defaultCompression}`)
+    table(table) {
+      calls.push(`table:${table.table}`)
 
       return {
         createSegment(tmpPath) {
@@ -120,8 +120,9 @@ describe('parquetTarget with a custom engine', () => {
       }),
     )
 
-    // table() received the declared table plus resolved defaults, once, at construction.
-    expect(calls).toEqual(['table:blocks:rowGroupSize=100000:compression=SNAPPY'])
+    // table() received the declared table, once, at construction. Encoding options are the
+    // engine's own business (its factory), so no context travels across the seam.
+    expect(calls).toEqual(['table:blocks'])
 
     // Only the finalized rows (1-3) published; the file is named by the target for the coverage
     // window — from the configured start (0) to the finalized boundary (3). The engine never saw

--- a/packages/pipes/src/targets/parquet/engine.ts
+++ b/packages/pipes/src/targets/parquet/engine.ts
@@ -1,43 +1,56 @@
 import type { Codec, ParquetTable } from './schema.js'
 import type { SegmentWriter } from './segment.js'
 
-/** Resolved per-table write settings every engine receives. */
+/**
+ * Resolved per-table write settings every engine receives. Both are *encoding requests*, not
+ * target invariants: the target's correctness (naming, durability, recovery) never depends on
+ * them. An engine should honor them at least approximately, and must refuse (throw from
+ * `table()`) a declaration it cannot honor rather than silently ignore it.
+ */
 export type ParquetTableContext = {
-  /** The table's output directory (`<dir>/<table>`), created by the state layer before writes. */
-  dir: string
-  /** Rows per row group. */
+  /**
+   * Rows per row group — a row count, not bytes. Writer-side it is the in-memory flush
+   * threshold (how many rows are buffered before a row group is encoded to disk), reader-side
+   * the pruning granularity. It is how users bound an engine's staging memory.
+   */
   rowGroupSize: number
-  /** File-level default compression codec. */
-  codec: Codec
+  /**
+   * Compression codec for columns that do not declare their own — the resolved
+   * `settings.compression` default. Individual columns may override it via
+   * `column.compression` in the declared schema; an engine limited to one file-level codec
+   * (e.g. DuckDB's COPY) must throw from `table()` when a column declares an override.
+   */
+  defaultCompression: Codec
 }
 
 /** Per-table handle created once at target startup; creates one writer per segment file. */
 export interface ParquetTableWriter {
-  /** Creates the writer for this table's NEXT segment file. Called once per file rotation. */
-  createSegment(): SegmentWriter
+  /**
+   * Creates the writer for one segment file, writing to `tmpPath` — a target-chosen temp path
+   * inside the table's output directory. Called once per file rotation. A segment may finish
+   * with **zero rows appended** (tail closing claims a window the table produced nothing in),
+   * so `finish()` must produce a valid schema-only Parquet file even if `append` never ran.
+   */
+  createSegment(tmpPath: string): SegmentWriter
 }
 
 /**
  * A pluggable segment-writer engine for `parquetTarget`.
  *
  * The target owns everything around the writer — staging, finalization buffering, rotation
- * triggers, coverage tracking, checkpointing, crash recovery, fork handling and metrics. An
- * engine owns exactly one thing: turning finalized rows into a Parquet file on disk. The SDK's
- * declared schema model ({@link ParquetTable}) plus the plain-JS row contract (see the
- * `ParquetLeafType` JSDoc) is the complete input; engines translate both to their native
- * representation internally, so there is no engine-specific schema mechanism at the API surface.
+ * triggers, coverage tracking, temp-file naming, publication (fsync → collision check → atomic
+ * rename → dir fsync), checkpointing, crash recovery, fork handling and metrics. An engine owns
+ * exactly one thing: writing finalized rows into a Parquet file at the temp path it is given.
+ * It never names, renames, fsyncs or deletes files, and it never sees a block number or
+ * coverage window — published files are named for the window the pipe processed, which only
+ * the target knows — so naming, durability and recovery semantics cannot vary per engine. The
+ * target also verifies the finished file's Parquet magic bytes before publishing it, so a
+ * non-Parquet output fails loudly at the checkpoint instead of reaching downstream readers.
  *
- * Implementations MUST:
- * - produce real Parquet files — downstream readers rely on it;
- * - name segment temp files via `nextTmpPath` (startup recovery deletes `.tmp-*` files);
- * - publish through `finalizeSegmentFile` (fsync → collision check → atomic rename → dir
- *   fsync), the durability tail that checkpoints depend on, named for the coverage window the
- *   store passes to `publish(range)` — never for the rows' own block numbers;
- * - publish a valid (schema-only) Parquet file even with **zero appended rows** — tail closing
- *   claims a table's final window with an empty segment;
- * - keep `table()` synchronous and cheap;
- * - accept rows in the plain-JS shape (`LIST` cells are plain arrays, `STRUCT` cells plain
- *   objects) — any library-specific row reshaping happens inside the engine.
+ * The SDK's declared schema model ({@link ParquetTable}) plus the plain-JS row contract (see
+ * the `ParquetLeafType` JSDoc) is the complete input: `LIST` cells arrive as plain arrays,
+ * `STRUCT` cells as plain objects, and any library-specific schema or row reshaping happens
+ * inside the engine — there is no engine-specific schema mechanism at the API surface.
  */
 export interface ParquetEngine {
   /** Engine name, used in logs and error messages. */

--- a/packages/pipes/src/targets/parquet/engine.ts
+++ b/packages/pipes/src/targets/parquet/engine.ts
@@ -1,27 +1,5 @@
-import type { Codec, ParquetTable } from './schema.js'
+import type { ParquetTable } from './schema.js'
 import type { SegmentWriter } from './segment.js'
-
-/**
- * Resolved per-table write settings every engine receives. Both are *encoding requests*, not
- * target invariants: the target's correctness (naming, durability, recovery) never depends on
- * them. An engine should honor them at least approximately, and must refuse (throw from
- * `table()`) a declaration it cannot honor rather than silently ignore it.
- */
-export type ParquetTableContext = {
-  /**
-   * Rows per row group — a row count, not bytes. Writer-side it is the in-memory flush
-   * threshold (how many rows are buffered before a row group is encoded to disk), reader-side
-   * the pruning granularity. It is how users bound an engine's staging memory.
-   */
-  rowGroupSize: number
-  /**
-   * Compression codec for columns that do not declare their own — the resolved
-   * `settings.compression` default. Individual columns may override it via
-   * `column.compression` in the declared schema; an engine limited to one file-level codec
-   * (e.g. DuckDB's COPY) must throw from `table()` when a column declares an override.
-   */
-  defaultCompression: Codec
-}
 
 /** Per-table handle created once at target startup; creates one writer per segment file. */
 export interface ParquetTableWriter {
@@ -47,6 +25,14 @@ export interface ParquetTableWriter {
  * target also verifies the finished file's Parquet magic bytes before publishing it, so a
  * non-Parquet output fails loudly at the checkpoint instead of reaching downstream readers.
  *
+ * **Encoding options belong to the engine, not the target.** Row-group size, compression and
+ * any backend tuning are declared by each engine's own factory (`parquetjsEngine({...})`,
+ * `duckdbEngine({...})`) and typed to what that engine can actually do — the target neither
+ * consumes nor forwards them, so an engine can never be asked for an encoding it cannot
+ * honor. The one capability gate left is {@link table}: the declared schema may carry
+ * per-column `compression` overrides from the neutral model, and an engine that cannot honor
+ * a declaration must throw there rather than silently ignore it.
+ *
  * The SDK's declared schema model ({@link ParquetTable}) plus the plain-JS row contract (see
  * the `ParquetLeafType` JSDoc) is the complete input: `LIST` cells arrive as plain arrays,
  * `STRUCT` cells as plain objects, and any library-specific schema or row reshaping happens
@@ -58,7 +44,8 @@ export interface ParquetEngine {
   /**
    * Called once per declared table at target construction, after the model-level schema
    * validation. Validate engine capability limits here (throw `ParquetTargetError` for
-   * declarations this engine cannot honor) and return the table's segment-writer factory.
+   * declarations this engine cannot honor — e.g. per-column `compression` overrides on a
+   * backend with one file-level codec) and return the table's segment-writer factory.
    */
-  table(table: ParquetTable, context: ParquetTableContext): ParquetTableWriter
+  table(table: ParquetTable): ParquetTableWriter
 }

--- a/packages/pipes/src/targets/parquet/errors.ts
+++ b/packages/pipes/src/targets/parquet/errors.ts
@@ -56,4 +56,6 @@ export const PARQUET_ERROR_CODES = {
   // compile-time typed. (The duckdb per-column-compression check moved out with its engine,
   // see ADR-19; coverage naming makes zero-row segments legitimate, so no empty-segment code
   // exists either.)
+  /** An engine's finished segment file failed the Parquet magic-bytes check at publication. */
+  SEGMENT_NOT_PARQUET: 'E2320',
 } as const

--- a/packages/pipes/src/targets/parquet/index.ts
+++ b/packages/pipes/src/targets/parquet/index.ts
@@ -11,10 +11,4 @@ export {
   type ParquetLeafType,
   type ParquetTable,
 } from './schema.js'
-export {
-  type PublishedSegment,
-  type SegmentRange,
-  type SegmentWriter,
-  finalizeSegmentFile,
-  nextTmpPath,
-} from './segment.js'
+export { type PublishedSegment, type SegmentWriter } from './segment.js'

--- a/packages/pipes/src/targets/parquet/index.ts
+++ b/packages/pipes/src/targets/parquet/index.ts
@@ -1,8 +1,8 @@
-export type { ParquetEngine, ParquetTableContext, ParquetTableWriter } from './engine.js'
+export type { ParquetEngine, ParquetTableWriter } from './engine.js'
 export { PARQUET_ERROR_CODES, ParquetTargetError } from './errors.js'
 export { type AppendStat, ParquetStore, type RotationLimits } from './parquet-store.js'
 export { type ParquetRollover, type ParquetSettings, parquetTarget } from './parquet-target.js'
-export { parquetjsEngine } from './parquetjs/index.js'
+export { type ParquetjsEngineOptions, parquetjsEngine } from './parquetjs/index.js'
 export {
   type Codec,
   type ParquetColumn,

--- a/packages/pipes/src/targets/parquet/parquet-store.test.ts
+++ b/packages/pipes/src/targets/parquet/parquet-store.test.ts
@@ -39,9 +39,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [bytesTable],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       expect.assertions(1)
       try {
@@ -55,9 +53,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [BLOCKS_TABLE],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       expect.assertions(1)
       try {
@@ -71,9 +67,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [bytesTable],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       expect(() => store.insert('t', [{ blockNumber: 1n, raw: Buffer.from('deadbeef', 'hex') }])).not.toThrow()
     })
@@ -92,9 +86,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [stampsTable],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       expect(() =>
         store.insert('stamps', [
@@ -114,9 +106,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [stampsTable],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       // 19723.5: not whole days; -1: the library rejects negatives; 1704067200000: epoch millis
       // passed by mistake (would crash the int32 encoder at flush time); pre-1970 Date: the
@@ -136,9 +126,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [stampsTable],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       const circular: Record<string, unknown> = {}
       circular['self'] = circular
@@ -168,9 +156,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [nestedTable],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       expect(() =>
         store.insert('n', [
@@ -185,9 +171,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [nestedTable],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       // [row, expected message fragment]: scalar where a struct object is expected; missing
       // required nested field; non-array LIST; null element under a required element decl;
@@ -214,9 +198,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [nestedTable],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       // The writer shreds structs via `value[field]`, so Map/Set entries read as undefined:
       // required fields fail with a misleading "required but undefined" and optional fields
@@ -237,9 +219,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [nestedTable],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       // Both expose their fields to property access, so they write correctly — the STRUCT
       // check must not tighten to a prototype test that would reject them.
@@ -263,9 +243,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [BLOCKS_TABLE, other],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
 
       // `blocks` owes an earlier window (start 5) while this run resumes at 7; `other` was declared
@@ -286,9 +264,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [BLOCKS_TABLE],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
 
       store.seedCoverage({ blocks: value }, 7)
@@ -301,9 +277,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [BLOCKS_TABLE],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       store.seedCoverage(undefined, 0, [
         { from: 0, to: 1 },
@@ -327,9 +301,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [BLOCKS_TABLE],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       store.seedCoverage(undefined, 0)
       const stuck = { finalized: { number: 1, hash: '0x1' }, rollbackChain: [] }
@@ -359,9 +331,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [BLOCKS_TABLE, other],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       store.seedCoverage(undefined, 0)
 
@@ -383,9 +353,7 @@ describe('ParquetStore', () => {
       const store = new ParquetStore({
         dir,
         tables: [BLOCKS_TABLE],
-        rowGroupSize: 1,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 1 }),
       })
       store.insert('blocks', [{ blockNumber: 1, hash: '0x1', timestamp: 1 }])
       await store.flushBatch({ finalized: { number: 1, hash: '0x1' }, rollbackChain: [] })

--- a/packages/pipes/src/targets/parquet/parquet-store.ts
+++ b/packages/pipes/src/targets/parquet/parquet-store.ts
@@ -12,7 +12,6 @@ import {
 import type { ParquetEngine, ParquetTableWriter } from './engine.js'
 import { PARQUET_ERROR_CODES, ParquetTargetError } from './errors.js'
 import {
-  type Codec,
   type ParquetColumn,
   type ParquetColumns,
   type ParquetLeafType,
@@ -93,13 +92,7 @@ export class ParquetStore {
   // Per-cell type checking is a hot-path cost, so it only runs outside production.
   readonly #validateValues = process.env.NODE_ENV !== 'production'
 
-  constructor(options: {
-    dir: string
-    tables: ParquetTable[]
-    rowGroupSize: number
-    defaultCodec: Codec
-    engine: ParquetEngine
-  }) {
+  constructor(options: { dir: string; tables: ParquetTable[]; engine: ParquetEngine }) {
     this.#engineName = options.engine.name
     for (const table of options.tables) {
       const blockColumn = blockColumnOf(table)
@@ -110,10 +103,7 @@ export class ParquetStore {
         getBlockNumber,
         columns: table.schema,
         dir,
-        tableWriter: options.engine.table(table, {
-          rowGroupSize: options.rowGroupSize,
-          defaultCompression: options.defaultCodec,
-        }),
+        tableWriter: options.engine.table(table),
       })
       this.#buffers.set(table.table, finalizationBuffer<Row>({ getBlockNumber }))
     }

--- a/packages/pipes/src/targets/parquet/parquet-store.ts
+++ b/packages/pipes/src/targets/parquet/parquet-store.ts
@@ -1,3 +1,4 @@
+import { unlink } from 'node:fs/promises'
 import path from 'node:path'
 
 import {
@@ -18,7 +19,7 @@ import {
   type ParquetTable,
   blockColumnOf,
 } from './schema.js'
-import { type PublishedSegment, type SegmentWriter } from './segment.js'
+import { type PublishedSegment, type SegmentWriter, finalizeSegmentFile, nextTmpPath } from './segment.js'
 
 /** Per-table first block the next published file will cover, keyed by table name. */
 export type CoverageStarts = Record<string, number>
@@ -41,6 +42,17 @@ type TableConfig = {
   dir: string
   /** Creates this table's segment writers; engine-specific state lives behind it. */
   tableWriter: ParquetTableWriter
+}
+
+/**
+ * A table's currently-open segment: the engine's writer plus the bookkeeping the target owns —
+ * the temp path it assigned and the row count that drives rotation and the published-file
+ * stats. Engines never see or report any of these.
+ */
+type OpenSegment = {
+  writer: SegmentWriter
+  tmpPath: string
+  rows: number
 }
 
 /** Rotation thresholds checked at each batch boundary. */
@@ -70,7 +82,9 @@ export class ParquetStore {
   readonly #buffers = new Map<string, FinalizationBuffer<Row>>()
   readonly #staged = new Map<string, Row[]>()
   // The current open segment per table — at most one. Reset (published/discarded) at checkpoints.
-  readonly #writers = new Map<string, SegmentWriter>()
+  readonly #segments = new Map<string, OpenSegment>()
+  // For error messages in the publish tail.
+  readonly #engineName: string
   // First block each table's NEXT published file will claim to cover. Seeded by `seedCoverage`
   // and advanced only when that table actually publishes — see `publishAll`.
   readonly #coverageStart = new Map<string, number>()
@@ -86,6 +100,7 @@ export class ParquetStore {
     defaultCodec: Codec
     engine: ParquetEngine
   }) {
+    this.#engineName = options.engine.name
     for (const table of options.tables) {
       const blockColumn = blockColumnOf(table)
       const getBlockNumber = (row: Row): number => readBlockNumber(table.table, blockColumn, row)
@@ -96,9 +111,8 @@ export class ParquetStore {
         columns: table.schema,
         dir,
         tableWriter: options.engine.table(table, {
-          dir,
           rowGroupSize: options.rowGroupSize,
-          codec: options.defaultCodec,
+          defaultCompression: options.defaultCodec,
         }),
       })
       this.#buffers.set(table.table, finalizationBuffer<Row>({ getBlockNumber }))
@@ -147,10 +161,9 @@ export class ParquetStore {
       const released = buffer.push(staged, finalization)
 
       if (released.length > 0) {
-        const writer = this.#getOrCreateWriter(table, config)
-        for (const row of released) {
-          await writer.appendRow(row)
-        }
+        const segment = this.#getOrCreateSegment(table, config)
+        await segment.writer.append(released)
+        segment.rows += released.length
         stats.push({ table, rows: released.length })
       }
     }
@@ -162,9 +175,9 @@ export class ParquetStore {
 
   /** True if any open writer has reached the byte or row rotation threshold. */
   async shouldRotate(limits: RotationLimits): Promise<boolean> {
-    for (const writer of this.#writers.values()) {
-      if (limits.maxRows !== undefined && writer.rowCount >= limits.maxRows) return true
-      if ((await writer.size()) >= limits.maxBytes) return true
+    for (const segment of this.#segments.values()) {
+      if (limits.maxRows !== undefined && segment.rows >= limits.maxRows) return true
+      if ((await segment.writer.size()) >= limits.maxBytes) return true
     }
 
     return false
@@ -172,7 +185,7 @@ export class ParquetStore {
 
   /** Whether any segment writer is currently open (has buffered ≥1 finalized row on disk). */
   get hasOpenWriters(): boolean {
-    return this.#writers.size > 0
+    return this.#segments.size > 0
   }
 
   /**
@@ -295,7 +308,7 @@ export class ParquetStore {
    */
   async publishAll(to: number, options: { closeTails?: boolean; tables?: string[] } = {}): Promise<PublishedFile[]> {
     const published: PublishedFile[] = []
-    const tables = options.tables ?? (options.closeTails ? this.tablesOwingCoverage(to) : [...this.#writers.keys()])
+    const tables = options.tables ?? (options.closeTails ? this.tablesOwingCoverage(to) : [...this.#segments.keys()])
 
     for (const table of tables) {
       const from = this.#coverageStart.get(table)
@@ -308,16 +321,28 @@ export class ParquetStore {
       }
       if (from > to) continue
 
-      // Only tail-closing invents a writer for a table that has none; a plain checkpoint publishes
+      // Only tail-closing invents a segment for a table that has none; a plain checkpoint publishes
       // what is open and nothing else, so it never writes a zero-row file.
-      const open = this.#writers.get(table)
+      const open = this.#segments.get(table)
       if (!open && !options.closeTails) continue
 
       const config = this.#configs.get(table)!
-      const writer = open ?? this.#getOrCreateWriter(table, config)
+      const segment = open ?? this.#getOrCreateSegment(table, config)
 
-      published.push({ table, from, to, ...(await writer.publish({ from, to })) })
-      this.#writers.delete(table)
+      // The engine only completes the temp file; the publish tail — magic-bytes check, fsync,
+      // collision refusal, atomic rename to the coverage-window name, dir fsync — runs here, so
+      // naming and durability are engine-invariant.
+      await segment.writer.finish()
+      const file = await finalizeSegmentFile({
+        dir: config.dir,
+        tmpPath: segment.tmpPath,
+        rows: segment.rows,
+        range: { from, to },
+        engine: this.#engineName,
+      })
+
+      published.push({ table, from, to, ...file })
+      this.#segments.delete(table)
       this.#coverageStart.set(table, this.#nextQueriedBlock(to + 1))
     }
 
@@ -369,26 +394,30 @@ export class ParquetStore {
   }
 
   /**
-   * Best-effort teardown for the error path: discards (closes + deletes) every open segment's
-   * temp file. The discarded rows are finalized-but-not-checkpointed, so they regenerate from the
-   * portal on the next run since the cursor never advanced past them.
+   * Best-effort teardown for the error path: aborts every open segment's writer (releasing its
+   * resources) and deletes its temp file — file removal is target-owned, like naming. The
+   * discarded rows are finalized-but-not-checkpointed, so they regenerate from the portal on the
+   * next run since the cursor never advanced past them.
    */
   async close(): Promise<void> {
-    for (const writer of this.#writers.values()) {
-      await writer.discard()
+    for (const segment of this.#segments.values()) {
+      await segment.writer.abort().catch(() => {})
+      // Best-effort — the engine may never have created the file, or it may already be gone.
+      await unlink(segment.tmpPath).catch(() => {})
     }
-    this.#writers.clear()
+    this.#segments.clear()
     this.#staged.clear()
   }
 
-  #getOrCreateWriter(table: string, config: TableConfig): SegmentWriter {
-    let writer = this.#writers.get(table)
-    if (!writer) {
-      writer = config.tableWriter.createSegment()
-      this.#writers.set(table, writer)
+  #getOrCreateSegment(table: string, config: TableConfig): OpenSegment {
+    let segment = this.#segments.get(table)
+    if (!segment) {
+      const tmpPath = nextTmpPath(config.dir)
+      segment = { writer: config.tableWriter.createSegment(tmpPath), tmpPath, rows: 0 }
+      this.#segments.set(table, segment)
     }
 
-    return writer
+    return segment
   }
 }
 

--- a/packages/pipes/src/targets/parquet/parquet-target.test.ts
+++ b/packages/pipes/src/targets/parquet/parquet-target.test.ts
@@ -16,6 +16,7 @@ import { parquetTarget } from './parquet-target.js'
 import { parquetjsEngine } from './parquetjs/parquetjs-engine.js'
 import { ParquetSegmentWriter } from './parquetjs/parquetjs-writer.js'
 import type { ParquetTable } from './schema.js'
+import { finalizeSegmentFile } from './segment.js'
 
 // ---------------------------------------------------------------------------------------------
 // Helpers
@@ -1177,113 +1178,149 @@ describe('parquetTarget', () => {
   })
 
   describe('ParquetSegmentWriter', () => {
-    it('lazy-opens, tracks rowCount, and names the file for the coverage range it is given', async () => {
+    it('lazy-opens, grows the temp file, and finish() completes a readable Parquet file', async () => {
       const segDir = path.join(dir, 'seg')
       await mkdir(segDir, { recursive: true })
       const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
 
-      const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
-      expect(writer.isOpen).toBe(false)
+      const tmpPath = path.join(segDir, '.tmp-writer.parquet')
+      const writer = new ParquetSegmentWriter({ tmpPath, schema, rowGroupSize: 1 })
       expect(await writer.size()).toBe(0)
 
-      await writer.appendRow({ blockNumber: 5 })
-      await writer.appendRow({ blockNumber: 8 })
-      expect(writer.isOpen).toBe(true)
-      expect(writer.rowCount).toBe(2)
+      await writer.append([{ blockNumber: 5 }, { blockNumber: 8 }])
       expect(await writer.size()).toBeGreaterThan(0)
 
+      await writer.finish()
+      const reader = await ParquetReader.openFile(tmpPath)
+      expect(Number(reader.getRowCount())).toBe(2)
+      await reader.close()
+    })
+
+    it('finish() with no appended rows writes a real, schema-only file (tail closing)', async () => {
+      const segDir = path.join(dir, 'seg')
+      await mkdir(segDir, { recursive: true })
+      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
+
+      const tmpPath = path.join(segDir, '.tmp-empty.parquet')
+      const writer = new ParquetSegmentWriter({ tmpPath, schema, rowGroupSize: 1 })
+      await writer.finish()
+
+      const reader = await ParquetReader.openFile(tmpPath)
+      expect(Number(reader.getRowCount())).toBe(0)
+      expect(reader.getSchema().fieldList.length).toBe(1)
+      await reader.close()
+    })
+
+    it('abort() releases the stream and is safe to call twice', async () => {
+      // Exercises the error-path fd cleanup: destroy the owned stream, idempotently, with no throw.
+      // Deleting the temp file is the target's job, not the writer's.
+      const segDir = path.join(dir, 'seg')
+      await mkdir(segDir, { recursive: true })
+      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
+
+      const writer = new ParquetSegmentWriter({
+        tmpPath: path.join(segDir, '.tmp-abort.parquet'),
+        schema,
+        rowGroupSize: 1,
+      })
+      await writer.append([{ blockNumber: 1 }])
+      await writer.abort()
+      await writer.abort()
+    })
+  })
+
+  describe('finalizeSegmentFile', () => {
+    /** Writes a finished single-column segment at `tmpPath` via the parquetjs writer. */
+    async function writeSegment(tmpPath: string, blockNumbers: number[]): Promise<void> {
+      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
+      const writer = new ParquetSegmentWriter({ tmpPath, schema, rowGroupSize: 1 })
+      if (blockNumbers.length > 0) await writer.append(blockNumbers.map((blockNumber) => ({ blockNumber })))
+      await writer.finish()
+    }
+
+    it('names the file for the coverage range, not the rows inside it', async () => {
+      const segDir = path.join(dir, 'seg')
+      await mkdir(segDir, { recursive: true })
+
       // Rows span 5–8, but the window covered is 2–10: the name follows the window.
-      const published = await writer.publish({ from: 2, to: 10 })
+      const tmpPath = path.join(segDir, '.tmp-pub.parquet')
+      await writeSegment(tmpPath, [5, 8])
+
+      const published = await finalizeSegmentFile({
+        dir: segDir,
+        tmpPath,
+        rows: 2,
+        range: { from: 2, to: 10 },
+        engine: 'test',
+      })
       expect(published.path.endsWith('000000000002-000000000010.parquet')).toBe(true)
       expect(published.rows).toBe(2)
       expect(published.bytes).toBeGreaterThan(0)
-    })
-
-    it('accepts rows keyed outside the window, since the name states coverage not content', async () => {
-      const segDir = path.join(dir, 'seg')
-      await mkdir(segDir, { recursive: true })
-      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
-
-      const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
-      // An aggregate stamped with its window's first block, emitted while covering a later window.
-      await writer.appendRow({ blockNumber: 1 })
-
-      const published = await writer.publish({ from: 6, to: 10 })
-      expect(published.path.endsWith('000000000006-000000000010.parquet')).toBe(true)
-      expect(published.rows).toBe(1)
+      expect((await readdir(segDir)).sort()).toEqual(['000000000002-000000000010.parquet'])
     })
 
     it('publishes a zero-row segment so a table can claim a window it produced nothing in', async () => {
       const segDir = path.join(dir, 'seg')
       await mkdir(segDir, { recursive: true })
-      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
 
-      const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
-      expect(writer.isOpen).toBe(false)
+      const tmpPath = path.join(segDir, '.tmp-zero.parquet')
+      await writeSegment(tmpPath, [])
 
-      const published = await writer.publish({ from: 2, to: 4 })
+      const published = await finalizeSegmentFile({
+        dir: segDir,
+        tmpPath,
+        rows: 0,
+        range: { from: 2, to: 4 },
+        engine: 'test',
+      })
       expect(published.path.endsWith('000000000002-000000000004.parquet')).toBe(true)
       expect(published.rows).toBe(0)
 
       // A real, readable Parquet file — schema and footer present, just no rows.
       const reader = await ParquetReader.openFile(published.path)
       expect(Number(reader.getRowCount())).toBe(0)
-      expect(reader.getSchema().fieldList.length).toBe(1)
       await reader.close()
     })
 
     it('refuses an inverted coverage range', async () => {
       const segDir = path.join(dir, 'seg')
       await mkdir(segDir, { recursive: true })
-      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
 
-      const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
-      await writer.appendRow({ blockNumber: 5 })
+      const tmpPath = path.join(segDir, '.tmp-inv.parquet')
+      await writeSegment(tmpPath, [5])
 
-      await expect(writer.publish({ from: 10, to: 4 })).rejects.toThrowError(/inverted coverage range/)
-      await writer.discard()
-      expect((await readdir(segDir)).filter((f) => f.startsWith('.tmp-'))).toEqual([])
+      await expect(
+        finalizeSegmentFile({ dir: segDir, tmpPath, rows: 1, range: { from: 10, to: 4 }, engine: 'test' }),
+      ).rejects.toThrowError(/inverted coverage range/)
     })
 
     it('refuses to overwrite an existing file (collision)', async () => {
       const segDir = path.join(dir, 'seg')
       await mkdir(segDir, { recursive: true })
-      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
 
-      const first = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
-      await first.appendRow({ blockNumber: 1 })
-      await first.publish({ from: 0, to: 1 })
+      const firstTmp = path.join(segDir, '.tmp-first.parquet')
+      await writeSegment(firstTmp, [1])
+      await finalizeSegmentFile({ dir: segDir, tmpPath: firstTmp, rows: 1, range: { from: 0, to: 1 }, engine: 'test' })
 
-      const second = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
-      await second.appendRow({ blockNumber: 1 })
-      await expect(second.publish({ from: 0, to: 1 })).rejects.toThrowError(/Refusing to overwrite/)
-      await second.discard()
+      const secondTmp = path.join(segDir, '.tmp-second.parquet')
+      await writeSegment(secondTmp, [1])
+      await expect(
+        finalizeSegmentFile({ dir: segDir, tmpPath: secondTmp, rows: 1, range: { from: 0, to: 1 }, engine: 'test' }),
+      ).rejects.toThrowError(/Refusing to overwrite/)
     })
 
-    it('discard() removes the temp file of an unpublished segment', async () => {
+    it('refuses a finished file that is not Parquet (magic-bytes check)', async () => {
       const segDir = path.join(dir, 'seg')
       await mkdir(segDir, { recursive: true })
-      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
 
-      const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
-      await writer.appendRow({ blockNumber: 1 })
-      await writer.discard()
+      const tmpPath = path.join(segDir, '.tmp-junk.parquet')
+      await writeFile(tmpPath, 'this is definitely not a parquet file')
 
-      expect((await readdir(segDir)).filter((f) => f.startsWith('.tmp-'))).toEqual([])
-    })
-
-    it('discard() releases the stream and is safe to call twice', async () => {
-      // Exercises the error-path fd cleanup: destroy the owned stream, idempotently, with no throw.
-      const segDir = path.join(dir, 'seg')
-      await mkdir(segDir, { recursive: true })
-      const schema = new ParquetSchema({ blockNumber: { type: 'INT64' } })
-
-      const writer = new ParquetSegmentWriter({ dir: segDir, schema, rowGroupSize: 1 })
-      await writer.appendRow({ blockNumber: 1 })
-      await writer.discard()
-      await writer.discard()
-
-      expect((await readdir(segDir)).filter((f) => f.startsWith('.tmp-'))).toEqual([])
+      await expect(
+        finalizeSegmentFile({ dir: segDir, tmpPath, rows: 1, range: { from: 0, to: 1 }, engine: 'test' }),
+      ).rejects.toThrowError(/Parquet magic bytes/)
+      // The junk file was not renamed into a published name.
+      expect((await readdir(segDir)).sort()).toEqual(['.tmp-junk.parquet'])
     })
   })
 

--- a/packages/pipes/src/targets/parquet/parquet-target.test.ts
+++ b/packages/pipes/src/targets/parquet/parquet-target.test.ts
@@ -340,7 +340,7 @@ describe('parquetTarget', () => {
         parquetTarget({
           dir,
           tables: [BLOCKS_TABLE],
-          settings: { rollover: { maxBytes: 1 }, rowGroupSize: 1 },
+          settings: { rollover: { maxBytes: 1 }, engine: parquetjsEngine({ rowGroupSize: 1 }) },
           onData: insertBlocks,
         }),
       )
@@ -577,7 +577,7 @@ describe('parquetTarget', () => {
         parquetTarget({
           dir,
           tables: [BLOCKS_TABLE, sparseTable],
-          settings: { rollover: { maxBytes: 1 }, rowGroupSize: 1 },
+          settings: { rollover: { maxBytes: 1 }, engine: parquetjsEngine({ rowGroupSize: 1 }) },
           onData: ({ store, data }) => {
             insertBlocks({ store, data })
             const rows = data.filter((b) => b.number === 1 || b.number === 6)
@@ -886,7 +886,7 @@ describe('parquetTarget', () => {
         parquetTarget({
           dir,
           tables: [BLOCKS_TABLE],
-          settings: { rollover: { maxBytes: 1 }, rowGroupSize: 1 },
+          settings: { rollover: { maxBytes: 1 }, engine: parquetjsEngine({ rowGroupSize: 1 }) },
           onData: ({ store, data }) => {
             // Every row keyed at block 1 (an aggregate re-stamped to an already-final block), so
             // rows keep releasing while the boundary cursor stays pinned at 1.
@@ -913,9 +913,7 @@ describe('parquetTarget', () => {
       return new ParquetStore({
         dir,
         tables: [BLOCKS_TABLE],
-        rowGroupSize: 100,
-        defaultCodec: 'SNAPPY',
-        engine: parquetjsEngine(),
+        engine: parquetjsEngine({ rowGroupSize: 100 }),
       })
     }
 
@@ -1034,7 +1032,7 @@ describe('parquetTarget', () => {
         parquetTarget({
           dir,
           tables: [BLOCKS_TABLE, emptyTable],
-          settings: { rollover: { maxBytes: 1 }, rowGroupSize: 1 },
+          settings: { rollover: { maxBytes: 1 }, engine: parquetjsEngine({ rowGroupSize: 1 }) },
           onData: insertBlocks,
         }),
       )

--- a/packages/pipes/src/targets/parquet/parquet-target.test.ts
+++ b/packages/pipes/src/targets/parquet/parquet-target.test.ts
@@ -1320,6 +1320,21 @@ describe('parquetTarget', () => {
       // The junk file was not renamed into a published name.
       expect((await readdir(segDir)).sort()).toEqual(['.tmp-junk.parquet'])
     })
+
+    it('refuses arbitrary bytes merely wrapped in the magic (footer length check)', async () => {
+      const segDir = path.join(dir, 'seg')
+      await mkdir(segDir, { recursive: true })
+
+      // Correct magic at both ends, but the 4 bytes before the trailing magic — the footer
+      // length field — are payload, not a length that fits inside the file.
+      const tmpPath = path.join(segDir, '.tmp-spoof.parquet')
+      await writeFile(tmpPath, 'PAR1this is not a parquet footer PAR1')
+
+      await expect(
+        finalizeSegmentFile({ dir: segDir, tmpPath, rows: 1, range: { from: 0, to: 1 }, engine: 'test' }),
+      ).rejects.toThrowError(/footer length field/)
+      expect((await readdir(segDir)).sort()).toEqual(['.tmp-spoof.parquet'])
+    })
   })
 
   describe('ParquetState', () => {

--- a/packages/pipes/src/targets/parquet/parquet-target.ts
+++ b/packages/pipes/src/targets/parquet/parquet-target.ts
@@ -45,9 +45,11 @@ export type ParquetSettings = {
   /**
    * Segment writer engine. Omitted → the default `parquetjsEngine()`, the SDK's only
    * built-in. Pass any {@link ParquetEngine} implementation to swap the writer: an engine
-   * translates the declared schema and plain-JS rows privately, stages via `nextTmpPath`,
-   * and publishes through `finalizeSegmentFile`, so file naming, durability and crash
-   * recovery stay engine-invariant (see `engine.ts` for the full contract).
+   * translates the declared schema and plain-JS rows privately and writes each segment file
+   * at a temp path the target assigns; the target names files for their coverage window,
+   * verifies engine output (Parquet magic bytes) and owns publication, so naming, durability
+   * and crash recovery are engine-invariant by construction (see `engine.ts` for the full
+   * contract).
    */
   engine?: ParquetEngine
   /**

--- a/packages/pipes/src/targets/parquet/parquet-target.ts
+++ b/packages/pipes/src/targets/parquet/parquet-target.ts
@@ -17,13 +17,10 @@ import type { ParquetEngine } from './engine.js'
 import { ParquetState } from './parquet-state.js'
 import { ParquetStore } from './parquet-store.js'
 import { parquetjsEngine } from './parquetjs/parquetjs-engine.js'
-import { type Codec, type ParquetTable, validateTables } from './schema.js'
+import { type ParquetTable, validateTables } from './schema.js'
 
 /** Default rollover byte size — 128 MiB is a good Parquet file size for data-lake query engines. */
 const DEFAULT_MAX_BYTES = 128 * 1024 * 1024
-/** Default rows per row group — the in-memory "split size" that bounds writer memory. */
-const DEFAULT_ROW_GROUP_SIZE = 100_000
-const DEFAULT_CODEC: Codec = 'SNAPPY'
 
 export type ParquetRollover = {
   /** Soft byte cap per file — checked at each batch boundary, so a huge batch can overshoot. Default 128 MiB. */
@@ -38,10 +35,6 @@ export type ParquetRollover = {
 
 export type ParquetSettings = {
   rollover?: ParquetRollover
-  /** Rows per row group — bounds writer memory. Default 100_000. */
-  rowGroupSize?: number
-  /** Default per-column compression. Default `'SNAPPY'`. */
-  compression?: Codec
   /**
    * Segment writer engine. Omitted → the default `parquetjsEngine()`, the SDK's only
    * built-in. Pass any {@link ParquetEngine} implementation to swap the writer: an engine
@@ -50,6 +43,11 @@ export type ParquetSettings = {
    * verifies engine output (Parquet magic bytes) and owns publication, so naming, durability
    * and crash recovery are engine-invariant by construction (see `engine.ts` for the full
    * contract).
+   *
+   * Encoding options (row-group size, compression, backend tuning) are engine-owned: pass
+   * them to the engine's factory — `parquetjsEngine({ rowGroupSize, compression })` — where
+   * they are typed to what that engine can actually do. The target neither consumes nor
+   * forwards them.
    */
   engine?: ParquetEngine
   /**
@@ -86,8 +84,11 @@ type ParquetTargetMetrics = {
  *
  * **Constant memory.** Finalized rows stream straight to a temp file and the file rotates by byte
  * size, so a multi-gigabyte finalized backfill never lands wholly in RAM (the default parquetjs
- * engine flushes row groups to disk incrementally — verified by the Step 0 spike; alternative
- * engines own their staging bounds). `rowGroupSize` bounds the writer's in-memory buffer.
+ * engine flushes row groups to disk incrementally — verified by the Step 0 spike — with its
+ * `rowGroupSize` factory option bounding the in-memory buffer; alternative engines own their
+ * staging bounds through their own factory options). For an engine whose byte reporting is
+ * estimated rather than measured, `rollover.maxRows` is an exact, engine-independent backstop —
+ * the target counts appended rows itself.
  *
  * **Coverage-named files.** Files are named `<from>-<to>.parquet` for the block window they
  * **cover** — the window the pipe processed — not for the min/max block of the rows inside. Within
@@ -153,13 +154,10 @@ export function parquetTarget<T>(options: {
   // so config mistakes surface at startup, not deep in the first batch.
   const engine = settings.engine ?? parquetjsEngine()
 
-  const rowGroupSize = settings.rowGroupSize ?? DEFAULT_ROW_GROUP_SIZE
-  const defaultCodec = settings.compression ?? DEFAULT_CODEC
-
   const maxBytes = settings.rollover?.maxBytes ?? DEFAULT_MAX_BYTES
   const { maxRows, intervalMs, intervalBlocks } = settings.rollover ?? {}
 
-  const store = new ParquetStore({ dir, tables, rowGroupSize, defaultCodec, engine })
+  const store = new ParquetStore({ dir, tables, engine })
 
   return createTarget<T>({
     write: async ({ read, logger, id }) => {

--- a/packages/pipes/src/targets/parquet/parquetjs/index.ts
+++ b/packages/pipes/src/targets/parquet/parquetjs/index.ts
@@ -1,1 +1,1 @@
-export { parquetjsEngine } from './parquetjs-engine.js'
+export { type ParquetjsEngineOptions, parquetjsEngine } from './parquetjs-engine.js'

--- a/packages/pipes/src/targets/parquet/parquetjs/parquetjs-engine.ts
+++ b/packages/pipes/src/targets/parquet/parquetjs/parquetjs-engine.ts
@@ -1,8 +1,32 @@
 import { ParquetSchema } from '@dsnp/parquetjs'
 
 import type { ParquetEngine } from '../engine.js'
+import type { Codec } from '../schema.js'
 import { buildRowWrapper, toParquetSchemaShape } from './parquetjs-schema.js'
 import { ParquetSegmentWriter } from './parquetjs-writer.js'
+
+/**
+ * Encoding options for the parquetjs engine — typed to what this engine can actually do.
+ * Encoding is engine-owned: the target neither consumes nor forwards these.
+ */
+export type ParquetjsEngineOptions = {
+  /**
+   * Rows per row group — a row count, not bytes. Writer-side it is the in-memory flush
+   * threshold (how many rows are buffered before a row group is encoded to disk), reader-side
+   * the pruning granularity. It bounds this engine's staging memory. Default 100_000.
+   */
+  rowGroupSize?: number
+  /**
+   * Compression codec for columns that do not declare their own. Individual columns may
+   * override it via `column.compression` in the declared schema — this engine honors
+   * per-column overrides. Default `'SNAPPY'`.
+   */
+  compression?: Codec
+}
+
+/** Default rows per row group — the in-memory "split size" that bounds writer memory. */
+export const DEFAULT_ROW_GROUP_SIZE = 100_000
+export const DEFAULT_COMPRESSION: Codec = 'SNAPPY'
 
 /**
  * The default engine: writes segments with `@dsnp/parquetjs` on the JS thread. Requires the
@@ -12,11 +36,14 @@ import { ParquetSegmentWriter } from './parquetjs-writer.js'
  * Per-table state compiled once and shared by every segment of that table: the library
  * schema and the LIST row wrapper.
  */
-export function parquetjsEngine(): ParquetEngine {
+export function parquetjsEngine(options: ParquetjsEngineOptions = {}): ParquetEngine {
+  const rowGroupSize = options.rowGroupSize ?? DEFAULT_ROW_GROUP_SIZE
+  const compression = options.compression ?? DEFAULT_COMPRESSION
+
   return {
     name: 'parquetjs',
-    table(table, context) {
-      const schema = new ParquetSchema(toParquetSchemaShape(table, context.defaultCompression))
+    table(table) {
+      const schema = new ParquetSchema(toParquetSchemaShape(table, compression))
       const wrapRow = buildRowWrapper(table.schema)
 
       return {
@@ -24,7 +51,7 @@ export function parquetjsEngine(): ParquetEngine {
           new ParquetSegmentWriter({
             tmpPath,
             schema,
-            rowGroupSize: context.rowGroupSize,
+            rowGroupSize,
             wrapRow,
           }),
       }

--- a/packages/pipes/src/targets/parquet/parquetjs/parquetjs-engine.ts
+++ b/packages/pipes/src/targets/parquet/parquetjs/parquetjs-engine.ts
@@ -16,13 +16,13 @@ export function parquetjsEngine(): ParquetEngine {
   return {
     name: 'parquetjs',
     table(table, context) {
-      const schema = new ParquetSchema(toParquetSchemaShape(table, context.codec))
+      const schema = new ParquetSchema(toParquetSchemaShape(table, context.defaultCompression))
       const wrapRow = buildRowWrapper(table.schema)
 
       return {
-        createSegment: () =>
+        createSegment: (tmpPath) =>
           new ParquetSegmentWriter({
-            dir: context.dir,
+            tmpPath,
             schema,
             rowGroupSize: context.rowGroupSize,
             wrapRow,

--- a/packages/pipes/src/targets/parquet/parquetjs/parquetjs-writer.test.ts
+++ b/packages/pipes/src/targets/parquet/parquetjs/parquetjs-writer.test.ts
@@ -41,10 +41,10 @@ describe('parquetjsEngine', () => {
   })
 
   it('round-trips plain rows (LIST cells as plain arrays) through a finished segment', async () => {
-    const engine = parquetjsEngine()
+    const engine = parquetjsEngine({ rowGroupSize: 100 })
     expect(engine.name).toBe('parquetjs')
 
-    const tableWriter = engine.table(TRANSFERS, { rowGroupSize: 100, defaultCompression: 'SNAPPY' })
+    const tableWriter = engine.table(TRANSFERS)
 
     const tmpPath = path.join(dir, 'transfers', '.tmp-000000.parquet')
     const writer = tableWriter.createSegment(tmpPath)
@@ -67,7 +67,7 @@ describe('parquetjsEngine', () => {
 
   it('finish() with no appended rows still writes a real, readable schema-only file', async () => {
     // Tail closing claims a window a table produced nothing in — the zero-row contract.
-    const tableWriter = parquetjsEngine().table(TRANSFERS, { rowGroupSize: 100, defaultCompression: 'SNAPPY' })
+    const tableWriter = parquetjsEngine({ rowGroupSize: 100 }).table(TRANSFERS)
 
     const tmpPath = path.join(dir, 'transfers', '.tmp-empty.parquet')
     const writer = tableWriter.createSegment(tmpPath)
@@ -80,7 +80,7 @@ describe('parquetjsEngine', () => {
   })
 
   it('reuses the compiled library schema across successive segments', async () => {
-    const tableWriter = parquetjsEngine().table(TRANSFERS, { rowGroupSize: 100, defaultCompression: 'SNAPPY' })
+    const tableWriter = parquetjsEngine({ rowGroupSize: 100 }).table(TRANSFERS)
 
     const firstPath = path.join(dir, 'transfers', '.tmp-first.parquet')
     const first = tableWriter.createSegment(firstPath)

--- a/packages/pipes/src/targets/parquet/parquetjs/parquetjs-writer.test.ts
+++ b/packages/pipes/src/targets/parquet/parquetjs/parquetjs-writer.test.ts
@@ -40,22 +40,22 @@ describe('parquetjsEngine', () => {
     await rm(dir, { recursive: true, force: true })
   })
 
-  it('round-trips plain rows (LIST cells as plain arrays) through a published segment', async () => {
+  it('round-trips plain rows (LIST cells as plain arrays) through a finished segment', async () => {
     const engine = parquetjsEngine()
     expect(engine.name).toBe('parquetjs')
 
-    const tableDir = path.join(dir, 'transfers')
-    const tableWriter = engine.table(TRANSFERS, { dir: tableDir, rowGroupSize: 100, codec: 'SNAPPY' })
+    const tableWriter = engine.table(TRANSFERS, { rowGroupSize: 100, defaultCompression: 'SNAPPY' })
 
-    const writer = tableWriter.createSegment()
-    await writer.appendRow({ blockNumber: 1, to: '0xa', tags: ['x', 'y'] })
-    await writer.appendRow({ blockNumber: 2, to: '0xb', tags: ['z'] })
-    const published = await writer.publish({ from: 1, to: 2 })
+    const tmpPath = path.join(dir, 'transfers', '.tmp-000000.parquet')
+    const writer = tableWriter.createSegment(tmpPath)
+    await writer.append([
+      { blockNumber: 1, to: '0xa', tags: ['x', 'y'] },
+      { blockNumber: 2, to: '0xb', tags: ['z'] },
+    ])
+    await writer.finish()
 
-    expect(published.path).toBe(path.join(tableDir, '000000000001-000000000002.parquet'))
-    expect(published.rows).toBe(2)
-
-    const rows = await readAllRows(published.path)
+    // The engine wrote a complete Parquet file exactly at the target-assigned temp path.
+    const rows = await readAllRows(tmpPath)
     expect(rows.map((r) => [r['blockNumber'], r['to']])).toEqual([
       [1n, '0xa'],
       [2n, '0xb'],
@@ -65,19 +65,34 @@ describe('parquetjsEngine', () => {
     expect(rows[0]?.['tags']).toEqual({ list: [{ element: 'x' }, { element: 'y' }] })
   })
 
+  it('finish() with no appended rows still writes a real, readable schema-only file', async () => {
+    // Tail closing claims a window a table produced nothing in — the zero-row contract.
+    const tableWriter = parquetjsEngine().table(TRANSFERS, { rowGroupSize: 100, defaultCompression: 'SNAPPY' })
+
+    const tmpPath = path.join(dir, 'transfers', '.tmp-empty.parquet')
+    const writer = tableWriter.createSegment(tmpPath)
+    await writer.finish()
+
+    const reader = await ParquetReader.openFile(tmpPath)
+    expect(Number(reader.getRowCount())).toBe(0)
+    expect(reader.getSchema().fieldList.length).toBeGreaterThan(0)
+    await reader.close()
+  })
+
   it('reuses the compiled library schema across successive segments', async () => {
-    const tableDir = path.join(dir, 'transfers')
-    const tableWriter = parquetjsEngine().table(TRANSFERS, { dir: tableDir, rowGroupSize: 100, codec: 'SNAPPY' })
+    const tableWriter = parquetjsEngine().table(TRANSFERS, { rowGroupSize: 100, defaultCompression: 'SNAPPY' })
 
-    const first = tableWriter.createSegment()
-    await first.appendRow({ blockNumber: 1, to: '0xa', tags: [] })
-    await first.publish({ from: 1, to: 1 })
+    const firstPath = path.join(dir, 'transfers', '.tmp-first.parquet')
+    const first = tableWriter.createSegment(firstPath)
+    await first.append([{ blockNumber: 1, to: '0xa', tags: [] }])
+    await first.finish()
 
-    const second = tableWriter.createSegment()
-    await second.appendRow({ blockNumber: 2, to: '0xb', tags: [] })
-    const published = await second.publish({ from: 2, to: 2 })
+    const secondPath = path.join(dir, 'transfers', '.tmp-second.parquet')
+    const second = tableWriter.createSegment(secondPath)
+    await second.append([{ blockNumber: 2, to: '0xb', tags: [] }])
+    await second.finish()
 
-    expect(published.path).toBe(path.join(tableDir, '000000000002-000000000002.parquet'))
-    expect((await readAllRows(published.path)).length).toBe(1)
+    expect((await readAllRows(firstPath)).length).toBe(1)
+    expect((await readAllRows(secondPath)).length).toBe(1)
   })
 })

--- a/packages/pipes/src/targets/parquet/parquetjs/parquetjs-writer.ts
+++ b/packages/pipes/src/targets/parquet/parquetjs/parquetjs-writer.ts
@@ -1,22 +1,16 @@
 import type { WriteStream } from 'node:fs'
-import { stat, unlink } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
 
 import { ParquetSchema, ParquetWriter } from '@dsnp/parquetjs'
 
 import { openWriteStream } from '../fs-durable.js'
-import {
-  type PublishedSegment,
-  type SegmentRange,
-  type SegmentWriter,
-  finalizeSegmentFile,
-  nextTmpPath,
-} from '../segment.js'
+import { type SegmentWriter } from '../segment.js'
 
 type Row = Record<string, unknown>
 
 export type ParquetjsSegmentWriterOptions = {
-  /** The table's directory: `<baseDir>/<table>`. Created by the state layer before writes. */
-  dir: string
+  /** The target-assigned temp path this segment writes to. */
+  tmpPath: string
   /** The compiled library schema, shared by every segment of the table. */
   schema: ParquetSchema
   /** Rows per row group — the "split size" that bounds the writer's in-memory buffer. */
@@ -27,65 +21,43 @@ export type ParquetjsSegmentWriterOptions = {
 }
 
 /**
- * Wraps a single open `ParquetWriter` writing **one** output file (a "segment") for one table.
+ * Wraps a single open `ParquetWriter` writing **one** segment file at the temp path the target
+ * assigned. The writer's whole job is rows → Parquet bytes at that path: the target tracks row
+ * counts, assigns the coverage window, names/publishes the finished file and deletes it on the
+ * error path.
  *
- * The underlying file is **lazy-opened on the first `appendRow`** (or at `publish` for a
- * zero-row segment). The writer tracks the row count it has seen, exposes the growing temp
- * file size for byte-based rotation, and publishes atomically through the shared segment
- * toolkit:
- *
- *   `close()` (footer) → fsync file → atomic `rename` temp → `<dir>/<from>-<to>.parquet` → fsync dir
- *
- * The published name comes from the {@link SegmentRange} the caller passes to `publish()` — the
- * window the pipe processed. The writer never inspects the rows' own block numbers; it has no way
- * to know which blocks it was *responsible* for, only which ones happened to produce rows.
- *
- * A published file is immutable and contains only finalized rows, so it is never rewritten.
+ * The underlying file is **lazy-opened on the first `append`** (or at `finish` for a zero-row
+ * segment — tail closing publishes real, schema-only files). The writer never inspects the
+ * rows' block numbers: the published name states the coverage window, which only the target
+ * knows, and per-block min/max lands in each row group's footer statistics anyway (what
+ * DuckDB/Spark/Athena prune on).
  */
 export class ParquetSegmentWriter implements SegmentWriter {
-  readonly #dir: string
+  readonly #tmpPath: string
   readonly #schema: ParquetSchema
   readonly #rowGroupSize: number
   readonly #wrapRow: ((row: Row) => Row) | undefined
-  readonly #tmpPath: string
 
   #writer: ParquetWriter | undefined
   // We own the underlying stream (rather than ParquetWriter.openFile owning it) so the error path
   // can force the fd shut — ParquetWriter.close() flips `closed` first and never reaches the
   // stream's close() if a footer write throws, which would otherwise leak the descriptor.
   #stream: WriteStream | undefined
-  #rowCount = 0
   #closed = false
 
   constructor(options: ParquetjsSegmentWriterOptions) {
-    this.#dir = options.dir
+    this.#tmpPath = options.tmpPath
     this.#schema = options.schema
     this.#rowGroupSize = options.rowGroupSize
     this.#wrapRow = options.wrapRow
-    this.#tmpPath = nextTmpPath(options.dir)
   }
 
-  /** Whether the underlying file has been opened (i.e. at least one row was appended). */
-  get isOpen(): boolean {
-    return this.#writer !== undefined
-  }
-
-  get rowCount(): number {
-    return this.#rowCount
-  }
-
-  /**
-   * Appends one row, lazy-opening the temp file on first use.
-   *
-   * The writer tracks no block range of its own: the filename comes from the coverage window the
-   * caller passes to {@link publish}, and per-block min/max is already written into each row group's
-   * statistics by the Parquet footer (what DuckDB/Spark/Athena prune on).
-   */
-  async appendRow(row: Row): Promise<void> {
+  /** Appends a batch of rows, lazy-opening the temp file on first use. */
+  async append(rows: readonly Row[]): Promise<void> {
     await this.#ensureOpen()
-    await this.#writer!.appendRow(this.#wrapRow ? this.#wrapRow(row) : row)
-
-    this.#rowCount++
+    for (const row of rows) {
+      await this.#writer!.appendRow(this.#wrapRow ? this.#wrapRow(row) : row)
+    }
   }
 
   async #ensureOpen(): Promise<void> {
@@ -118,44 +90,29 @@ export class ParquetSegmentWriter implements SegmentWriter {
   }
 
   /**
-   * Finalizes the segment: writes the Parquet footer, then publishes through the shared
-   * `finalizeSegmentFile` tail (fsync → collision check → atomic rename to
-   * `<dir>/<from>-<to>.parquet` → dir fsync). Returns the published file's path, row count and
-   * byte size.
-   *
-   * `range` is the window the caller assigns; the file is named for it so consumers read coverage
-   * off the filename. Publishing with **no rows** is legitimate and how a table claims a window it
-   * was present for but produced nothing in — the file carries the schema and an empty row set.
+   * Completes the segment file: opens it if no row ever arrived (a zero-row window still
+   * produces a real, schema-only segment), flushes the last row group, writes the Parquet
+   * footer and releases the fd. The target verifies and publishes the file afterwards.
    */
-  async publish(range: SegmentRange): Promise<PublishedSegment> {
-    // Opens the file if no row ever arrived, so a zero-row window still produces a real segment.
+  async finish(): Promise<void> {
     await this.#ensureOpen()
 
     await this.#writer!.close()
     this.#closed = true
     // close() ended the stream (via the library's envelopeWriter.close → stream.end), so its fd is
-    // already released; drop the reference so discard()/GC don't touch a finished stream.
+    // already released; drop the reference so abort()/GC don't touch a finished stream.
     this.#stream = undefined
-
-    return finalizeSegmentFile({
-      dir: this.#dir,
-      tmpPath: this.#tmpPath,
-      rows: this.#rowCount,
-      range,
-    })
   }
 
   /**
-   * Best-effort cleanup of an unpublished segment: releases the open fd and deletes the temp file.
-   * Used on the error path — the temp file holds finalized-but-not-checkpointed rows that will be
-   * regenerated from the portal on the next run, since the cursor never advanced.
-   *
-   * We `destroy()` the stream directly instead of `ParquetWriter.close()`-ing it: the file is about
-   * to be unlinked, so there is no point flushing a footer, and `close()` could leak the fd (it
-   * flips `closed` before the stream is ended, so a throw mid-footer skips the end) or hang on a
-   * footer flush against a full disk. `destroy()` frees the descriptor immediately and can't hang.
+   * Error-path teardown: releases the open fd without finishing the file (the target deletes the
+   * temp file). We `destroy()` the stream directly instead of `ParquetWriter.close()`-ing it: the
+   * file is about to be unlinked, so there is no point flushing a footer, and `close()` could
+   * leak the fd (it flips `closed` before the stream is ended, so a throw mid-footer skips the
+   * end) or hang on a footer flush against a full disk. `destroy()` frees the descriptor
+   * immediately and can't hang.
    */
-  async discard(): Promise<void> {
+  async abort(): Promise<void> {
     if (this.#stream && !this.#closed) {
       this.#closed = true
       // A destroyed stream can emit 'error' for an in-flight write; swallow it so it never surfaces
@@ -165,11 +122,5 @@ export class ParquetSegmentWriter implements SegmentWriter {
     }
     this.#writer = undefined
     this.#stream = undefined
-
-    try {
-      await unlink(this.#tmpPath)
-    } catch {
-      // best-effort — the temp file may not exist yet (never opened) or already be gone
-    }
   }
 }

--- a/packages/pipes/src/targets/parquet/segment.ts
+++ b/packages/pipes/src/targets/parquet/segment.ts
@@ -1,4 +1,4 @@
-import { rename, stat } from 'node:fs/promises'
+import { open as fsOpen, rename, stat } from 'node:fs/promises'
 import path from 'node:path'
 
 import { PARQUET_ERROR_CODES, ParquetTargetError } from './errors.js'
@@ -14,7 +14,7 @@ export const TMP_PREFIX = '.tmp-'
 // reset-to-0 across restarts can never collide with a leftover temp file.
 let segmentSeq = 0
 
-/** Next process-unique temp file path inside `dir`. */
+/** Next process-unique temp file path inside `dir`. Target-internal: engines receive the path. */
 export function nextTmpPath(dir: string): string {
   return path.join(dir, `${TMP_PREFIX}${(segmentSeq++).toString().padStart(6, '0')}.parquet`)
 }
@@ -23,7 +23,7 @@ export function nextTmpPath(dir: string): string {
  * Block range a published file **covers** — the window the pipe processed, not the rows' own
  * min/max. The two are independent: the window's edge blocks may carry no data, and a row may be
  * keyed outside the window that emitted it. That is the point — the filename states coverage, not
- * content.
+ * content. Target-internal: engines never see a range; the store names files itself.
  */
 export type SegmentRange = { from: number; to: number }
 
@@ -35,30 +35,38 @@ export type PublishedSegment = {
 }
 
 /**
- * The exact surface `ParquetStore` drives a per-table segment writer through. Every engine
- * implements it — the built-in `parquetjsEngine` and any external `ParquetEngine`; everything
- * above the writer — finalization buffers, coverage tracking, the durable cursor, `.tmp-*`
- * recovery, collision refusal — is engine-agnostic; external engines reuse `nextTmpPath` and
- * `finalizeSegmentFile` so recovery and collision semantics stay uniform.
+ * The per-segment surface an engine implements: write rows into the Parquet file at the temp
+ * path the target passed to `createSegment`, and nothing else. The target tracks row counts,
+ * assigns the coverage window, names and publishes the file (`finalizeSegmentFile`), and
+ * deletes the temp file on the error path — so a writer holds no naming, durability or
+ * recovery responsibilities and none of those semantics can vary per engine.
  */
 export interface SegmentWriter {
-  /** Whether the segment's file has been opened (i.e. at least one row was appended). */
-  readonly isOpen: boolean
-  readonly rowCount: number
-  appendRow(row: Record<string, unknown>): Promise<void>
+  /** Appends a batch of finalized rows (≥1) to the segment file, in order. */
+  append(rows: readonly Record<string, unknown>[]): Promise<void>
+  /**
+   * Bytes staged so far, used for byte-based rotation. An estimate is fine (e.g. in-memory
+   * staging before the file exists); it only needs to grow with the data.
+   */
   size(): Promise<number>
   /**
-   * Finalizes and publishes the segment, named for the coverage window `range`. Must succeed
-   * with **zero appended rows** — a zero-row window still publishes a real (schema-only)
-   * Parquet file; that is how a table claims a window it produced nothing in.
+   * Completes the file at the temp path: flush everything, write the footer, release the fd.
+   * Must succeed with **zero appended rows** — tail closing claims a window the table produced
+   * nothing in with a real, schema-only Parquet file. After `finish()` resolves the file must
+   * be complete Parquet — the target verifies its magic bytes before publishing.
    */
-  publish(range: SegmentRange): Promise<PublishedSegment>
-  discard(): Promise<void>
+  finish(): Promise<void>
+  /**
+   * Error-path teardown: release resources (fds, native handles) without completing the file.
+   * Must be idempotent and must not throw. The target deletes the temp file afterwards.
+   */
+  abort(): Promise<void>
 }
 
 /**
- * Shared publish tail for every engine: refuse an inverted coverage range, fsync the finished
- * temp file so its content is durable before the rename makes it visible, refuse to overwrite an
+ * Target-internal publish tail, run by `ParquetStore` after the engine's `finish()`: refuse an
+ * inverted coverage range, verify the finished temp file is actually Parquet (magic bytes),
+ * fsync it so its content is durable before the rename makes it visible, refuse to overwrite an
  * existing `<from>-<to>.parquet` (a collision means two segments claimed the same window, which
  * would silently drop data), atomically rename into place, then fsync the directory so the
  * rename is durable.
@@ -68,8 +76,10 @@ export async function finalizeSegmentFile(options: {
   tmpPath: string
   rows: number
   range: SegmentRange
+  /** Engine name for error messages. */
+  engine: string
 }): Promise<PublishedSegment> {
-  const { dir, tmpPath, rows, range } = options
+  const { dir, tmpPath, rows, range, engine } = options
 
   if (range.from > range.to) {
     throw new ParquetTargetError(
@@ -79,6 +89,7 @@ export async function finalizeSegmentFile(options: {
     )
   }
 
+  await assertParquetMagic(tmpPath, engine)
   await fsyncFile(tmpPath)
 
   const finalPath = path.join(dir, `${pad(range.from)}-${pad(range.to)}.parquet`)
@@ -99,6 +110,50 @@ export async function finalizeSegmentFile(options: {
     .catch(() => 0)
 
   return { path: finalPath, rows, bytes }
+}
+
+const PARQUET_MAGIC = Buffer.from('PAR1')
+// Header magic (4) + footer metadata length (4) + footer magic (4) — no valid file is smaller.
+const PARQUET_MIN_BYTES = 12
+
+/**
+ * Verifies the finished segment file starts and ends with the Parquet magic bytes (`PAR1`).
+ * This is the runtime check behind the engine contract's "must produce real Parquet files":
+ * a truncated or non-Parquet output is refused here, at the checkpoint, instead of surfacing
+ * as a corrupt file in a downstream reader.
+ */
+async function assertParquetMagic(tmpPath: string, engine: string): Promise<void> {
+  const refuse = (problem: string): never => {
+    throw new ParquetTargetError(
+      PARQUET_ERROR_CODES.SEGMENT_NOT_PARQUET,
+      `Refusing to publish segment file '${tmpPath}' from engine '${engine}': ${problem}. ` +
+        `Engines must produce complete Parquet files — downstream readers rely on it.`,
+    )
+  }
+
+  let fh: Awaited<ReturnType<typeof fsOpen>>
+  try {
+    fh = await fsOpen(tmpPath, 'r')
+  } catch (error) {
+    return refuse(`the file cannot be opened (${error instanceof Error ? error.message : String(error)})`)
+  }
+
+  try {
+    const { size } = await fh.stat()
+    if (size < PARQUET_MIN_BYTES) {
+      return refuse(`the file is ${size} byte(s), smaller than any valid Parquet file`)
+    }
+
+    const head = Buffer.alloc(4)
+    const tail = Buffer.alloc(4)
+    await fh.read(head, 0, 4, 0)
+    await fh.read(tail, 0, 4, size - 4)
+    if (!head.equals(PARQUET_MAGIC) || !tail.equals(PARQUET_MAGIC)) {
+      return refuse('it does not start and end with the Parquet magic bytes (PAR1)')
+    }
+  } finally {
+    await fh.close()
+  }
 }
 
 function pad(block: number): string {

--- a/packages/pipes/src/targets/parquet/segment.ts
+++ b/packages/pipes/src/targets/parquet/segment.ts
@@ -117,10 +117,14 @@ const PARQUET_MAGIC = Buffer.from('PAR1')
 const PARQUET_MIN_BYTES = 12
 
 /**
- * Verifies the finished segment file starts and ends with the Parquet magic bytes (`PAR1`).
- * This is the runtime check behind the engine contract's "must produce real Parquet files":
- * a truncated or non-Parquet output is refused here, at the checkpoint, instead of surfacing
- * as a corrupt file in a downstream reader.
+ * Verifies the finished segment file has the Parquet envelope: it starts and ends with the
+ * magic bytes (`PAR1`), and the footer length field (the little-endian uint32 immediately
+ * before the trailing magic) describes a footer that actually fits inside the file. This is
+ * the runtime check behind the engine contract's "must produce real Parquet files": a
+ * truncated, non-Parquet, or magic-wrapped-garbage output is refused here, at the checkpoint,
+ * instead of surfacing as a corrupt file in a downstream reader. (It is an envelope check,
+ * not a decode — an engine writing structurally valid Parquet with wrong *contents* is beyond
+ * cheap verification.)
  */
 async function assertParquetMagic(tmpPath: string, engine: string): Promise<void> {
   const refuse = (problem: string): never => {
@@ -145,11 +149,19 @@ async function assertParquetMagic(tmpPath: string, engine: string): Promise<void
     }
 
     const head = Buffer.alloc(4)
-    const tail = Buffer.alloc(4)
+    // The last 8 bytes: footer metadata length (LE uint32) followed by the trailing magic.
+    const tail = Buffer.alloc(8)
     await fh.read(head, 0, 4, 0)
-    await fh.read(tail, 0, 4, size - 4)
-    if (!head.equals(PARQUET_MAGIC) || !tail.equals(PARQUET_MAGIC)) {
+    await fh.read(tail, 0, 8, size - 8)
+    if (!head.equals(PARQUET_MAGIC) || !tail.subarray(4).equals(PARQUET_MAGIC)) {
       return refuse('it does not start and end with the Parquet magic bytes (PAR1)')
+    }
+
+    // The footer must be non-empty and fit between the header magic and its own length field —
+    // this is what rejects arbitrary payloads merely wrapped in PAR1.
+    const footerLength = tail.readUInt32LE(0)
+    if (footerLength < 1 || footerLength > size - PARQUET_MIN_BYTES) {
+      return refuse(`its footer length field claims ${footerLength} byte(s), which cannot fit in a ${size}-byte file`)
     }
   } finally {
     await fh.close()

--- a/spec/14-interface-binding.md
+++ b/spec/14-interface-binding.md
@@ -213,7 +213,7 @@ consumers MUST NOT read it as a block number.
 | E20xx | ClickHouse binding | E2001–E2006 (retention, table name, distributed-rollback, collapse-column, missing sign, rollback-index) |
 | E21xx | Postgres binding | E2101–E2106 (client, config, advisory lock, untracked table, missing PK, FK cycle) |
 | E22xx | BigQuery binding | E2201–E2213 (schema/partition guards, orphan data E2212, append rejection E2213) |
-| E23xx | Parquet binding | E2301–E2317 in use (schema/config; file collision E2309, state corrupt E2310, recovery delete failure E2314, nested-schema E2315; coverage guards E2316 invalid range, E2317 state/data disagreement) |
+| E23xx | Parquet binding | E2301–E2317 and E2320 in use (schema/config; file collision E2309, state corrupt E2310, recovery delete failure E2314, nested-schema E2315; coverage guards E2316 invalid range, E2317 state/data disagreement; engine-output verification E2320 non-Parquet segment refused). E2318–E2319 retired, unassigned |
 
 **IB-51 — Transport errors.** Non-coded, typed: HTTP error (with response), request
 timeout, body-stall timeout. Retryability: request timeouts and connection-class errors

--- a/spec/decisions/ADR-18-parquet-pluggable-engine-seam.md
+++ b/spec/decisions/ADR-18-parquet-pluggable-engine-seam.md
@@ -13,16 +13,31 @@ different native schema and row representations.
 
 ## Decision
 
-Introduce a `ParquetEngine` seam that owns exactly one thing: turning finalized
-plain-JS rows of a declared table into a Parquet file on disk. The sink keeps owning
-everything around the writer — staging, finalization buffering, rotation triggers,
-checkpoints, recovery, fork handling, metrics. No engine-specific schema mechanism:
-the SDK's engine-neutral declared column model plus the documented plain-JS row-value
-contract is the complete input; each engine translates it to its native representation
-privately. Capability limits are enforced by throwing from `engine.table()` at
-construction. Every engine stages via the shared temp-naming helper and publishes
-through the shared finalize tail (fsync → collision check → atomic rename → dir
-fsync), so durability, crash recovery and file naming are engine-invariant.
+Introduce a `ParquetEngine` seam that owns exactly one thing: writing finalized
+plain-JS rows of a declared table into a Parquet file at a temp path the sink assigns.
+The sink keeps owning everything around the writer — staging, finalization buffering,
+rotation triggers, coverage tracking, checkpoints, recovery, fork handling, metrics.
+No engine-specific schema mechanism: the SDK's engine-neutral declared column model
+plus the documented plain-JS row-value contract is the complete input; each engine
+translates it to its native representation privately. Capability limits are enforced
+by throwing from `engine.table()` at construction.
+
+The seam's invariants are enforced structurally, not by documentation. The sink picks
+every temp path and passes it to `createSegment(tmpPath)`; the writer's surface is
+`append(rows)` / `size()` / `finish()` / `abort()`, so an engine has no way to name,
+rename, fsync or delete files — and no way to see a block number or coverage window,
+which only the sink knows (ADR-6 names files for the window the pipe processed, not
+row content). Row counts are sink bookkeeping. After `finish()`, the sink verifies
+the file's Parquet magic bytes (refusing with `E2320` otherwise) and runs the publish
+tail (inverted-range refusal → fsync → collision check → atomic rename → dir fsync)
+itself; on the error path the sink deletes the temp file after `abort()`. A segment
+may finish with zero rows — tail closing claims a window with a real, schema-only
+file — so `finish()` must produce a valid file even if `append` never ran. The
+temp-naming and finalize helpers are sink-internal, not exported API. The remaining
+non-structural contract is minimal: the bytes an engine writes must be real Parquet
+(checked at publication) and rows arrive in the documented plain-JS shape (an input
+format, not an honor-system rule).
+
 `settings.engine` takes an engine instance; omitted selects the default parquetjs
 engine. The core entry statically imports `@dsnp/parquetjs`, so the module graph —
 not a runtime loader — enforces its optional-peer status: importing the entry without
@@ -33,7 +48,13 @@ the SDK never references them.
 ## Consequences
 
 Engines are interchangeable without touching IB-22 state formats or CN-32 fork
-mechanics, and naming/publication decisions (ADR-6) bind every engine through the
-shared tail. Third-party engines become possible; engine capability gaps surface at
-construction — FM-25's fail-at-startup posture — not mid-run. The parquetjs default
-keeps zero-config behavior unchanged.
+mechanics, and naming/publication decisions (ADR-6) bind every engine by construction
+— a third-party engine cannot break `.tmp-*` recovery, coverage-window naming or the
+durability tail even deliberately, and a non-Parquet output fails at the checkpoint
+instead of corrupting a downstream reader. Third-party engines become possible;
+engine capability gaps surface at construction — FM-25's fail-at-startup posture —
+not mid-run. Batched `append(rows)` keeps per-row `await` overhead out of the seam
+for columnar/native engines. The parquetjs default keeps zero-config behavior
+unchanged. The public surface shrinks to the three engine types plus `SegmentWriter`
+and `PublishedSegment`; the helpers formerly exported for engines to call
+(`nextTmpPath`, `finalizeSegmentFile`) are no longer API the SDK must keep stable.

--- a/spec/decisions/ADR-18-parquet-pluggable-engine-seam.md
+++ b/spec/decisions/ADR-18-parquet-pluggable-engine-seam.md
@@ -38,6 +38,17 @@ non-structural contract is minimal: the bytes an engine writes must be real Parq
 (checked at publication) and rows arrive in the documented plain-JS shape (an input
 format, not an honor-system rule).
 
+Encoding options are engine-owned, applying the same principle to configuration. The
+sink consumes neither row-group size nor compression — it only forwarded them, in a
+fixed vocabulary that was simultaneously too wide for some engines (per-column codecs
+a file-level backend must refuse) and too narrow for others (codecs the neutral union
+omits because the parquetjs build lacks them). Each engine factory now declares its
+own option type (`parquetjsEngine({ rowGroupSize, compression })`), typed to what it
+can actually honor, so a capability mismatch on these options is unrepresentable
+rather than refused at runtime. `engine.table(table)` takes no context; the one
+capability gate it retains is per-column `compression` overrides, which live in the
+neutral schema declaration and are refused by engines that cannot honor them.
+
 `settings.engine` takes an engine instance; omitted selects the default parquetjs
 engine. The core entry statically imports `@dsnp/parquetjs`, so the module graph —
 not a runtime loader — enforces its optional-peer status: importing the entry without

--- a/spec/decisions/ADR-19-duckdb-segment-writer-engine.md
+++ b/spec/decisions/ADR-19-duckdb-segment-writer-engine.md
@@ -21,16 +21,18 @@ platform-built dependency in the SDK.
 
 The SDK ships exactly one engine — parquetjs — and stays engine-agnostic behind the
 ADR-18 seam. The DuckDB engine is maintained by its consumer (the GFS pipeline's
-`@pipeline/core`), implementing the public `ParquetEngine` contract and reusing the
-shared segment toolkit, with no SDK involvement. The engine-comparison benchmark
+`@pipeline/core`), implementing the public `ParquetEngine` contract — writing each
+segment at the sink-assigned temp path, with naming, verification and publication
+staying sink-side per ADR-18 — with no SDK involvement. The engine-comparison benchmark
 harness, its reports, and the extracted engine source are archived with the consumer
 (`sqd/360/google/parquet-engine-benchmarks/`).
 
 ## Consequences
 
 The SDK carries no native optional dependency and no duckdb-specific error code
-(E2316 retired, number unassigned). The seam is the compatibility contract: changes
-to `ParquetEngine`, `SegmentWriter` or the segment toolkit are breaking for external
-engines and must be versioned accordingly. DuckDB-specific behaviors
+(its per-column-compression check moved out with the engine; E2318–E2319 retired,
+numbers unassigned). The seam is the compatibility contract: changes to
+`ParquetEngine` or `SegmentWriter` are breaking for external engines and must be
+versioned accordingly. DuckDB-specific behaviors
 (estimate-based byte rotation, single file-level codec, publish-time JS-thread
 stalls) are documented where the engine lives.


### PR DESCRIPTION
## Summary

Stacked on #124. Addresses the review thread on `engine.ts`'s "Implementations MUST" block (https://github.com/subsquid/pipes-sdk/pull/124/changes#r3630770886): the seam's rules move from documentation into code, in two steps.

- **Structural enforcement (`8487f2f`).** The target assigns every temp path (`createSegment(tmpPath)`), counts rows itself, and owns the entire publish tail — Parquet magic-bytes verification (new `E2320 SEGMENT_NOT_PARQUET`), inverted-range refusal, fsync, collision check, atomic rename to the coverage-window name, dir fsync. Engines shrink to `append(rows)` / `size()` / `finish()` / `abort()`, never see a block number or coverage window, and must `finish()` a valid schema-only file for zero-row tail closing. `nextTmpPath`/`finalizeSegmentFile` leave the public API; batched `append` replaces per-row `appendRow`. A third-party engine can no longer break `.tmp-*` recovery, file naming, or the durability tail — even deliberately — and a non-Parquet output fails at the checkpoint instead of reaching downstream readers.
- **Engine-owned encoding options (`9098f78`).** `settings.rowGroupSize`/`settings.compression` are removed; each engine factory declares its own option type (`parquetjsEngine({ rowGroupSize, compression })`), typed to what it can actually honor — so a capability mismatch on these options is unrepresentable rather than refused at runtime. `engine.table(table)` loses its context parameter entirely; per-column `compression` overrides stay in the neutral schema as `table()`'s one remaining capability gate. The target consumed neither option — it only forwarded them, in a vocabulary that was too wide for some engines (per-column codecs DuckDB must refuse) and too narrow for others (ZSTD/LZ4, absent from the parquetjs-flavored union).

ADR-18/ADR-19 record both decisions; `docs/errors.md` documents `E2320`; the parquet example shows the new option idiom.

## Breaking notes (vs #124's current head)

- `SegmentWriter` is a new, smaller surface (`append`/`size`/`finish`/`abort`); `PublishedSegment` is produced by the store, not by engines.
- `ParquetTableContext` is gone; `ParquetEngine.table(table)` takes no context.
- `ParquetSettings` loses `rowGroupSize`/`compression` (moved to engine factories; defaults unchanged, zero-config behavior identical).
- `nextTmpPath`, `finalizeSegmentFile`, `SegmentRange` are no longer exported.
- The external DuckDB engine (GFS `@pipeline/core`) needs the mechanical migration described in ADR-19; its options object gains `rowGroupSize`/`compression` it already forwards natively to `COPY`, and its `compression` type can now include ZSTD/LZ4.

## Coverage

Base = `worktree-parquet-duckdb-engine` (`fd82355`); head = `9098f78`. Both via `pnpm vitest run --coverage src/targets/parquet` (same scoping as #124's table). 101 tests pass on head (98 on base).

| Module | Stmts | Δ | Branch | Δ |
|--------|-------|---|--------|---|
| **src/targets/parquet (total)** | 97.3% | -0.3 | 92.0% | -0.3 |
| src/targets/parquet | 97.3% | -0.4 | 91.3% | -0.3 |
| src/targets/parquet/parquetjs | 96.9% | -0.3 | 96.4% | -0.1 |

The small dips are the new best-effort error paths (target-side `abort()`+unlink cleanup, magic-check open-failure branch), all under the gate's 1% threshold.

## Test plan

- [x] Custom engine driven end-to-end through finalization, target-side naming, publish and cursor persistence (`custom-engine.test.ts`)
- [x] Non-Parquet engine output refused at the checkpoint (`E2320`), temp file cleaned up, no cursor persisted — run fully recoverable
- [x] `finalizeSegmentFile`: coverage-window naming, zero-row publish, inverted-range refusal, collision refusal, magic-bytes refusal
- [x] parquetjs writer: batched append round-trip (LIST wrapping intact), zero-row `finish()` produces a readable schema-only file, `abort()` idempotent
- [x] Engine factory options honored (`parquetjsEngine({ rowGroupSize })` drives row-group layout in store/target tests)
- [x] All pre-existing coverage/rotation/recovery/fork suites pass unchanged (101/101)
- [x] `spec/check-spec.mjs` clean (50 thrown codes / 50 documented, no dangling references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eUnQiQZgDCPS4fYi8hQbj