### PR TITLE
fix(core): keep a bounded stream alive until the finalized head reaches its range end

### DIFF
--- a/packages/pipes/src/core/bounded-range-finality.test.ts
+++ b/packages/pipes/src/core/bounded-range-finality.test.ts
@@ -134,6 +134,38 @@ describe('bounded range above the finalized head', () => {
     expect(polls).toBe(0)
   })
 
+  it('treats a headless finalized-head poll as no progress and keeps waiting', async () => {
+    // The first poll finds no finalized head at all (204); the second finds it at toBlock.
+    let polls = 0
+    portal = await mockPortal(
+      [
+        {
+          statusCode: 200,
+          data: [1, 2, 3].map((number) => ({ header: { number, hash: `0x${number}`, timestamp: number * 1000 } })),
+          head: { finalized: { number: 1, hash: '0x1' }, latest: { number: 3 } },
+        },
+      ],
+      {
+        finalizedHead: () => {
+          polls++
+          return polls === 1 ? undefined : { number: 3, hash: '0x3' }
+        },
+      },
+    )
+
+    const stream = evmPortalStream({
+      id: 'test',
+      portal: { url: portal.url, headPollIntervalMs: 5 },
+      outputs: blockDecoder({ from: 1, to: 3 }),
+    })
+
+    const finalizedSeen: (number | undefined)[] = []
+    await stream.pipeTo(target(finalizedSeen) as any)
+
+    expect(finalizedSeen.at(-1)).toBe(3)
+    expect(polls).toBe(2)
+  })
+
   it('retries a bounded range the portal answers with no data instead of ending it short', async () => {
     // First response: 200 with an empty body (no blocks at fromBlock yet). Second: the data.
     portal = await mockPortal([

--- a/packages/pipes/src/core/bounded-range-finality.test.ts
+++ b/packages/pipes/src/core/bounded-range-finality.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createTarget } from '~/core/target.js'
+import { evmPortalStream } from '~/evm/index.js'
+import { MockPortal, blockDecoder, mockPortal } from '~/testing/index.js'
+
+/**
+ * A bounded stream (`toBlock` set) whose upper end sits above the portal's current finalized head.
+ *
+ * Delivering every block is not enough to end such a stream: a finalized-only target (parquet)
+ * holds rows back until some batch reports them final, and the batch that delivered the tail
+ * reported a finalized head BELOW `toBlock`. If the stream ends there, the target discards the
+ * tail it was never allowed to commit — the run "succeeds" with the data ending short of
+ * `toBlock`, which is how the Avalanche backfill shipped a range its completion marker claimed
+ * but its files did not cover.
+ *
+ * The contract under test: `pipeTo` resolves only after the consumer has been shown a finalized
+ * head at (or above) `toBlock` — waiting for finality to catch up, not crashing, not ending short.
+ */
+describe('bounded range above the finalized head', () => {
+  let portal: MockPortal
+
+  afterEach(async () => {
+    await portal?.close()
+  })
+
+  const target = (finalizedSeen: (number | undefined)[]) =>
+    createTarget({
+      write: async ({ read }) => {
+        for await (const { ctx } of read()) {
+          finalizedSeen.push(ctx.stream.head.finalized?.number)
+        }
+      },
+    })
+
+  it('does not resolve pipeTo before the finalized head reaches toBlock', async () => {
+    // One response delivers every requested block (1..3) but reports finality only up to 1 —
+    // the shape a backfill sees when its END_BLOCK is above the current finalized head. The
+    // portal's finalized head then advances one block per poll.
+    let finalizedNow = 1
+    const polled: number[] = []
+    portal = await mockPortal(
+      [
+        {
+          statusCode: 200,
+          data: [1, 2, 3].map((number) => ({ header: { number, hash: `0x${number}`, timestamp: number * 1000 } })),
+          head: { finalized: { number: 1, hash: '0x1' }, latest: { number: 3 } },
+        },
+      ],
+      {
+        finalizedHead: () => {
+          finalizedNow = Math.min(finalizedNow + 1, 3)
+          polled.push(finalizedNow)
+          return { number: finalizedNow, hash: `0x${finalizedNow}` }
+        },
+      },
+    )
+
+    const stream = evmPortalStream({
+      id: 'test',
+      portal: { url: portal.url, headPollIntervalMs: 5 },
+      outputs: blockDecoder({ from: 1, to: 3 }),
+    })
+
+    const finalizedSeen: (number | undefined)[] = []
+    await stream.pipeTo(target(finalizedSeen) as any)
+
+    // Without the finality wait this resolved right after the [1..3] batch: the tail (2..3) was
+    // delivered but never reported final, so finalizedSeen ended at 1.
+    expect(finalizedSeen.at(-1)).toBe(3)
+    // It took more than one poll: finality was genuinely waited for, not assumed.
+    expect(polled).toEqual([2, 3])
+  })
+
+  it('ends immediately when the delivered blocks are already final', async () => {
+    let polls = 0
+    portal = await mockPortal(
+      [
+        {
+          statusCode: 200,
+          data: [1, 2, 3].map((number) => ({ header: { number, hash: `0x${number}`, timestamp: number * 1000 } })),
+          head: { finalized: { number: 5, hash: '0x5' }, latest: { number: 5 } },
+        },
+      ],
+      {
+        finalizedHead: () => {
+          polls++
+          return { number: 5, hash: '0x5' }
+        },
+      },
+    )
+
+    const stream = evmPortalStream({
+      id: 'test',
+      portal: portal.url,
+      outputs: blockDecoder({ from: 1, to: 3 }),
+    })
+
+    const finalizedSeen: (number | undefined)[] = []
+    await stream.pipeTo(target(finalizedSeen) as any)
+
+    expect(finalizedSeen).toEqual([5])
+    expect(polls).toBe(0)
+  })
+
+  it('ends immediately on a no-finality dataset — there is nothing to wait for', async () => {
+    let polls = 0
+    portal = await mockPortal(
+      [
+        {
+          statusCode: 200,
+          data: [1, 2, 3].map((number) => ({ header: { number, hash: `0x${number}`, timestamp: number * 1000 } })),
+          // no head at all → the dataset reports no finality
+        },
+      ],
+      {
+        finalizedHead: () => {
+          polls++
+          return undefined
+        },
+      },
+    )
+
+    const stream = evmPortalStream({
+      id: 'test',
+      portal: portal.url,
+      outputs: blockDecoder({ from: 1, to: 3 }),
+    })
+
+    const finalizedSeen: (number | undefined)[] = []
+    await stream.pipeTo(target(finalizedSeen) as any)
+
+    expect(finalizedSeen).toEqual([undefined])
+    expect(polls).toBe(0)
+  })
+
+  it('retries a bounded range the portal answers with no data instead of ending it short', async () => {
+    // First response: 200 with an empty body (no blocks at fromBlock yet). Second: the data.
+    portal = await mockPortal([
+      { statusCode: 200, data: [], head: { finalized: { number: 3, hash: '0x3' }, latest: { number: 3 } } },
+      {
+        statusCode: 200,
+        data: [1, 2, 3].map((number) => ({ header: { number, hash: `0x${number}`, timestamp: number * 1000 } })),
+        head: { finalized: { number: 3, hash: '0x3' }, latest: { number: 3 } },
+      },
+    ])
+
+    const stream = evmPortalStream({
+      id: 'test',
+      portal: { url: portal.url, headPollIntervalMs: 5 },
+      outputs: blockDecoder({ from: 1, to: 3 }),
+    })
+
+    const finalizedSeen: (number | undefined)[] = []
+    await stream.pipeTo(target(finalizedSeen) as any)
+
+    expect(finalizedSeen.at(-1)).toBe(3)
+  })
+})

--- a/packages/pipes/src/core/portal-source.test.ts
+++ b/packages/pipes/src/core/portal-source.test.ts
@@ -545,7 +545,13 @@ describe('Portal abstract stream', () => {
       await stream.pipeTo(target as any)
 
       // The persisted floor (5) survives the restart and clamps the lower reported head (3).
-      expect(seen).toEqual([{ number: 5, hash: '0x5f' }])
+      // The second batch is the finality catch-up: the range ends at 6, above every reported
+      // finalized head, so the stream waits for finality (the mock finalizes what it served)
+      // and delivers the caught-up head before ending.
+      expect(seen).toEqual([
+        { number: 5, hash: '0x5f' },
+        { number: 6, hash: '0x6' },
+      ])
     })
 
     it('leaves finalized undefined for a no-finality dataset (passthrough)', async () => {
@@ -702,9 +708,10 @@ describe('stop lifecycle', () => {
       }),
     )
 
-    // Two yielded, one dropped from the 204, one armed for the batch that never arrives.
+    // Two yielded, one dropped from the 204, one for the finality catch-up (the range ends at 2,
+    // above the reported finalized head 0), one armed for the batch that never arrives.
     expect(blocks.length).toBe(2)
-    expect(spans.started['batch']).toBe(4)
+    expect(spans.started['batch']).toBe(5)
     expect(spans.unbalanced()).toEqual([])
   })
 

--- a/packages/pipes/src/core/portal-source.ts
+++ b/packages/pipes/src/core/portal-source.ts
@@ -220,6 +220,13 @@ export class PortalStream<Q extends QueryBuilder<any>, T = any> {
       this.#logger.warn(NOT_REAL_TIME_WARNING(datasetMetadata.dataset))
     }
 
+    // What the consumer has been shown so far: the cursor of the last delivered block and the
+    // finalized head that came with it. Both seed from the resume state. They decide whether an
+    // otherwise-empty batch carries news the consumer must see — the finality catch-up a bounded
+    // stream emits after its final block (see the portal client's finality wait).
+    let lastYielded = cursor
+    let consumerFinalized = state?.finalized?.number
+
     for (const { range, request } of bounded) {
       // Anchor the cursor's hash only to the range that continues from it; a later disjoint range
       // doesn't border the cursor and would fault a spurious 409, so it starts unanchored (ADR-20).
@@ -302,12 +309,65 @@ export class PortalStream<Q extends QueryBuilder<any>, T = any> {
               },
             }
 
+            lastYielded = ctx.stream.state.current
+            consumerFinalized = finalized?.number ?? consumerFinalized
+
             const data = await this.applyTransformers(ctx, batch.blocks as T)
 
             yield { data, ctx }
           } else {
-            // Never yielded, so batchEnd won't run.
-            batchSpan.end()
+            // An empty batch normally carries nothing the consumer needs. The exception: when it
+            // advances the finalized head over the last delivered block — the catch-up a bounded
+            // stream emits after its final block. Withholding that one would leave a
+            // finalized-only target holding a tail it never learns is final.
+            const finalized = this.#watermark.clamp(batch.head.finalized)
+            if (
+              lastYielded != null &&
+              finalized != null &&
+              finalized.number >= lastYielded.number &&
+              finalized.number > (consumerFinalized ?? -1)
+            ) {
+              const ctx: BatchContext = {
+                id: this.#id,
+                profiler: batchSpan,
+                metrics: this.#metricServer.metrics,
+                logger: this.#logger,
+                stream: {
+                  dataset: datasetMetadata,
+                  head: {
+                    finalized,
+                    latest: batch.head.latest,
+                  },
+                  query: {
+                    url: this.#portal.getUrl(),
+                    hash: await hashQuery(query),
+                    raw: query,
+                  },
+                  state: {
+                    initial,
+                    ranges,
+                    current: lastYielded,
+                    last: last(bounded)?.range?.to ?? batch.head.latest?.number ?? finalized.number,
+                    rollbackChain: [],
+                  },
+                },
+                batch: {
+                  blocksCount: 0,
+                  bytesSize: batch.meta.bytes,
+                  requests: batch.meta.requests,
+                  lastBlockReceivedAt: batch.meta.lastBlockReceivedAt,
+                },
+              }
+
+              consumerFinalized = finalized.number
+
+              const data = await this.applyTransformers(ctx, batch.blocks as T)
+
+              yield { data, ctx }
+            } else {
+              // Never yielded, so batchEnd won't run.
+              batchSpan.end()
+            }
           }
 
           batchSpan = Span.root('batch', this.#options.profiler).addLabels('core')

--- a/packages/pipes/src/portal-cache/node/portal-cache.test.ts
+++ b/packages/pipes/src/portal-cache/node/portal-cache.test.ts
@@ -463,6 +463,53 @@ describe('Portal cache', () => {
               },
             },
           },
+          {
+            "data": [],
+            "meta": {
+              "head": {
+                "finalized": {
+                  "hash": "0x5",
+                  "number": 5,
+                },
+                "latest": undefined,
+              },
+              "meta": {
+                "bytesSize": 0,
+              },
+              "query": {
+                "hash": "1137b8a50718df4ec48060ae5cef9c8e929b619a23846c34a2535b3548b589c5",
+                "raw": {
+                  "fields": {
+                    "block": {
+                      "hash": true,
+                      "number": true,
+                      "timestamp": true,
+                    },
+                  },
+                  "fromBlock": 0,
+                  "parentBlockHash": undefined,
+                  "toBlock": 5,
+                  "type": "evm",
+                },
+              },
+              "state": {
+                "current": {
+                  "hash": "0x5",
+                  "number": 5,
+                  "timestamp": 5000,
+                },
+                "initial": 0,
+                "last": 5,
+                "ranges": [
+                  {
+                    "from": 0,
+                    "to": 5,
+                  },
+                ],
+                "rollbackChain": [],
+              },
+            },
+          },
         ]
       `)
       expect(res2).toMatchInlineSnapshot(`
@@ -483,8 +530,8 @@ describe('Portal cache', () => {
             "meta": {
               "head": {
                 "finalized": {
-                  "hash": "0x2",
-                  "number": 2,
+                  "hash": "0x5",
+                  "number": 5,
                 },
                 "latest": undefined,
               },

--- a/packages/pipes/src/portal-client/client.test.ts
+++ b/packages/pipes/src/portal-client/client.test.ts
@@ -50,13 +50,14 @@ async function countRequests(
 }
 
 describe('PortalClient batching', () => {
-  // What every target except Postgres gets.
+  // What every target except Postgres gets. Finality covers the whole range so the stream ends
+  // without a finality catch-up batch — that path has its own tests below.
   it('delivers one batch per response by default', async () => {
     portal = await mockPortal([
       {
         statusCode: 200,
         data: [block(1), block(2), block(3)],
-        head: { finalized: { number: 2, hash: '0x2' } },
+        head: { finalized: { number: 3, hash: '0x3' } },
       },
     ])
 
@@ -77,7 +78,9 @@ describe('PortalClient batching', () => {
 
     const client = new PortalClient({ url: portal.url })
 
-    expect(await batchShapes(client, true)).toEqual([[1], [2], [3]])
+    // The trailing [] is the finality catch-up: the range ends above the reported finalized
+    // head, so the stream waits for finality and delivers it as one final empty batch.
+    expect(await batchShapes(client, true)).toEqual([[1], [2], [3], []])
   })
 
   // Read as "no finality", every hot block would be filed as finalized instead.
@@ -92,7 +95,7 @@ describe('PortalClient batching', () => {
 
     const client = new PortalClient({ url: portal.url })
 
-    expect(await batchShapes(client, true)).toEqual([[1], [2], [3]])
+    expect(await batchShapes(client, true)).toEqual([[1], [2], [3], []])
   })
 
   // maxIdleTimeMs is pinned high so only cut() can separate the batches — on the default 300ms an
@@ -116,7 +119,7 @@ describe('PortalClient batching', () => {
     const shapes = await batchShapes(client, true, { maxIdleTimeMs: 60_000 })
 
     expect(shapes.some((s) => s.includes(1) && s.length > 1)).toBe(false)
-    expect(shapes).toEqual([[1], [2], [3]])
+    expect(shapes).toEqual([[1], [2], [3], []])
   })
 })
 
@@ -235,7 +238,8 @@ describe('PortalClient request accounting', () => {
       },
     ] satisfies MockResponse[])
 
-    const client = new PortalClient({ url: portal.url })
+    // A blockless 200 now waits before the re-ask (no more hot-looping the portal); keep it short.
+    const client = new PortalClient({ url: portal.url, headPollIntervalMs: 5 })
 
     expect(await countRequests(client)).toEqual({ 200: 2 })
   })
@@ -269,7 +273,7 @@ describe('PortalClient request accounting', () => {
       },
     ] satisfies MockResponse[])
 
-    const client = new PortalClient({ url: portal.url })
+    const client = new PortalClient({ url: portal.url, headPollIntervalMs: 5 })
 
     expect(await countRequests(client, false, { request: { retryAttempts: 2, retrySchedule: [1] } })).toEqual({
       200: 2,

--- a/packages/pipes/src/portal-client/client.ts
+++ b/packages/pipes/src/portal-client/client.ts
@@ -197,8 +197,12 @@ export class PortalClient {
       headPollInterval: options?.headPollIntervalMs ?? this.#options.headPollInterval,
     }
 
-    return createPortalStream(query, settings, async (q, o) =>
-      this.getStreamRequest((options?.finalized ?? this.#options.finalized) ? 'finalized-stream' : 'stream', q, o),
+    return createPortalStream(
+      query,
+      settings,
+      async (q, o) =>
+        this.getStreamRequest((options?.finalized ?? this.#options.finalized) ? 'finalized-stream' : 'stream', q, o),
+      async () => this.getHead({ ...settings.request, finalized: true }),
     )
   }
 
@@ -264,6 +268,7 @@ function createPortalStream<Q extends Query>(
     status: number
     stream?: AsyncIterable<string[]> | null | undefined
   }>,
+  getFinalizedHead: () => Promise<BlockRef | undefined>,
 ): PortalBlockStream<GetBlock<Q>> {
   const { headPollInterval, request, perBlockUnfinalized, ...bufferOptions } = options
   const buffer = new StreamBuffer<GetBlock<Q>>(bufferOptions)
@@ -274,10 +279,46 @@ function createPortalStream<Q extends Query>(
   // survive into the next iteration.
   let requests: Record<number, number> = {}
 
+  // Highest finalized head any response has reported. Stays undefined for a no-finality dataset,
+  // which is also the answer to whether there is anything to wait for at the end of a range.
+  let finalizedSeen: number | undefined
+
+  // Cadence for re-asking the portal when it has nothing for us yet — finality still below
+  // `toBlock`, or a bounded range answered with no data. `headPollInterval` keeps its opt-in
+  // role for the 204 head-tail; this one must never hot-loop, so it defaults on.
+  const retryInterval = headPollInterval > 0 ? headPollInterval : 1_000
+
   const ingest = async () => {
     while (!buffer.signal.aborted) {
-      if (toBlock != null && fromBlock > toBlock) break
+      if (toBlock != null && fromBlock > toBlock) {
+        if (finalizedSeen == null || finalizedSeen >= toBlock) break
 
+        // Every requested block is delivered, but finality is still below `toBlock`. Ending here
+        // would strand the tail: a finalized-only consumer holds rows back until some batch
+        // reports them final, and after the last block no such batch would ever come — the stream
+        // "completes" while the consumer silently discards what it was never allowed to commit.
+        // So poll the finalized head until it reaches `toBlock` and deliver the catch-up as one
+        // final empty batch. This waits exactly as long as finality itself does — for a range
+        // ending above the chain's current finalized head, minutes, not forever.
+        const head = await getFinalizedHead()
+        if (head != null && head.number > finalizedSeen) {
+          finalizedSeen = head.number
+          if (head.number >= toBlock) {
+            await buffer.put({
+              blocks: [],
+              head: { finalized: head },
+              meta: { bytes: 0, requestedFromBlock: fromBlock, lastBlockReceivedAt: new Date(), requests },
+            })
+            requests = {}
+            buffer.flush()
+            break
+          }
+        }
+        await wait(retryInterval, buffer.signal)
+        continue
+      }
+
+      const requestedFrom = fromBlock
       const res = await requestStream(
         {
           ...query,
@@ -295,6 +336,10 @@ function createPortalStream<Q extends Query>(
         },
       )
 
+      if (res.head.finalized != null) {
+        finalizedSeen = Math.max(finalizedSeen ?? -1, res.head.finalized.number)
+      }
+
       // We are on head, we need to wait a little bit until new dta arrives
       if (res.status === 204) {
         await buffer.put({
@@ -310,9 +355,15 @@ function createPortalStream<Q extends Query>(
         continue
       }
 
-      // If data is missing for a particular range,
-      // portal responds with 200 status and empty body
-      if (res.stream == null) break
+      // A 200 with no body: the portal has no data at `fromBlock` right now. For an open-ended
+      // stream that is the end of the dataset. For a bounded range it is a promise not yet kept —
+      // sealed chunks and hotblocks both lag the chain — so keep asking until the data shows up
+      // rather than silently ending `fromBlock..toBlock` short.
+      if (res.stream == null) {
+        if (toBlock == null) break
+        await wait(retryInterval, buffer.signal)
+        continue
+      }
 
       try {
         for await (let data of res.stream) {
@@ -418,6 +469,12 @@ function createPortalStream<Q extends Query>(
         if (!isStreamAbortedError(err)) {
           throw err
         }
+      }
+
+      // A response that advanced nothing (a 200 whose body carried no blocks) would otherwise be
+      // re-asked in a hot loop; pace it like the other empty answers.
+      if (fromBlock === requestedFrom) {
+        await wait(retryInterval, buffer.signal)
       }
     }
   }

--- a/packages/pipes/src/portal-client/client.ts
+++ b/packages/pipes/src/portal-client/client.ts
@@ -81,7 +81,7 @@ export interface PortalClientOptions {
 
 export type PortalRequestOptions = Pick<
   RequestOptions,
-  'headers' | 'retryAttempts' | 'retrySchedule' | 'httpTimeout' | 'bodyTimeout'
+  'headers' | 'retryAttempts' | 'retrySchedule' | 'httpTimeout' | 'bodyTimeout' | 'abort'
 >
 
 export interface PortalBlockStreamOptions {
@@ -202,7 +202,7 @@ export class PortalClient {
       settings,
       async (q, o) =>
         this.getStreamRequest((options?.finalized ?? this.#options.finalized) ? 'finalized-stream' : 'stream', q, o),
-      async () => this.getHead({ ...settings.request, finalized: true }),
+      async (signal) => this.getHead({ ...settings.request, finalized: true, abort: signal }),
     )
   }
 
@@ -268,7 +268,7 @@ function createPortalStream<Q extends Query>(
     status: number
     stream?: AsyncIterable<string[]> | null | undefined
   }>,
-  getFinalizedHead: () => Promise<BlockRef | undefined>,
+  getFinalizedHead: (signal?: AbortSignal) => Promise<BlockRef | undefined>,
 ): PortalBlockStream<GetBlock<Q>> {
   const { headPollInterval, request, perBlockUnfinalized, ...bufferOptions } = options
   const buffer = new StreamBuffer<GetBlock<Q>>(bufferOptions)
@@ -300,7 +300,9 @@ function createPortalStream<Q extends Query>(
         // So poll the finalized head until it reaches `toBlock` and deliver the catch-up as one
         // final empty batch. This waits exactly as long as finality itself does — for a range
         // ending above the chain's current finalized head, minutes, not forever.
-        const head = await getFinalizedHead()
+        // Wired to the buffer's signal like every stream request: an aborted consumer must not
+        // leave the poll running until the HTTP timeout.
+        const head = await getFinalizedHead(buffer.signal)
         if (head != null && head.number > finalizedSeen) {
           finalizedSeen = head.number
           if (head.number >= toBlock) {

--- a/packages/pipes/src/targets/bigquery/bigquery-target.ts
+++ b/packages/pipes/src/targets/bigquery/bigquery-target.ts
@@ -202,9 +202,14 @@ export function bigqueryTarget<T>(options: {
               ),
             )
 
-            await span.measure('user onData', () =>
-              Promise.resolve(onData({ store, data, ctx: { logger, profiler: span } })),
-            )
+            // Skipped for a batch built from zero source blocks (the finality catch-up a bounded
+            // stream ends with): it carries no rows, and user handlers never saw blockless
+            // batches before. The commit below still runs to record the caught-up finalized head.
+            if (ctx.batch?.blocksCount !== 0) {
+              await span.measure('user onData', () =>
+                Promise.resolve(onData({ store, data, ctx: { logger, profiler: span } })),
+              )
+            }
 
             // `getBufferStats` encodes rows lazily and caches the result so the eventual
             // `commitBatch` doesn't re-encode — single source of truth for both logs.

--- a/packages/pipes/src/targets/clickhouse/clickhouse-target.test.ts
+++ b/packages/pipes/src/targets/clickhouse/clickhouse-target.test.ts
@@ -71,6 +71,8 @@ describe('Clickhouse state', () => {
       )
 
       const data = await getAllFromSyncTable()
+      // Two offsets: the batch that delivered 3..5 as unfinalized, then the finality catch-up a
+      // bounded stream waits for before ending (the mock portal finalizes everything it served).
       expect(data).toMatchInlineSnapshot(`
         [
           {
@@ -78,6 +80,13 @@ describe('Clickhouse state', () => {
             "finalized": "{"hash":"0x2","number":2}",
             "id": "test",
             "rollback_chain": "[{"number":3,"hash":"0x3","timestamp":3000},{"number":4,"hash":"0x4","timestamp":4000},{"number":5,"hash":"0x5","timestamp":5000}]",
+            "sign": 1,
+          },
+          {
+            "current": "{"number":5,"hash":"0x5","timestamp":5000}",
+            "finalized": "{"number":5,"hash":"0x5"}",
+            "id": "test",
+            "rollback_chain": "[]",
             "sign": 1,
           },
         ]
@@ -903,6 +912,13 @@ describe('Clickhouse state', () => {
             "finalized": "{"hash":"0x4a","number":4}",
             "id": "test",
             "rollback_chain": "[{"number":5,"hash":"0x5a","timestamp":5000},{"number":6,"hash":"0x6a","timestamp":6000},{"number":7,"hash":"0x7a","timestamp":7000}]",
+            "sign": 1,
+          },
+          {
+            "current": "{"number":7,"hash":"0x7a","timestamp":7000}",
+            "finalized": "{"number":7,"hash":"0x7a"}",
+            "id": "test",
+            "rollback_chain": "[]",
             "sign": 1,
           },
         ]

--- a/packages/pipes/src/targets/clickhouse/clickouse-target.ts
+++ b/packages/pipes/src/targets/clickhouse/clickouse-target.ts
@@ -114,16 +114,21 @@ export function clickhouseTarget<T>({
         const target = ctx.profiler.start({ name: 'clickhouse', labels: 'db' })
 
         try {
-          await target.measure('data handler', async (profiler) => {
-            await onData({
-              store,
-              data: data,
-              ctx: {
-                logger,
-                profiler,
-              },
+          // A batch built from zero source blocks (the finality catch-up a bounded stream ends
+          // with) carries no rows to insert; it exists so the offset below records the caught-up
+          // finalized head. User handlers never saw blockless batches before, so keep it that way.
+          if (ctx.batch?.blocksCount !== 0) {
+            await target.measure('data handler', async (profiler) => {
+              await onData({
+                store,
+                data: data,
+                ctx: {
+                  logger,
+                  profiler,
+                },
+              })
             })
-          })
+          }
 
           await state.saveCursor(ctx, target)
         } finally {

--- a/packages/pipes/src/targets/drizzle/node-postgres/drizzle-target.test.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/drizzle-target.test.ts
@@ -121,6 +121,8 @@ describe('Drizzle target', () => {
       )
 
       const rows = await getAllFromSyncTable('test')
+      // Block 5's offset reflects the finality catch-up a bounded stream ends with (the mock
+      // finalizes everything it served): finalized 5, nothing left to roll back.
       expect(rows).toMatchInlineSnapshot(`
         [
           {
@@ -173,17 +175,11 @@ describe('Drizzle target', () => {
             "current_number": "5",
             "current_timestamp": 1970-01-01T01:23:20.000Z,
             "finalized": {
-              "hash": "0x2",
-              "number": 2,
+              "hash": "0x5",
+              "number": 5,
             },
             "id": "test",
-            "rollback_chain": [
-              {
-                "hash": "0x5",
-                "number": 5,
-                "timestamp": 5000,
-              },
-            ],
+            "rollback_chain": [],
           },
         ]
       `)

--- a/packages/pipes/src/targets/drizzle/node-postgres/drizzle-target.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/drizzle-target.ts
@@ -136,16 +136,21 @@ export function drizzleTarget<T>({
                   SET LOCAL sqd.snapshot_block_number = ${ctx.stream.state.current.number};
                 `)
 
-                await target.measure('data handler', async (profiler) => {
-                  await onData({
-                    tx: tracker.wrapTransaction(tx),
-                    data,
-                    ctx: {
-                      logger,
-                      profiler,
-                    },
+                // Skipped for a batch built from zero source blocks (the finality catch-up a
+                // bounded stream ends with): it carries no rows, and user handlers never saw
+                // blockless batches before. The cursor save below still runs.
+                if (ctx.batch?.blocksCount !== 0) {
+                  await target.measure('data handler', async (profiler) => {
+                    await onData({
+                      tx: tracker.wrapTransaction(tx),
+                      data,
+                      ctx: {
+                        logger,
+                        profiler,
+                      },
+                    })
                   })
-                })
+                }
 
                 const { safeBlockNumber } = await state.saveCursor(tx, ctx, target)
                 if (safeBlockNumber > 0) {

--- a/packages/pipes/src/targets/drizzle/node-postgres/postgres-state.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/postgres-state.ts
@@ -166,6 +166,9 @@ export class PostgresState {
     const finalizedBlock = head.finalized?.number
 
     logger.debug(`Saving cursor at block ${current.number} for ${this.#key.value} row...`)
+    // Upsert: a finality catch-up batch (the empty batch a bounded stream ends with) re-saves the
+    // offset of the last delivered block with a newer finalized head; that must update the row,
+    // not trip the (id, current_number) primary key.
     await parentSpan.measure({ name: 'insert cursor', labels: 'db' }, async () => {
       await tx.execute(
         sql`
@@ -180,6 +183,11 @@ export class PostgresState {
               ${JSON.stringify(head.finalized || {})},
               ${JSON.stringify(rollbackChain || [])}
           )
+          ON CONFLICT (id, current_number) DO UPDATE SET
+              current_hash = EXCLUDED.current_hash,
+              "current_timestamp" = EXCLUDED."current_timestamp",
+              finalized = EXCLUDED.finalized,
+              rollback_chain = EXCLUDED.rollback_chain
         `,
       )
     })

--- a/packages/pipes/src/targets/memory/memory-target.test.ts
+++ b/packages/pipes/src/targets/memory/memory-target.test.ts
@@ -80,12 +80,15 @@ describe('createMemoryTarget', () => {
     const emitted: Row[][] = []
     await streamTo(portal, 5, emitted)
 
-    // Block 5 is never finalized, so it must not be emitted.
+    // Block 5 is above the last reported finalized head, so it is held back — until the
+    // finality catch-up the bounded stream ends with (the mock finalizes everything it served)
+    // releases it. Nothing is ever emitted ahead of a finalized head that covers it.
     const blockNumbers = emitted.flat().map((r) => r.blockNumber)
-    expect(blockNumbers).toEqual([1, 2, 3, 4])
+    expect(blockNumbers).toEqual([1, 2, 3, 4, 5])
 
-    // Buffered rows (2, 3) are released before the current batch's row (4).
-    expect(emitted.flat().map((r) => r.value)).toEqual([1n, 2n, 3n, 4n])
+    // Buffered rows (2, 3) are released before the current batch's row (4); 5 comes last, alone.
+    expect(emitted.flat().map((r) => r.value)).toEqual([1n, 2n, 3n, 4n, 5n])
+    expect(emitted.at(-1)!.map((r) => r.blockNumber)).toEqual([5])
   })
 
   it('passes every row straight through when the dataset has no finalized head', async () => {

--- a/packages/pipes/src/targets/parquet/custom-engine.test.ts
+++ b/packages/pipes/src/targets/parquet/custom-engine.test.ts
@@ -154,11 +154,12 @@ describe('parquetTarget with a custom engine', () => {
     // engine's own business (its factory), so no context travels across the seam.
     expect(calls).toEqual(['table:blocks'])
 
-    // Only the finalized rows (1-3) published; the file is named by the target for the coverage
-    // window — from the configured start (0) to the finalized boundary (3). The engine never saw
-    // the window or chose the name.
+    // All rows published: the bounded stream waits for finality to reach the range end (the mock
+    // finalizes everything it served), so the tail is released before the stream ends. The file
+    // is named by the target for the coverage window — from the configured start (0) to the
+    // final boundary (5). The engine never saw the window or chose the name.
     const files = (await readdir(path.join(dir, 'blocks'))).sort()
-    expect(files).toEqual(['000000000000-000000000003.parquet'])
+    expect(files).toEqual(['000000000000-000000000005.parquet'])
 
     // The published file is real Parquet, readable by an actual reader, with the rows the
     // engine received — in order, in the engine-neutral plain shape.
@@ -167,6 +168,8 @@ describe('parquetTarget with a custom engine', () => {
       [1n, '0x1'],
       [2n, '0x2'],
       [3n, '0x3'],
+      [4n, '0x4'],
+      [5n, '0x5'],
     ])
 
     // The checkpoint that published the segment also persisted the cursor.

--- a/packages/pipes/src/targets/parquet/parquet-target.test.ts
+++ b/packages/pipes/src/targets/parquet/parquet-target.test.ts
@@ -208,15 +208,32 @@ describe('parquetTarget', () => {
   })
 
   describe('finalized-only', () => {
-    it('does not write blocks above the finalized head', async () => {
-      portal = await mockPortal([blocksResponse([1, 2, 3, 4, 5], 2)])
+    it('never writes blocks above the finalized head, and publishes the tail only once finality reaches it', async () => {
+      // Finality sits at 2 for two polls, then catches up to 5. Snapshot the published files
+      // while it still lags: nothing above 2 may exist on disk at that point.
+      let polls = 0
+      let midStream: Promise<{ blockNumber: number }[]> | undefined
+      portal = await mockPortal([blocksResponse([1, 2, 3, 4, 5], 2)], {
+        finalizedHead: () => {
+          polls++
+          if (polls === 2) {
+            midStream = readBlocks(dir).catch(() => [])
+          }
+          return polls < 3 ? { number: 2, hash: '0x2' } : { number: 5, hash: '0x5' }
+        },
+      })
 
-      await evmPortalStream({ id: 'test', portal: portal.url, outputs: blockDecoder({ from: 0, to: 5 }) }).pipeTo(
-        parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }),
-      )
+      await evmPortalStream({
+        id: 'test',
+        portal: { url: portal.url, headPollIntervalMs: 5 },
+        outputs: blockDecoder({ from: 0, to: 5 }),
+      }).pipeTo(parquetTarget({ dir, tables: [BLOCKS_TABLE], onData: insertBlocks }))
 
-      // Only blocks 1–2 are finalized (head = 2); 3–5 stay buffered and are never written.
-      expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1, 2])
+      // The stream genuinely waited for finality rather than ending at delivery.
+      expect(polls).toBeGreaterThanOrEqual(3)
+      expect(((await midStream) ?? []).every((r) => r.blockNumber <= 2)).toBe(true)
+      // …and the tail is not silently dropped once finality arrives: all five land in files.
+      expect((await readBlocks(dir)).map((r) => r.blockNumber)).toEqual([1, 2, 3, 4, 5])
     })
 
     it('publishes previously-unfinalized blocks once a later batch finalizes them', async () => {
@@ -462,7 +479,13 @@ describe('parquetTarget', () => {
       )
 
       // The persisted floor (5) survives the restart and clamps the lower reported head (3).
-      expect(seen).toEqual([{ number: 5, hash: '0x5f' }])
+      // The second batch is the finality catch-up: the range ends at 6, above every reported
+      // finalized head, so the stream waits for finality (the mock finalizes what it served)
+      // and delivers the caught-up head before ending.
+      expect(seen).toEqual([
+        { number: 5, hash: '0x5f' },
+        { number: 6, hash: '0x6' },
+      ])
     })
   })
 

--- a/packages/pipes/src/targets/parquet/parquet-target.ts
+++ b/packages/pipes/src/targets/parquet/parquet-target.ts
@@ -312,10 +312,15 @@ export function parquetTarget<T>(options: {
               store.advanceCoverageInto(range.from)
             }
 
-            // 1. user stages rows via store.insert(...)
-            await target.measure('data handler', async (profiler) => {
-              await onData({ store, data, ctx: { logger, profiler } })
-            })
+            // 1. user stages rows via store.insert(...). Skipped for a batch built from zero
+            //    source blocks (the finality catch-up a bounded stream ends with): it carries no
+            //    rows, and user handlers never saw blockless batches before. Steps 2-4 still run —
+            //    the caught-up finalized head is exactly what releases the buffered tail.
+            if (ctx.batch?.blocksCount !== 0) {
+              await target.measure('data handler', async (profiler) => {
+                await onData({ store, data, ctx: { logger, profiler } })
+              })
+            }
 
             // 2. finalization + the cursor this batch could checkpoint to. The boundary carries the
             //    HASH needed for resume; boundary.number = min(finalized, current), correct for

--- a/packages/pipes/src/testing/test-portal.ts
+++ b/packages/pipes/src/testing/test-portal.ts
@@ -65,14 +65,35 @@ export async function finalizedMockPortal(mockResponses: MockResponse[]) {
 
 export async function mockPortal(
   mockResponses: MockResponse[],
-  { finalized = false }: { finalized?: boolean } = {},
+  {
+    finalized = false,
+    finalizedHead,
+  }: {
+    finalized?: boolean
+    /**
+     * Answer for GET `/finalized-head`, polled by a bounded stream whose delivered blocks are not
+     * yet reported final. Defaults to "everything served so far is final" — the highest block
+     * number any 200 response has carried — so existing scenarios complete without scripting it.
+     */
+    finalizedHead?: () => { number: number; hash: string } | undefined
+  } = {},
 ): Promise<MockPortal> {
   const promise = new Promise<Server>((resolve, reject) => {
     let requestCount = 0
+    let maxServedBlock: { number: number; hash: string } | undefined
 
     const streamUrl = finalized ? '/finalized-stream' : '/stream'
 
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      if (req.url === '/finalized-head') {
+        const head = finalizedHead ? finalizedHead() : maxServedBlock
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        if (head) {
+          res.write(JSON.stringify(head))
+        }
+        res.end()
+        return
+      }
       if (req.url?.startsWith('/metadata')) {
         res.writeHead(200, { 'Content-Type': 'application/json' })
         res.write(
@@ -134,6 +155,9 @@ export async function mockPortal(
             res.writeHead(mockResp.statusCode, headers)
             // Send each mock data item as a JSON line
             mockResp.data.forEach((data) => {
+              if (maxServedBlock == null || data.header.number > maxServedBlock.number) {
+                maxServedBlock = { number: data.header.number, hash: data.header.hash }
+              }
               res.write(JSON.stringify(data) + '\n')
             })
             break

--- a/packages/pipes/src/testing/test-portal.ts
+++ b/packages/pipes/src/testing/test-portal.ts
@@ -87,10 +87,15 @@ export async function mockPortal(
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
       if (req.url === '/finalized-head') {
         const head = finalizedHead ? finalizedHead() : maxServedBlock
-        res.writeHead(200, { 'Content-Type': 'application/json' })
-        if (head) {
-          res.write(JSON.stringify(head))
+        // No head → 204: a JSON content-type with an empty body would make the client's
+        // res.json() throw instead of resolving to undefined.
+        if (!head) {
+          res.writeHead(204)
+          res.end()
+          return
         }
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.write(JSON.stringify(head))
         res.end()
         return
       }


### PR DESCRIPTION
## Problem

A bounded stream (`toBlock` set) ends as soon as every requested block has been **delivered** — with no regard for whether the portal's reported finalized head has reached `toBlock`. Finalized-only targets (parquet) hold rows back until some batch reports them final; after the last block no such batch ever comes (empty batches are filtered out in `portal-source`), so `await pipeTo(...)` resolves while the target silently discards the unfinalized tail.

Concretely: a backfill whose `END_BLOCK` sits above the current finalized head "succeeds" with its output files ending short of `END_BLOCK`. This is how an Avalanche transactions backfill shipped a range its completion marker claimed but its parquet files did not cover (~1.7k blocks short — the gap between the network data source's reported finalized head and the range end).

## MRE

`packages/pipes/src/core/bounded-range-finality.test.ts`, first test: one response delivers blocks 1..3 but reports `finalized = 1` — the shape a backfill sees when `END_BLOCK` is above the current finalized head. On `main` the test fails with:

```
AssertionError: expected 1 to be 3
```

i.e. `pipeTo` resolved and the last finalized head the target ever saw was 1 — a finalized-only target must discard blocks 2..3, with no error anywhere.

## Fix

The contract is now: **a bounded stream ends only after the consumer has been shown a finalized head ≥ the range end** — waiting for finality to catch up, not crashing, not ending short.

- **portal-client** — after the last block of a bounded range, poll `GET /finalized-head` until it reaches `toBlock`, then deliver the catch-up as one final empty batch. No-finality datasets (no finalized head ever reported) and already-final ranges end exactly as before, without a single poll. A bounded range the portal answers with no data is retried on the same cadence instead of ending the range short, and a 200 that advanced nothing no longer re-requests in a hot loop.
- **portal-source** — forward an otherwise-filtered empty batch when it advances the finalized head over the last delivered block, so the consumer can commit its tail. All other empty batches stay filtered.
- **targets** (clickhouse / parquet / bigquery / drizzle) — skip the **user `onData` handler** for batches built from zero source blocks (user handlers never saw blockless batches before; one indexed `data[0]` and would crash). Finalization, cursor and offset persistence still run — recording the caught-up finalized head is the point of the batch. The postgres sync-table insert becomes an upsert, since the catch-up re-saves the last block's offset row with newer finality.

The wait is bounded by finality itself: for a range ending above the chain's current finalized head it is minutes. For a range the portal can never finalize (a frozen dataset) the stream now visibly waits instead of silently completing with missing data — the failure mode this bug traded that for.

## Tests

- New: `bounded-range-finality.test.ts` — the MRE (fails on `main`), plus no-poll fast-paths (already-final, no-finality) and the bounded no-data retry.
- The mock portal now serves `GET /finalized-head` (default: everything it served is final; scriptable per test).
- Updated existing snapshots/expectations that had frozen the old end-state — including a parquet test that literally asserted `3–5 stay buffered and are never written`, i.e. the incident behavior. It now asserts nothing is published above the finalized head *while finality lags*, and that the tail lands once finality arrives.
- Full suite: 734 passed (with local clickhouse + postgres services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)