### PR TITLE
evm: make baseFeePerGas optional and add tx blobGasUsed/blobGasPrice

### DIFF
--- a/packages/pipes/src/portal-client/query/evm.test.ts
+++ b/packages/pipes/src/portal-client/query/evm.test.ts
@@ -1,7 +1,7 @@
 import { cast } from '@subsquid/util-internal-validation'
 import { describe, expect, it } from 'vitest'
 
-import { getBlockSchema } from './evm.js'
+import { type BlockHeaderFieldSelection, getBlockSchema } from './evm.js'
 
 function castNonce(nonce: unknown) {
   const schema = getBlockSchema({ transaction: { nonce: true } })
@@ -220,5 +220,32 @@ describe('BlockHeaderFields withdrawals validation', () => {
 
   it('rejects a non-hex address', () => {
     expect(() => castWithdrawals([{ index: '0x1', validatorIndex: '0x2', address: 'nothex', amount: '0x3' }])).toThrow()
+  })
+})
+
+describe('BlockHeaderFields optional pre-fork fields', () => {
+  function castHeader(fields: BlockHeaderFieldSelection, header: Record<string, unknown>) {
+    const schema = getBlockSchema({ block: fields })
+    return cast(schema, { header, transactions: [] }).header as Record<string, unknown>
+  }
+
+  it('accepts a header without baseFeePerGas (pre-London) when the field is selected', () => {
+    expect(castHeader({ baseFeePerGas: true }, {})['baseFeePerGas']).toBeUndefined()
+  })
+
+  it('casts baseFeePerGas hex QTY to bigint when present', () => {
+    expect(castHeader({ baseFeePerGas: true }, { baseFeePerGas: '0x7' })['baseFeePerGas']).toBe(7n)
+  })
+
+  it('accepts a header without blobGasUsed/excessBlobGas (pre-Cancun) when selected', () => {
+    const h = castHeader({ blobGasUsed: true, excessBlobGas: true }, {})
+    expect(h['blobGasUsed']).toBeUndefined()
+    expect(h['excessBlobGas']).toBeUndefined()
+  })
+
+  it('casts blobGasUsed/excessBlobGas hex QTY to bigint when present', () => {
+    const h = castHeader({ blobGasUsed: true, excessBlobGas: true }, { blobGasUsed: '0x10', excessBlobGas: '0x20' })
+    expect(h['blobGasUsed']).toBe(16n)
+    expect(h['excessBlobGas']).toBe(32n)
   })
 })

--- a/packages/pipes/src/portal-client/query/evm.ts
+++ b/packages/pipes/src/portal-client/query/evm.ts
@@ -55,9 +55,9 @@ export type BlockHeaderFields = {
   gasUsed: bigint
   difficulty: bigint
   totalDifficulty?: bigint
-  baseFeePerGas: bigint
-  blobGasUsed: bigint
-  excessBlobGas: bigint
+  baseFeePerGas?: bigint
+  blobGasUsed?: bigint
+  excessBlobGas?: bigint
   l1BlockNumber?: number
   uncles?: Hex[]
   withdrawalsRoot?: Hex
@@ -95,6 +95,8 @@ export type TransactionFields = {
   status: number
   logsBloom?: Hex
   blobVersionedHashes?: Hex[]
+  blobGasUsed?: bigint
+  blobGasPrice?: bigint
   accessList?: {
     address: Hex
     storageKeys: Hex[]
@@ -443,9 +445,9 @@ const BlockHeaderShape: ObjectValidatorShape<BlockHeaderFields> = {
   gasUsed: QTY,
   difficulty: QTY,
   totalDifficulty: option(QTY),
-  baseFeePerGas: QTY,
-  blobGasUsed: QTY,
-  excessBlobGas: QTY,
+  baseFeePerGas: option(QTY),
+  blobGasUsed: option(QTY),
+  excessBlobGas: option(QTY),
   l1BlockNumber: option(NAT),
   uncles: option(array(BYTES)),
   withdrawalsRoot: option(BYTES),
@@ -487,6 +489,8 @@ const TransactionShape: ObjectValidatorShape<TransactionFields> = {
   status: NAT,
   logsBloom: option(BYTES),
   blobVersionedHashes: option(array(BYTES)),
+  blobGasUsed: option(QTY),
+  blobGasPrice: option(QTY),
   accessList: option(array(object({ address: BYTES, storageKeys: array(BYTES) }))),
   l1Fee: option(QTY),
   l1FeeScalar: option(NAT),


### PR DESCRIPTION
Two evm portal-query shape fixes we've been carrying downstream as a patch and would like to upstream:

1. **`baseFeePerGas` optional** — it is absent on pre-London blocks and on some chains, so the required `QTY` codec fails validation there. Changed `BlockHeaderShape.baseFeePerGas` to `option(QTY)` (and the field to optional).
2. **transaction `blobGasUsed` / `blobGasPrice`** — EIP-4844 blob gas is served per transaction by the portal but is missing from the transaction shape, so it cannot be selected or decoded. Added both as `option(QTY)` (and optional fields).

Both are minimal, additive, and backwards-compatible. Happy to adjust naming or placement.
