### PR TITLE
metrics: guard packPreview against unbounded recursion

### DIFF
--- a/packages/pipes/src/metrics/node/node-metrics-server.test.ts
+++ b/packages/pipes/src/metrics/node/node-metrics-server.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { packPreview } from './node-metrics-server.js'
+
+/** Wrap `leaf` in `depth` nested `{ v: ... }` objects. */
+function nest(leaf: unknown, depth: number): unknown {
+  let node: unknown = leaf
+  for (let i = 0; i < depth; i++) {
+    node = { v: node }
+  }
+
+  return node
+}
+
+describe('packPreview', () => {
+  it('does not overflow the stack on a cyclic object', () => {
+    const a: any = {}
+    a.self = a
+
+    expect(() => packPreview(a)).not.toThrow()
+    expect(JSON.stringify(packPreview(a))).toContain('[Truncated]')
+  })
+
+  it('bounds a deeply nested object instead of throwing', () => {
+    // 100k levels — overflowed the stack before the depth guard (the reported crash-loop).
+    const root: any = {}
+    let cur = root
+    for (let i = 0; i < 100_000; i++) {
+      cur.next = {}
+      cur = cur.next
+    }
+    cur.leaf = 'end'
+
+    expect(() => packPreview(root)).not.toThrow()
+    expect(JSON.stringify(packPreview(root))).toContain('[Truncated]')
+  })
+
+  it('keeps values up to the depth bound and truncates just past it', () => {
+    const withinBound = JSON.stringify(packPreview(nest('LEAF', 8)))
+    expect(withinBound).toContain('LEAF')
+    expect(withinBound).not.toContain('[Truncated]')
+
+    const pastBound = JSON.stringify(packPreview(nest('LEAF', 9)))
+    expect(pastBound).not.toContain('LEAF')
+    expect(pastBound).toContain('[Truncated]')
+  })
+
+  it('leaves realistic shallow preview data untouched', () => {
+    const value = {
+      header: { number: 100, hash: '0xabc' },
+      transactions: [{ from: '0x1', to: '0x2', logs: [{ topics: ['0xa', '0xb'] }] }],
+    }
+
+    expect(packPreview(value)).toEqual(value)
+  })
+
+  it('passes primitives, null and Date through unchanged', () => {
+    const date = new Date(0)
+
+    expect(packPreview(42)).toBe(42)
+    expect(packPreview('x')).toBe('x')
+    expect(packPreview(null)).toBe(null)
+    expect(packPreview(date)).toBe(date)
+  })
+
+  it('returns short primitive arrays verbatim', () => {
+    expect(packPreview([1, 2, 3])).toEqual([1, 2, 3])
+  })
+
+  it('collapses long arrays to head plus a remainder marker', () => {
+    const arr = Array.from({ length: 25 }, (_, i) => ({ i }))
+
+    expect(packPreview(arr)).toEqual([{ i: 0 }, '... 24 more ...'])
+  })
+})

--- a/packages/pipes/src/metrics/node/node-metrics-server.ts
+++ b/packages/pipes/src/metrics/node/node-metrics-server.ts
@@ -117,7 +117,9 @@ type TransformationResult = {
   children: TransformationResult[]
 }
 
-function packPreview(value: any): any {
+export function packPreview(value: any, depth = 0): any {
+  if (depth > 8) return '[Truncated]'
+
   if (Array.isArray(value)) {
     if (
       value.length <= 10 &&
@@ -127,10 +129,10 @@ function packPreview(value: any): any {
     }
 
     if (value.length > 10) {
-      return [packPreview(value[0]), `... ${value.length - 1} more ...`]
+      return [packPreview(value[0], depth + 1), `... ${value.length - 1} more ...`]
     }
 
-    return value.map(packPreview)
+    return value.map((v) => packPreview(v, depth + 1))
   }
 
   if (value === null || value instanceof Date) return value
@@ -138,7 +140,7 @@ function packPreview(value: any): any {
   if (typeof value === 'object') {
     const res: any = {}
     for (const key in value) {
-      res[key] = packPreview(value[key])
+      res[key] = packPreview(value[key], depth + 1)
     }
     return res
   }


### PR DESCRIPTION
## Problem
`packPreview` in the node metrics server recurses over batch/preview data with no depth or cycle guard. On some payloads it throws `RangeError: Maximum call stack size exceeded`, which propagates out of the per-batch metrics processing and crash-loops the pipe. We hit this on a TRON pipe (restarting every ~30s), but it is data-shape dependent and not TRON-specific.

Repro (either overflows the stack with the current implementation):
- cyclic object: `const a = {}; a.self = a; packPreview(a)`
- deeply nested object (e.g. 100k levels)

## Fix
Bound the recursion depth (returns a `[Truncated]` marker beyond depth 8). A preview is best-effort telemetry, so truncating deep/cyclic structures is preferable to overflowing the stack. Verified locally that the original throws on both the cyclic and deep cases while the guarded version returns cleanly.

Reported in the Telegram channel; opening the PR here as suggested.
