### PR TITLE
fix(core): scope resume parent-hash anchor to the continuation range (GAP-11)

### DIFF
--- a/packages/pipes/src/core/portal-source.test.ts
+++ b/packages/pipes/src/core/portal-source.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import { SpanHooks } from '~/core/profiling.js'
 import { Target, createTarget } from '~/core/target.js'
 import { TransformerArgs, createTransformer } from '~/core/transformer.js'
-import { evmPortalStream } from '~/evm/index.js'
+import { evmPortalStream, evmQuery } from '~/evm/index.js'
 import { MockPortal, blockDecoder, finalizedMockPortal, mockPortal, readAll } from '~/testing/index.js'
 
 /**
@@ -356,6 +356,58 @@ describe('Portal abstract stream', () => {
           `Please refer to the documentation on how to handle forks.`,
         ].join('\n'),
       )
+    })
+  })
+
+  describe('resume anchor (multi-range)', () => {
+    // ADR-20: the recovered cursor's hash is the parent-linkage anchor only for the range that
+    // continues directly from it (from === cursor.number + 1). Carrying it into a later disjoint
+    // range makes the portal check that hash against a block it doesn't border — a spurious
+    // 409/fork. The anchor must be scoped to the continuation range only.
+    it('anchors only the range continuing from the resume cursor, not disjoint later ranges', async () => {
+      const requests: any[] = []
+
+      portal = await mockPortal([
+        {
+          statusCode: 200,
+          data: [{ header: { number: 200, hash: '0xA200', timestamp: 200_000 } }],
+          head: { finalized: { number: 200, hash: '0xA200' }, latest: { number: 200 } },
+          validateRequest: (r) => requests.push(r),
+        },
+        {
+          statusCode: 200,
+          data: [{ header: { number: 5001, hash: '0xB5001', timestamp: 5_001_000 } }],
+          head: { finalized: { number: 5001, hash: '0xB5001' }, latest: { number: 5001 } },
+          validateRequest: (r) => requests.push(r),
+        },
+      ])
+
+      const outputs = evmQuery()
+        .addRange({ from: 100, to: 200 })
+        .addRange({ from: 5000, to: 5001 })
+        .addFields({ block: { number: true, hash: true, timestamp: true } })
+        .build()
+        .pipe((d) => d.flatMap((b) => b.header))
+
+      const stream = evmPortalStream({
+        id: 'test',
+        portal: portal.url,
+        outputs,
+      })
+
+      const target = createTarget({
+        write: async ({ read }) => {
+          for await (const _ of read({ latest: { number: 150, hash: '0xresume' }, finalized: null })) {
+          }
+        },
+      })
+
+      await stream.pipeTo(target as any)
+
+      expect(requests.map((r) => ({ fromBlock: r.fromBlock, parentBlockHash: r.parentBlockHash }))).toEqual([
+        { fromBlock: 151, parentBlockHash: '0xresume' },
+        { fromBlock: 5000, parentBlockHash: undefined },
+      ])
     })
   })
 

--- a/packages/pipes/src/core/portal-source.ts
+++ b/packages/pipes/src/core/portal-source.ts
@@ -221,13 +221,20 @@ export class PortalStream<Q extends QueryBuilder<any>, T = any> {
     }
 
     for (const { range, request } of bounded) {
+      // The recovered cursor's hash is the parent-linkage anchor only for the range that
+      // continues directly from it. Any later disjoint range starts across a gap the cursor does
+      // not border, so anchoring it there makes the portal compare that hash against a block it
+      // never precedes — a spurious 409/fork on resume. Such ranges start unanchored; the anchor
+      // re-establishes from their own first block (ADR-20).
+      const isResumeContinuation = cursor?.hash != null && range.from === cursor.number + 1
+
       const query = {
         ...request,
         type: this.#queryBuilder.getType(),
         fields: this.#queryBuilder.getFields(),
         fromBlock: range.from,
         toBlock: range.to,
-        parentBlockHash: cursor?.hash ? cursor.hash : undefined,
+        parentBlockHash: isResumeContinuation ? cursor.hash : undefined,
       }
 
       const source = this.#options.cache

--- a/spec/13-conformance-tdd.md
+++ b/spec/13-conformance-tdd.md
@@ -175,7 +175,6 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
 | GAP-8 | Fork-signal handling crashes uncoded on an empty canonical chain (exception constructor) before the coded guard runs | WP-41, FM-14 | P2 | fork response with empty chain → assert coded error, not raw crash |
 | GAP-9 | Canonical-chain-below-cursor guard enforced by one binding only; others can strand orphan rows above the new chain | RP-43, FM-15 | P2 | fork with max(canonical) < cursor against each class; assert coded refusal |
 | GAP-10 | ClickHouse and BigQuery order cursor records by wall-clock timestamp (resume + fork-record + retention ordering; BigQuery's per-process monotonic counter resets on restart); clock regression can misorder — violates clock independence | CN-45, CN-15 | P2 | two commits under a regressed clock, per binding; resume must pick commit-order latest |
-| GAP-11 | Confirmed: the resume parent-hash anchor is sent for every configured range, including later disjoint ranges where it is not the range predecessor — a resumed multi-range run gets a spurious 409/fork on the later range | WP-1, IB-3 | P1 | two disjoint ranges + resume; simulator asserts anchor semantics per request |
 | GAP-12 | Class-W binding assumes single-writer (client-assigned monotonic timestamps) with no lock and no detection; dual instance corrupts undetected | INV-15 (declaration) | P3 | document in IB-24; optional fencing probe |
 | GAP-13 | No automated sync between thrown error codes and the registry; the "all codes cross-checked" claim is manual | REQ-13, IB-50 | P3 | enumerate codes from source; diff against IB-50 table |
 | GAP-14 | Crash-recovery kill-point coverage exists only for class K; classes T/W/A have no kill-point tests | INV-40…INV-42 | P1 | Phase-0 ledger mode first (an ordinal script cannot answer the post-restart re-request), then the kill-point harness at the T transaction boundary |
@@ -204,7 +203,7 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
 - **Phase 0 — harness skeleton**: the reference implementation already serves the
   simulator's wire surface from an HTTP fixture (200 NDJSON · 204 · 409 with canonical
   chain · 5xx · head headers, IB-4/IB-5) with a per-request assertion hook — sufficient
-  as-is for request-shape work (GAP-11). The Phase-0 delta is **ledger mode**:
+  as-is for request-shape work (resume-anchor scoping, ADR-20). The Phase-0 delta is **ledger mode**:
   derive responses from the request anchor (IB-3) against a held chain instead of
   selecting them by request ordinal. An ordinal script has no answer for the re-request
   a restarted SUT issues from its recovered cursor, so this gates the entire CT-2
@@ -214,7 +213,7 @@ P2 bounded/rare · P3 polish. "First test" = cheapest failing-test-first entry p
   class (K — cheapest, file-based; the only crash imitation today is a pre-commit
   abort, one point of the CT-2 matrix). Exit: CT-1 green on the reference
   implementation for S1, ledger mode answering post-restart re-requests.
-- **Phase 1 — P1 gaps**: GAP-11 (range anchors), GAP-14 kill-point harness for class T
+- **Phase 1 — P1 gaps**: range anchors (landed under ADR-20), GAP-14 kill-point harness for class T
   (and the class-A no-hook recovery window, now an accepted deviation under ADR-15). Exit:
   register updated, fixes landed or accepted as documented deviations.
 - **Phase 2 — correctness core**: full CT-2 matrix all classes; CT-3 fork suite; CT-5

--- a/spec/14-interface-binding.md
+++ b/spec/14-interface-binding.md
@@ -20,8 +20,11 @@ arrays are per-entity filter lists (IB-8).
 
 **IB-3 — Anchor advance.** After each received block: `fromBlock ← number+1`,
 `parentBlockHash ← hash`. The anchor is the fork-detection mechanism; the first request
-of a resumed run carries the recovered cursor's hash. *(Anchor semantics on later
-disjoint ranges: GAP-11.)*
+of a resumed run carries the recovered cursor's hash — but only on the range that
+continues directly from it (`fromBlock = cursor.number+1`). A later disjoint range starts
+unanchored (no `parentBlockHash`) and re-establishes the anchor from its own first block;
+carrying the cursor's hash across the gap would fault a 409 against a block it never
+precedes (ADR-20).
 
 **IB-4 — Fork signal.** HTTP **409** on stream requests; body key `previousBlocks`: the
 canonical chain as `[{number, hash}, …]` (spec name: DEF-10). The wire key is frozen —

--- a/spec/decisions/ADR-20-resume-anchor-scoping.md
+++ b/spec/decisions/ADR-20-resume-anchor-scoping.md
@@ -1,0 +1,37 @@
+# ADR-20 — The resume anchor binds only the range that continues from the cursor
+
+Status: Accepted — settles anchor semantics on a resumed multi-range run
+
+## Context
+
+A pipe may configure several disjoint block ranges. On resume, WP-1 seeds the first
+request from the recovered cursor and IB-3 carries that cursor's hash as the
+parent-linkage anchor. IB-3 left one case open: which of several ranges the anchor
+attaches to.
+
+The reference binding sent the cursor's hash as the initial anchor for *every*
+configured range. For the range that continues directly from the cursor that is correct
+— the cursor's hash is the parent of its first block. For any later disjoint range it is
+not: the cursor is block N, the range starts at some M ≫ N+1, and block N does not
+precede block M. Under ADR-1 the portal validates linkage and answers a mismatch with a
+409, so the resumed run took a spurious fork on the later range — a P1 correctness hole.
+
+## Decision
+
+The recovered cursor's hash anchors **only the range that continues directly from it**,
+identified by `fromBlock = cursor.number + 1`. Every later range starts **unanchored**
+(no `parentBlockHash`); IB-3 then re-establishes the anchor from that range's own first
+block as it arrives. A gap between the cursor and a range's start means there is no known
+parent to assert, so none is sent.
+
+This is a scoping refinement of IB-3, not a change to the trust model: the portal still
+owns linkage (ADR-1). An unanchored request asks the portal to begin at `fromBlock` and
+resume per-block linkage from there, exactly as a fresh (non-resumed) range already does.
+
+## Consequences
+
+A resumed multi-range run no longer faults a 409 against a block the cursor never
+precedes; the continuation range keeps its linkage check unchanged. Fork detection
+(ADR-1, IB-4) is unaffected — it still runs within every range once that range's own
+anchor is established. IB-3 states the scoping normatively. Shapes WP-1, IB-3, IB-4,
+REQ-6.


### PR DESCRIPTION
## Summary

- Closes **GAP-11** (P1). On resume, the recovered cursor's hash was sent as the initial `parentBlockHash` anchor for **every** configured range. For a later disjoint range the cursor is not the predecessor of its first block, so the portal's parent-linkage check answered a spurious **409/fork** and the run took a false fork on that range.
- The anchor is now carried only on the range that continues directly from the cursor (`fromBlock = cursor.number + 1`). Later disjoint ranges start unanchored and re-establish the anchor from their own first block (per IB-3).
- Spec closure: anchor semantics are now normative in **IB-3**, recorded in new **ADR-20**, and the GAP-11 row is removed from the register (live tracker = open only).

## Coverage

Scope: `src/core` test suite only (`--coverage.include=src/core/**`); the change is isolated to `src/core/portal-source.ts` and needs no ClickHouse/Postgres services. Base = `main` (126 tests) vs head (127 tests, +1 new resume-anchor test).

| Module | Stmts | Δ | Branch | Δ |
|--------|-------|---|--------|---|
| src/core (total) | 76.4% | +0.0 | 84.5% | +0.6 |
| src/core/portal-source.ts | 86.5% | +0.1 | 84.3% | +0.6 |

No module dropped; the new conditional branch is exercised both ways by the added test.

## Test plan

- [x] `resume anchor (multi-range)` — two disjoint ranges + resume cursor; asserts the continuation range carries `parentBlockHash`, the later disjoint range does not (failing-first: pre-fix the disjoint range carried the cursor hash).
- [x] `portal-source.test.ts` full suite green (24/24).
- [x] `core` + `portal-client` + `portal-cache` regression green (204/204).
- [x] `tsc --noEmit` and Biome clean.
- [x] `spec/check-spec.mjs`: 0 dangling references, 0 broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
