### PR TITLE
fix(tron): tolerate full int64 range in tx numeric field validation

### DIFF
--- a/packages/pipes/src/portal-client/query/tron.test.ts
+++ b/packages/pipes/src/portal-client/query/tron.test.ts
@@ -1,0 +1,86 @@
+import { cast } from '@subsquid/util-internal-validation'
+import { describe, expect, it } from 'vitest'
+
+import { getBlockSchema } from './tron.js'
+
+// tx `expiration`/`timestamp` share the timestamp decoder.
+function castExpiration(value: unknown) {
+  const schema = getBlockSchema({ transaction: { expiration: true } })
+  const block = { header: {}, transactions: [{ expiration: value }] }
+
+  return cast(schema, block).transactions[0].expiration
+}
+
+// block `timestamp`: same decoder, but required (not optional).
+function castBlockTimestamp(value: unknown) {
+  const schema = getBlockSchema({ block: { timestamp: true } })
+  const block = { header: { timestamp: value } }
+
+  return cast(schema, block).header.timestamp
+}
+
+// all int64 amounts share the signed decoder; `fee` stands in.
+function castFee(value: unknown) {
+  const schema = getBlockSchema({ transaction: { fee: true } })
+  const block = { header: {}, transactions: [{ fee: value }] }
+
+  return cast(schema, block).transactions[0].fee
+}
+
+describe('TRON timestamp validation (int64 milliseconds)', () => {
+  it('accepts a normal ms timestamp', () => {
+    expect(castExpiration(1782669723000)).toBe(1782669723000)
+    expect(castBlockTimestamp(1782669669000)).toBe(1782669669000)
+  })
+
+  it('accepts values above the safe-integer range (served as imprecise floats)', () => {
+    const huge = Number('639208360527210660')
+    expect(Number.isSafeInteger(huge)).toBe(false)
+    expect(castExpiration(huge)).toBe(huge)
+    expect(castBlockTimestamp(huge)).toBe(huge)
+  })
+
+  it('accepts negative int64 values', () => {
+    expect(castExpiration(-1)).toBe(-1)
+  })
+
+  it('normalizes a selected-but-null field to undefined', () => {
+    expect(castExpiration(null)).toBeUndefined()
+  })
+
+  it('rejects non-integer and non-number values', () => {
+    expect(() => castExpiration(3.14)).toThrow()
+    expect(() => castExpiration('1782669723000')).toThrow()
+    expect(() => castBlockTimestamp('nope')).toThrow()
+  })
+})
+
+describe('TRON amount validation (signed int64 BigNum)', () => {
+  it('accepts a decimal string and casts to bigint', () => {
+    expect(castFee('269000')).toBe(269000n)
+  })
+
+  it('accepts zero', () => {
+    expect(castFee('0')).toBe(0n)
+  })
+
+  it('accepts negative amounts (the portal serves them verbatim)', () => {
+    expect(castFee('-269000')).toBe(-269000n)
+  })
+
+  it('accepts values beyond 2^53', () => {
+    expect(castFee('9007199254740993')).toBe(9007199254740993n)
+  })
+
+  it('normalizes a selected-but-null field to undefined', () => {
+    expect(castFee(null)).toBeUndefined()
+  })
+
+  it('rejects a non-numeric string', () => {
+    expect(() => castFee('abc')).toThrow()
+  })
+
+  it('rejects a number (amounts arrive as decimal strings)', () => {
+    expect(() => castFee(269000)).toThrow()
+  })
+})

--- a/packages/pipes/src/portal-client/query/tron.ts
+++ b/packages/pipes/src/portal-client/query/tron.ts
@@ -1,6 +1,5 @@
 import {
   ANY,
-  BIG_NAT,
   BOOLEAN,
   NAT,
   STRING,
@@ -23,8 +22,8 @@ import {
   project,
 } from './common.js'
 
-// The TRON portal emits negative decimal strings for `feeLimit` on some early blocks
-// (e.g. `"-18395898"` at block 51068797), so it needs a signed variant of `BIG_NAT`.
+// int64 amounts, sent as decimal strings that can be negative (e.g. `feeLimit: "-18395898"`).
+// Unsigned `BIG_NAT` would reject the negatives and halt the stream.
 const BIG_INT: Validator<bigint, string> = {
   cast(value) {
     return typeof value === 'string' && /^-?\d+$/.test(value)
@@ -38,6 +37,24 @@ const BIG_INT: Validator<bigint, string> = {
   },
   phantom() {
     return '0'
+  },
+}
+
+// int64 ms timestamps served as JSON numbers; the portal emits garbage above 2^53 that
+// `JSON.parse` has already rounded to a float, so tolerate any integer instead of `NAT`.
+const TIMESTAMP_MS: Validator<number, number> = {
+  cast(value) {
+    return typeof value === 'number' && Number.isInteger(value)
+      ? value
+      : new ValidationFailure(value, '{value} is not a millisecond timestamp')
+  },
+  validate(value) {
+    return typeof value === 'number' && Number.isInteger(value)
+      ? undefined
+      : new ValidationFailure(value, '{value} is not a millisecond timestamp')
+  },
+  phantom() {
+    return 0
   },
 }
 
@@ -249,7 +266,7 @@ const BlockHeaderShape: ObjectValidatorShape<BlockHeaderFields> = {
   parentHash: STRING,
   txTrieRoot: STRING,
   version: option(NAT),
-  timestamp: NAT,
+  timestamp: TIMESTAMP_MS,
   witnessAddress: STRING,
   witnessSignature: option(STRING),
 }
@@ -264,29 +281,27 @@ const TransactionShape: ObjectValidatorShape<TransactionFields> = {
   permissionId: option(NAT),
   refBlockBytes: option(STRING),
   refBlockHash: option(STRING),
-  // TRON amounts arrive as decimal strings (e.g. "26400000"), not 0x-hex, so we use BIG_NAT
-  // (decimal string -> bigint) rather than EVM's hex-only QTY. `feeLimit` additionally has to
-  // accept negatives, hence the signed BIG_INT.
+  // int64 amounts -> signed BIG_INT (decimal strings, not hex QTY); int64 ms -> TIMESTAMP_MS.
   feeLimit: option(BIG_INT),
-  expiration: option(NAT),
-  timestamp: option(NAT),
+  expiration: option(TIMESTAMP_MS),
+  timestamp: option(TIMESTAMP_MS),
   rawDataHex: STRING,
-  fee: option(BIG_NAT),
+  fee: option(BIG_INT),
   contractResult: option(STRING),
   contractAddress: option(STRING),
   resMessage: option(STRING),
-  withdrawAmount: option(BIG_NAT),
-  unfreezeAmount: option(BIG_NAT),
-  withdrawExpireAmount: option(BIG_NAT),
+  withdrawAmount: option(BIG_INT),
+  unfreezeAmount: option(BIG_INT),
+  withdrawExpireAmount: option(BIG_INT),
   cancelUnfreezeV2Amount: option(ANY),
   result: option(STRING),
-  energyFee: option(BIG_NAT),
-  energyUsage: option(BIG_NAT),
-  energyUsageTotal: option(BIG_NAT),
-  netUsage: option(BIG_NAT),
-  netFee: option(BIG_NAT),
-  originEnergyUsage: option(BIG_NAT),
-  energyPenaltyTotal: option(BIG_NAT),
+  energyFee: option(BIG_INT),
+  energyUsage: option(BIG_INT),
+  energyUsageTotal: option(BIG_INT),
+  netUsage: option(BIG_INT),
+  netFee: option(BIG_INT),
+  originEnergyUsage: option(BIG_INT),
+  energyPenaltyTotal: option(BIG_INT),
 }
 
 const LogShape: ObjectValidatorShape<LogFields> = {

--- a/packages/pipes/src/tron/tron-portal-source.test.ts
+++ b/packages/pipes/src/tron/tron-portal-source.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { MockPortal, mockPortal } from '../testing/index.js'
+import { MockPortal, mockPortal, readAll } from '../testing/index.js'
 import { tronPortalStream } from './tron-portal-source.js'
 import { TronQueryBuilder } from './tron-query-builder.js'
 
@@ -61,8 +61,8 @@ describe('Tron portal stream', () => {
   })
 
   // Regression guard: real TRON data validated end-to-end through the full schema.
-  // The portal serializes big amounts as DECIMAL strings (not 0x-hex), so they
-  // must go through BIG_NAT (-> bigint), while ms timestamps stay plain numbers
+  // The portal serializes big amounts as signed DECIMAL strings (not 0x-hex), so they
+  // go through BIG_INT (-> bigint), while ms timestamps stay plain numbers
   // and `parameter`/`ret`/`callValueInfo` pass through as raw JSON. Mocks with
   // fake `0x...` data would hide a wrong-validator regression; this pumps an
   // unmodified portal response (block #84000000) so any such regression fails here.
@@ -169,5 +169,110 @@ describe('Tron portal stream', () => {
       expect(internal.rejected).toBeUndefined()
       expect(internal.extra).toBeUndefined()
     }
+  })
+
+  // Regression: int64 ms timestamps above 2^53 (e.g. 639208360527210660) arrive as JSON numbers;
+  // `NAT` rejected the resulting imprecise floats and halted the stream.
+  it('tolerates int64 timestamps above the safe-integer range', async () => {
+    // string-built so the imprecision reads as intentional, not a typo
+    const hugeMs = Number('639208360527210660')
+    expect(Number.isSafeInteger(hugeMs)).toBe(false)
+
+    portal = await mockPortal([
+      {
+        statusCode: 200,
+        data: [
+          {
+            header: { number: 84856193, hash: '00000000abcd1', timestamp: hugeMs },
+            transactions: [
+              {
+                transactionIndex: 0,
+                hash: 'deadbeef',
+                type: 'TransferContract',
+                expiration: hugeMs,
+                timestamp: hugeMs,
+              },
+            ],
+          },
+        ],
+      },
+    ])
+
+    const stream = tronPortalStream({
+      id: 'huge-timestamp',
+      portal: portal.url,
+      outputs: new TronQueryBuilder()
+        .addFields({
+          block: { number: true, hash: true, timestamp: true },
+          transaction: { transactionIndex: true, hash: true, type: true, expiration: true, timestamp: true },
+        })
+        .addRange({ from: 84856193, to: 84856193 }),
+    })
+
+    const data = await readAll(stream)
+    expect(data).toHaveLength(1)
+
+    // survive validation as imprecise floats instead of throwing
+    expect(data[0].header.timestamp).toBe(hugeMs)
+    const [tx] = data[0].transactions
+    expect(tx.expiration).toBe(hugeMs)
+    expect(tx.timestamp).toBe(hugeMs)
+  })
+
+  // Regression: int64 amounts can be negative (e.g. `feeLimit: "-18395898"`); `BIG_NAT` rejected
+  // them. Every amount field must use the signed decoder.
+  it('parses negative int64 amount fields instead of halting', async () => {
+    portal = await mockPortal([
+      {
+        statusCode: 200,
+        data: [
+          {
+            header: { number: 51068797, hash: '00000000abcd2', timestamp: 1782669669000 },
+            transactions: [
+              {
+                transactionIndex: 0,
+                hash: 'cafe',
+                type: 'TransferContract',
+                feeLimit: '-18395898',
+                fee: '-269000',
+                netFee: '-269000',
+                energyUsage: '-5',
+                withdrawAmount: '-1',
+              },
+            ],
+          },
+        ],
+      },
+    ])
+
+    const stream = tronPortalStream({
+      id: 'negative-amounts',
+      portal: portal.url,
+      outputs: new TronQueryBuilder()
+        .addFields({
+          block: { number: true, hash: true },
+          transaction: {
+            transactionIndex: true,
+            hash: true,
+            type: true,
+            feeLimit: true,
+            fee: true,
+            netFee: true,
+            energyUsage: true,
+            withdrawAmount: true,
+          },
+        })
+        .addRange({ from: 51068797, to: 51068797 }),
+    })
+
+    const data = await readAll(stream)
+    expect(data).toHaveLength(1)
+
+    const [tx] = data[0].transactions
+    expect(tx.feeLimit).toBe(-18395898n)
+    expect(tx.fee).toBe(-269000n)
+    expect(tx.netFee).toBe(-269000n)
+    expect(tx.energyUsage).toBe(-5n)
+    expect(tx.withdrawAmount).toBe(-1n)
   })
 })


### PR DESCRIPTION
## Summary

Synchronizes the TRON portal client validation (`portal-client/query/tron.ts`) with the Rust query API and the java-tron wire types. Two decoders were **stricter than what the portal actually serves**, so valid blocks halted the stream mid-batch:

| Fields | Codec (Rust) | Proto type | Before | After |
|---|---|---|---|---|
| tx `expiration`, tx `timestamp`, block `timestamp` | `TimestampMillisecond` (JSON number) | `int64` | `NAT` (safe-int only) | **`TIMESTAMP_MS`** (any integer number) |
| `fee`, `withdrawAmount`, `unfreezeAmount`, `withdrawExpireAmount`, `energyFee`, `energyUsage`, `energyUsageTotal`, `netUsage`, `netFee`, `originEnergyUsage`, `energyPenaltyTotal` | `BigNum` (decimal string) | `int64` | `BIG_NAT` (unsigned) | **`BIG_INT`** (signed) |

`feeLimit` was already signed (#137); this generalizes that fix to **every** `int64` amount field, since they share the same `BigNum` codec and can all be negative.

## Why

- **Timestamps** are `int64` milliseconds served as plain JSON numbers. The portal emits garbage values far above `2^53` (the support ticket reports `639208360527210660`, present in 30 of 41 blocks in range 84856193–84856233). `NAT`'s safe-integer check rejected them and the stream could not get past the block. Because portal NDJSON is parsed with plain `JSON.parse` (`client.ts:321`, no bigint reviver), such a value is **already an imprecise float before validation runs** — the exact `int64` is unrecoverable on the JS side, so we tolerate it as a number rather than a bigint. Normal timestamps stay exact.
- **Amounts** are `int64` (java-tron `Tron.proto`) and the portal serves negatives verbatim as decimal strings; the unsigned `BIG_NAT` (`\d+` only) rejected them — the same failure class as `feeLimit` in #137.

No public types change: timestamp fields stay `number`, amount fields stay `bigint`.

## Support ticket

> Transaction `timestamp` and `expiration` are still `option(NAT)` in alpha.21, but the portal serves values well above 2^53, so `NAT.cast` throws and the stream cannot get past the block. … e.g. `639208360527210660`.

**Valid — confirmed against the wire format and the proto**, and **this sync fixes it**. Caveat: the huge value is retained as an imprecise float (the reporter notes these are garbage, not real times); recovering the exact integer would require a lossless JSON parser across all networks, which is out of scope. Blocks now stream through instead of stalling.

## Test coverage (base → head) — `packages/pipes/src/portal-client/query/tron.ts`

| Metric | Base | Head |
|---|---|---|
| Branch | 66.6% | **100%** |
| Lines / Stmts | 92.0% | 88.3% |

Branch coverage is now complete (all accept/reject paths of both validators). The lines dip is mechanical: the new `TIMESTAMP_MS` validator adds interface-required `validate()`/`phantom()` methods that the runtime `cast()` path never invokes — the identical boilerplate that `BIG_INT` (#137) already leaves uncovered. All new *behavior* is tested.

New tests (internal framework only — `mockPortal`/`readAll`, no ad-hoc HTTP mocks):
- `tron.test.ts` (new, 12 cases) — schema-level accept/reject for `TIMESTAMP_MS` and the signed `BigNum` decoder (normal, `>2^53`, negative, zero, null→undefined, and rejection of floats / non-numeric strings / bare numbers).
- `tron-portal-source.test.ts` (2 cases) — end-to-end through the real `JSON.parse` path: a block with `timestamp`/`expiration` = `639208360527210660` streams through; negative `feeLimit`/`fee`/`netFee`/`energyUsage`/`withdrawAmount` parse to negative bigints. Both fail on the pre-fix code.

## Test plan
- [x] `vitest run src/tron src/portal-client/query/tron.test.ts` — 21 passed
- [x] `tsc --noEmit` — clean
- [x] `biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
