### PR TITLE
fix(portal-client): require previous blocks before reading a 409 as a fork

### DIFF
--- a/packages/pipes/src/portal-client/client.test.ts
+++ b/packages/pipes/src/portal-client/client.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
+import { HttpError } from '~/http-client/index.js'
 import { PortalClient } from '~/portal-client/client.js'
+import { isForkException } from '~/portal-client/fork-exception.js'
 import { MockPortal, MockResponse, mockPortal } from '~/testing/index.js'
 
 let portal: MockPortal | undefined
@@ -115,6 +117,92 @@ describe('PortalClient batching', () => {
 
     expect(shapes.some((s) => s.includes(1) && s.length > 1)).toBe(false)
     expect(shapes).toEqual([[1], [2], [3]])
+  })
+})
+
+describe('PortalClient fork detection', () => {
+  /** Drains the stream and returns whatever it threw. */
+  async function streamError(client: PortalClient): Promise<unknown> {
+    try {
+      for await (const _ of client.getStream(query, { request: { retryAttempts: 0 } })) {
+        // a fork faults the stream before any batch
+      }
+
+      return undefined
+    } catch (err: unknown) {
+      return err
+    }
+  }
+
+  // The pre-ADR-011 shape, and still the only part of the body that is read.
+  it('reads a fork from a 409 that carries previous blocks alone', async () => {
+    portal = await mockPortal([
+      { statusCode: 409, data: { previousBlocks: [{ number: 1, hash: '0x1' }] } },
+    ] satisfies MockResponse[])
+
+    const client = new PortalClient({ url: portal.url })
+    const err = await streamError(client)
+
+    expect(isForkException(err)).toBe(true)
+    expect((err as any).canonicalBlocks).toEqual([{ number: 1, hash: '0x1' }])
+  })
+
+  // ADR-011 put `error` beside `previousBlocks`, not in place of it.
+  it('reads a fork from a 409 that also carries the error envelope', async () => {
+    portal = await mockPortal([
+      {
+        statusCode: 409,
+        data: {
+          previousBlocks: [{ number: 1, hash: '0x1' }],
+          error: {
+            type: 'invalid_request_error',
+            code: 'base_block_mismatch',
+            message: 'Base block mismatch',
+          },
+        },
+      },
+    ] satisfies MockResponse[])
+
+    const client = new PortalClient({ url: portal.url })
+    const err = await streamError(client)
+
+    expect(isForkException(err)).toBe(true)
+    expect((err as any).canonicalBlocks).toEqual([{ number: 1, hash: '0x1' }])
+  })
+
+  // Read as a fork, this walks an undefined list and throws a TypeError over the status.
+  it('surfaces a 409 that carries no previous blocks instead of misreading it as a fork', async () => {
+    portal = await mockPortal([
+      {
+        statusCode: 409,
+        data: {
+          error: {
+            type: 'invalid_request_error',
+            code: 'base_block_mismatch',
+            message: 'Base block mismatch',
+          },
+        },
+      },
+    ] satisfies MockResponse[])
+
+    const client = new PortalClient({ url: portal.url })
+    const err = await streamError(client)
+
+    expect(isForkException(err)).toBe(false)
+    expect(err).toBeInstanceOf(HttpError)
+    expect((err as HttpError).response.status).toBe(409)
+  })
+
+  // No ancestor to walk back to either, and `last()` throws on it.
+  it('surfaces a 409 whose previous blocks are an empty list', async () => {
+    portal = await mockPortal([{ statusCode: 409, data: { previousBlocks: [] } }] satisfies MockResponse[])
+
+    const client = new PortalClient({ url: portal.url })
+    const err = await streamError(client)
+
+    expect(isForkException(err)).toBe(false)
+    expect(err).toBeInstanceOf(HttpError)
+    expect((err as HttpError).response.status).toBe(409)
   })
 })
 

--- a/packages/pipes/src/portal-client/client.ts
+++ b/packages/pipes/src/portal-client/client.ts
@@ -106,9 +106,13 @@ export interface PortalBlockStreamOptions {
  */
 export interface PortalBlockStream<B> extends AsyncIterable<StreamData<B>> {}
 
+/** The portal can answer 409 with the error envelope alone, leaving no chain to walk back to. */
 function isForkHttpError(err: unknown): err is HttpError {
   if (!(err instanceof HttpError)) return false
   if (err.response.status !== 409) return false
+
+  const previousBlocks = err.response.body?.previousBlocks
+  if (!Array.isArray(previousBlocks) || previousBlocks.length === 0) return false
 
   return true
 }

--- a/packages/pipes/src/testing/test-portal.ts
+++ b/packages/pipes/src/testing/test-portal.ts
@@ -32,11 +32,17 @@ export type MockResponse =
     }
   | {
       statusCode: 409
+      /** The body verbatim: since ADR-011 `error` sits beside `previousBlocks`, or stands alone. */
       data: {
-        previousBlocks: {
+        previousBlocks?: {
           number: number
           hash: string
         }[]
+        error?: {
+          type: string
+          code: string
+          message: string
+        }
       }
       validateRequest?: ValidateRequest
     }


### PR DESCRIPTION
## Why

`isForkHttpError` tested only the status:

```ts
if (err.response.status !== 409) return false
return true
```

Every 409 was therefore handed to `ForkException`, whose constructor calls `last(canonicalBlocks)`. When the body carries no usable `previousBlocks`, that is:

- **absent** → `last(undefined)` → `TypeError: Cannot read properties of undefined (reading 'length')`
- **empty** → `Error: last() was called on empty array`

Either way the 409 the caller needed to see is replaced by an error about the client's own internals — and on `PortalSource`, which runs with `retryAttempts: Number.MAX_SAFE_INTEGER`, that error is what faults the stream.

This was latent while hotblocks put its own flat body with `previousBlocks` on every 409. The portal's [error taxonomy change](https://github.com/subsquid/sqd-portal/pull/132) makes it reachable: the portal now parses the upstream list into a typed, non-empty one and answers 409 with the ADR-011 envelope alone when it cannot, listed there under *Not addressed* — "A proxied 409 with no `previousBlocks` still answers 409".

`@subsquid/portal-client` in squid-sdk has carried the equivalent guard since it was written; this brings us in line with it.

## What

A 409 is read as a fork only when it carries a non-empty `previousBlocks`. Anything else propagates as the `HttpError` it already was, so the status and body reach the caller intact.

The 409 mock in `~/testing/` gains the portal's real body shape — `previousBlocks` optional, `error` envelope beside it — so the case can be expressed at all. Existing call sites pass `{previousBlocks: [...]}` and are unaffected.

## Tests

Four cases in `src/portal-client/client.test.ts`, all against the internal `mockPortal`:

| Test | Pins |
|---|---|
| `reads a fork from a 409 that carries previous blocks alone` | the pre-ADR-011 shape, still accepted — only `previousBlocks` is read, so a body with no `error` is unaffected. Passes on `main` too; it is here so both accepted forms sit together rather than one of them living implicitly in `portal-source.test.ts` |
| `reads a fork from a 409 that also carries the error envelope` | ADR-011 put `error` *beside* `previousBlocks`, not in place of it — the recovery contract still works next to it |
| `surfaces a 409 that carries no previous blocks instead of misreading it as a fork` | the regression: fails on `main` with `expected TypeError: Cannot read properties of unde… to be an instance of HttpError` |
| `surfaces a 409 whose previous blocks are an empty list` | an empty list strands the client exactly as a missing one does |

## Coverage diff

Scope: `src/portal-client/**`, over `src/portal-client` + `src/core/portal-source.test.ts`.

| | base | head | |
|---|---|---|---|
| `client.ts` — branch | 88.88% | **90.54%** | +1.66 |
| `client.ts` — lines | 85.71% | **85.81%** | +0.10 |
| `portal-client/` — branch | 92.76% | **93.75%** | +0.99 |
| all files — branch | 90.43% | **91.24%** | +0.81 |

## Verification

`643 passed` across 49 files (`vitest run`, excluding the ClickHouse/Postgres/BigQuery integration suites, which need external services). `tsc --noEmit` clean, Biome clean.

`src/targets/delta-db/delta-db-target.test.ts` fails to load locally — untracked work in progress on this machine, not part of this branch.

## Note for reviewers

Two portal changes land alongside this one and are **not** addressed here, since neither is a defect in the SDK — both are the portal doing what its new taxonomy intends:

- **Integrity failure moved 503 → 500.** 500 is not retryable here, so a stream that used to retry forever now fails on the first response. That is the point of `api_error` (do not retry a portal bug), but it converts a stall into a hard failure.
- **Timestamp resolution now returns the classified upstream status** instead of a uniform 503. `resolveTimestamp` — reached from `QueryBuilder` whenever `from`/`to` is a `Date` — can now see a non-retryable 400 where it previously saw a retryable 503.

Worth deciding deliberately rather than discovering in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

