### PR TITLE
test(portal-client): pin the bounded-range finality wait on /finalized-stream

### DIFF
--- a/packages/pipes/src/portal-client/client.test.ts
+++ b/packages/pipes/src/portal-client/client.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { HttpError } from '~/http-client/index.js'
 import { PortalClient } from '~/portal-client/client.js'
 import { isForkException } from '~/portal-client/fork-exception.js'
-import { MockPortal, MockResponse, mockPortal } from '~/testing/index.js'
+import { MockPortal, MockResponse, finalizedMockPortal, mockPortal } from '~/testing/index.js'
 
 let portal: MockPortal | undefined
 
@@ -275,5 +275,41 @@ describe('PortalClient request accounting', () => {
       200: 2,
       503: 1,
     })
+  })
+})
+
+describe('PortalClient bounded range above the finalized head', () => {
+  // A finalized stream's blocks are final by definition, so delivering `toBlock` is the exit
+  // condition — not the current finalized head. The hot stream has no counterpart contract: there
+  // finality is a response header, and the range ends once it has been delivered.
+  it('waits at the finalized head, polling, until toBlock is delivered', async () => {
+    const polled: number[] = []
+    portal = await finalizedMockPortal([
+      {
+        statusCode: 200,
+        data: [block(1), block(2), block(3)],
+        head: { finalized: { number: 3, hash: '0x3' } },
+      },
+      { statusCode: 204, validateRequest: (req) => polled.push(req.fromBlock) },
+      { statusCode: 204, validateRequest: (req) => polled.push(req.fromBlock) },
+      {
+        statusCode: 200,
+        data: [block(4), block(5)],
+        head: { finalized: { number: 5, hash: '0x5' } },
+        validateRequest: (req) => polled.push(req.fromBlock),
+      },
+    ] satisfies MockResponse[])
+
+    const client = new PortalClient({ url: portal.url, finalized: true, headPollIntervalMs: 5 })
+
+    const delivered: number[] = []
+    for await (const batch of client.getStream({ ...query, fromBlock: 1, toBlock: 5 })) {
+      delivered.push(...batch.blocks.map((b: any) => b.header.number))
+    }
+
+    // The stream neither ended short at the finalized head (3) nor crashed on the wait.
+    expect(delivered).toEqual([1, 2, 3, 4, 5])
+    // The tail was genuinely waited for: the endpoint kept being polled at the finalized head.
+    expect(polled).toEqual([4, 4, 4])
   })
 })


### PR DESCRIPTION
## Summary

One mock-portal test on `PortalClient`: a bounded range (`toBlock` set) requested on `/finalized-stream` whose end sits above the portal's current finalized head. The stream waits at the latest finalized block, polling the endpoint, and ends only once `toBlock` has been delivered — a finalized stream's blocks are final by definition, so delivery is the exit condition. It must not end short at the current finalized head, and must not crash on the wait.

Passes on `main`: the 204 poll loop already provides this. The test pins it as a regression guard, next to the ingest loop that implements it.

## What changed since the first revision

This PR originally also pinned three `/stream` counterparts, expected to fail until a follow-up implemented them. They are dropped, because the contract itself was wrong:

- `/finalized-stream` already gives a finalized-only consumer what it needs, and `finalized: true` is the correct configuration for a bounded backfill into such a target.
- On `/stream`, finality is a response header, not a completion condition. Ending once the range has been delivered is correct behavior; waiting there reimplements `/finalized-stream` more slowly, and never terminates for a dataset that never finalizes.
- The `fork crossing toBlock` case turned out to be the argument against the approach rather than a specification for it: waiting for finality on `/stream` is only correct if fork detection stays alive past the range end, otherwise the wait sits on a tail that has already been reorged out. Merged onto #143 locally, that case still fails, with the reorged-out blocks surviving in the target.

Reasoning in full in the review comment on this PR. The residual real defect — a bounded range completing successfully while a finalized-only target still holds uncommitted rows — is a target-side fix and is tracked separately.

CI is green again, with no intentionally-red tests landing. That matters here beyond tidiness: `bail: 1` aborts the whole run at the first failure, so the first revision's CI never executed 45 of 59 test files, and two of the three pinned contracts never ran there at all.

## Coverage

Scope `src/portal-client/**`, measured with `vitest run src/core src/portal-client` on base and head.

| | Stmts | Branch | Funcs |
|---|-------|--------|-------|
| `main` | 89.36% | 91.44% | 76.66% |
| this PR | 89.52% | 92.20% | 76.66% |
| Δ | +0.16 | +0.76 | 0.00 |

## Test plan

- [x] `/finalized-stream` bounded above the finalized head: full range delivered, endpoint polled at the wait point (`fromBlock` pinned per poll) — passes
- [x] `src/core` + `src/portal-client`: 225 passed, 15 files
