### PR TITLE
fix(drizzle): resolve real DB column names for snapshot triggers and rollback

### DIFF
--- a/packages/pipes/src/targets/drizzle/node-postgres/consts.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/consts.ts
@@ -1,13 +1,14 @@
 import { Column, Table } from 'drizzle-orm'
 import { Reference } from 'drizzle-orm/pg-core/foreign-keys'
 
+import { POSTGRES_ERROR_CODES, PostgresTargetError } from './errors.js'
+
 const DRIZZLE_TABLE_NAME = Symbol.for('drizzle:BaseName')
 const IS_DRIZZLE_TABLE = Symbol.for('drizzle:IsDrizzleTable')
 const DRIZZLE_TABLE_COLS = Symbol.for('drizzle:Columns')
 const DRIZZLE_TABLE_EXTRA_BUILDER = Symbol.for('drizzle:ExtraConfigBuilder')
 const DRIZZLE_TABLE_EXTRA_COLUMNS = Symbol.for('drizzle:ExtraConfigColumns')
 const DRIZZLE_INLINE_FOREIGN_KEYS = Symbol.for('drizzle:PgInlineForeignKeys')
-export const SQD_PRIMARY_COLS = Symbol.for('sqd:PrimaryColumns')
 
 export function isDrizzleTable(table: unknown) {
   if (!table || (typeof table !== 'object' && typeof table !== 'function')) return false
@@ -31,6 +32,34 @@ export function getDrizzleTableExtraConfig(table: Table) {
 
 export function getDrizzleTableExtraColumns(table: Table) {
   return ((table as any)[DRIZZLE_TABLE_EXTRA_COLUMNS] as Record<string, Column>) || {}
+}
+
+/**
+ * Resolves a column's real Postgres name.
+ *
+ * `col.name` holds the database name only for an explicitly named column (`integer('item_id')`).
+ * A column declared without one (`integer()`) keeps the JS property key there and gets its real
+ * name from the dialect's casing cache, so `drizzle(..., { casing: 'snake_case' })` has to be
+ * asked rather than guessed.
+ */
+export function createColumnNameResolver(db: unknown): (col: Column) => string {
+  const casing = (db as any)?.dialect?.casing
+
+  return (col) => {
+    if (!col.keyAsName) {
+      return col.name
+    }
+
+    const resolved = casing?.getColumnCasing?.(col)
+    if (!resolved) {
+      throw new PostgresTargetError(
+        POSTGRES_ERROR_CODES.COLUMN_NAME_UNRESOLVED,
+        `Cannot resolve the database name of column "${col.name}". Declare it explicitly, e.g. integer('${col.name}').`,
+      )
+    }
+
+    return resolved
+  }
 }
 
 export function getDrizzleForeignKeys(table: Table) {

--- a/packages/pipes/src/targets/drizzle/node-postgres/drizzle-target.test.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/drizzle-target.test.ts
@@ -1,6 +1,6 @@
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/node-postgres'
-import { integer, pgTable, varchar } from 'drizzle-orm/pg-core'
+import { integer, jsonb, numeric, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core'
 import { Pool, QueryResultRow } from 'pg'
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -26,6 +26,37 @@ async function getAllFromSyncTable(schema = 'public') {
   const res = await execute(`SELECT * FROM "${schema}"."sync" ORDER BY current_number ASC`)
 
   return res.rows
+}
+
+/** Blocks 1 and 2 written at the finalized head, then block 2 forks and 2a/3a replace it. */
+function forkAtBlockTwo(): MockResponse[] {
+  return [
+    ...[1, 2].map(
+      (block): MockResponse => ({
+        statusCode: 200,
+        data: [{ header: { number: block, hash: `0x${block}`, timestamp: block * 1000 } }],
+        head: { finalized: { number: 1, hash: '0x1' } },
+      }),
+    ),
+    {
+      // Forks block 2; the safe ancestor is the finalized block 1.
+      statusCode: 409,
+      data: {
+        previousBlocks: [
+          { number: 1, hash: '0x1' },
+          { number: 2, hash: '0x2a' },
+        ],
+      },
+    },
+    {
+      statusCode: 200,
+      data: [
+        { header: { number: 2, hash: '0x2a', timestamp: 2000 } },
+        { header: { number: 3, hash: '0x3a', timestamp: 3000 } },
+      ],
+      head: { finalized: { number: 1, hash: '0x1' } },
+    },
+  ]
 }
 
 describe('Drizzle target', () => {
@@ -1079,6 +1110,278 @@ describe('Drizzle target', () => {
           },
         ]
       `)
+    })
+  })
+
+  // The snapshot trigger runs against the base table's real columns (NEW./OLD.), not the Drizzle
+  // property keys. A schema that maps a camelCase key to a snake_case column must still snapshot
+  // and roll back correctly instead of failing with `column "..." does not exist`.
+  describe('snapshot trigger with a camelCase-to-snake_case column mapping', () => {
+    const items = pgTable('items', {
+      itemId: integer('item_id').primaryKey(),
+      itemValue: integer('item_value').notNull(),
+    })
+
+    beforeEach(async () => {
+      await execute(`
+        DROP SCHEMA IF EXISTS "public" CASCADE;
+        CREATE SCHEMA IF NOT EXISTS "public";
+        CREATE TABLE items (
+          item_id integer PRIMARY KEY,
+          item_value integer NOT NULL
+        );
+      `)
+    })
+
+    it('rolls back to the pre-fork value without a missing-column error', async () => {
+      portal = await mockPortal(forkAtBlockTwo())
+
+      let rollbackCount = 0
+      let rolledBackValue: number | undefined
+
+      await evmPortalStream({
+        id: 'test',
+        portal: portal.url,
+        outputs: blockDecoder({ from: 0, to: 3 }),
+      }).pipeTo(
+        drizzleTarget({
+          db,
+          tables: [items],
+          onData: async ({ tx, data }) => {
+            for (const b of data) {
+              if (b.number === 1) {
+                await tx.insert(items).values({ itemId: 1, itemValue: 10 })
+              } else if (b.number === 2) {
+                await tx.update(items).set({ itemValue: 20 }).where(eq(items.itemId, 1))
+              }
+            }
+          },
+          onAfterRollback: async ({ tx }) => {
+            rollbackCount++
+
+            // Captured at the rollback point, before block 2's replay overwrites it again.
+            const [row] = await tx.select().from(items).where(eq(items.itemId, 1))
+            rolledBackValue = row?.itemValue
+          },
+        }),
+      )
+
+      expect(rollbackCount).toEqual(1)
+      expect(rolledBackValue).toEqual(10)
+    })
+  })
+
+  // Columns declared without a name keep the JS property key in `col.name`; only the dialect's
+  // casing cache knows the real column, so the trigger has to ask it rather than guess.
+  describe('snapshot trigger under dialect-level casing', () => {
+    const snakeDb = drizzle(pool, { casing: 'snake_case' })
+
+    const items = pgTable('items', {
+      itemId: integer().primaryKey(),
+      itemValue: integer().notNull(),
+    })
+
+    beforeEach(async () => {
+      await execute(`
+        DROP SCHEMA IF EXISTS "public" CASCADE;
+        CREATE SCHEMA IF NOT EXISTS "public";
+        CREATE TABLE items (
+          item_id integer PRIMARY KEY,
+          item_value integer NOT NULL
+        );
+      `)
+    })
+
+    it('rolls back to the pre-fork value without a missing-column error', async () => {
+      portal = await mockPortal(forkAtBlockTwo())
+
+      let rolledBackValue: number | undefined
+
+      await evmPortalStream({
+        id: 'test',
+        portal: portal.url,
+        outputs: blockDecoder({ from: 0, to: 3 }),
+      }).pipeTo(
+        drizzleTarget({
+          db: snakeDb,
+          tables: [items],
+          onData: async ({ tx, data }) => {
+            for (const b of data) {
+              if (b.number === 1) {
+                await tx.insert(items).values({ itemId: 1, itemValue: 10 })
+              } else if (b.number === 2) {
+                await tx.update(items).set({ itemValue: 20 }).where(eq(items.itemId, 1))
+              }
+            }
+          },
+          onAfterRollback: async ({ tx }) => {
+            const [row] = await tx.select().from(items).where(eq(items.itemId, 1))
+            rolledBackValue = row?.itemValue
+          },
+        }),
+      )
+
+      expect(rolledBackValue).toEqual(10)
+    })
+  })
+
+  // The undo copy runs inside Postgres, so values keep their driver representation. Reading them
+  // into JS and writing them back through the ORM would re-encode what the driver already encoded.
+  describe('rollback of non-scalar column types', () => {
+    const records = pgTable('records', {
+      recordId: integer('record_id').primaryKey(),
+      payload: jsonb('payload').notNull(),
+      amount: numeric('amount').notNull(),
+      seenAt: timestamp('seen_at', { withTimezone: true }).notNull(),
+    })
+
+    beforeEach(async () => {
+      await execute(`
+        DROP SCHEMA IF EXISTS "public" CASCADE;
+        CREATE SCHEMA IF NOT EXISTS "public";
+        CREATE TABLE records (
+          record_id integer PRIMARY KEY,
+          payload jsonb NOT NULL,
+          amount numeric NOT NULL,
+          seen_at timestamptz NOT NULL
+        );
+      `)
+    })
+
+    it('restores jsonb, numeric and timestamp values unchanged', async () => {
+      portal = await mockPortal(forkAtBlockTwo())
+
+      const payload = { tag: 'v1', nested: { n: 1 } }
+      const seenAt = new Date('2024-01-01T00:00:00.000Z')
+      let restored: typeof records.$inferSelect | undefined
+
+      await evmPortalStream({
+        id: 'test',
+        portal: portal.url,
+        outputs: blockDecoder({ from: 0, to: 3 }),
+      }).pipeTo(
+        drizzleTarget({
+          db,
+          tables: [records],
+          onData: async ({ tx, data }) => {
+            for (const b of data) {
+              if (b.number === 1) {
+                await tx.insert(records).values({ recordId: 1, payload, amount: '123.456', seenAt })
+              } else if (b.number === 2) {
+                await tx
+                  .update(records)
+                  .set({ payload: { tag: 'v2' }, amount: '999.999', seenAt: new Date('2025-06-06T12:00:00.000Z') })
+                  .where(eq(records.recordId, 1))
+              }
+            }
+          },
+          onAfterRollback: async ({ tx }) => {
+            const [row] = await tx.select().from(records).where(eq(records.recordId, 1))
+            restored = row
+          },
+        }),
+      )
+
+      expect(restored?.payload).toEqual(payload)
+      expect(restored?.amount).toEqual('123.456')
+      expect(restored?.seenAt?.toISOString()).toEqual(seenAt.toISOString())
+    })
+  })
+
+  // Postgres owns the value of these columns and rejects an explicit write, so undo has to leave a
+  // stored generated column alone and claim an identity key through OVERRIDING SYSTEM VALUE.
+  describe('rollback of columns Postgres writes itself', () => {
+    const generated = pgTable('gen', {
+      id: integer('id').primaryKey(),
+      amount: integer('amount').notNull(),
+      doubled: integer('doubled').generatedAlwaysAs(sql`"amount" * 2`),
+    })
+
+    const identity = pgTable('ident', {
+      id: integer('id').generatedAlwaysAsIdentity().primaryKey(),
+      amount: integer('amount').notNull(),
+    })
+
+    beforeEach(async () => {
+      await execute(`
+        DROP SCHEMA IF EXISTS "public" CASCADE;
+        CREATE SCHEMA IF NOT EXISTS "public";
+        CREATE TABLE gen (
+          id integer PRIMARY KEY,
+          amount integer NOT NULL,
+          doubled integer GENERATED ALWAYS AS (amount * 2) STORED
+        );
+        CREATE TABLE ident (
+          id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+          amount integer NOT NULL
+        );
+      `)
+    })
+
+    it('rolls back a stored generated column by letting Postgres recompute it', async () => {
+      portal = await mockPortal(forkAtBlockTwo())
+
+      let restored: typeof generated.$inferSelect | undefined
+
+      await evmPortalStream({
+        id: 'test',
+        portal: portal.url,
+        outputs: blockDecoder({ from: 0, to: 3 }),
+      }).pipeTo(
+        drizzleTarget({
+          db,
+          tables: [generated],
+          onData: async ({ tx, data }) => {
+            for (const b of data) {
+              if (b.number === 1) {
+                await tx.insert(generated).values({ id: 1, amount: 10 })
+              } else if (b.number === 2) {
+                await tx.update(generated).set({ amount: 20 }).where(eq(generated.id, 1))
+              }
+            }
+          },
+          onAfterRollback: async ({ tx }) => {
+            const [row] = await tx.select().from(generated).where(eq(generated.id, 1))
+            restored = row
+          },
+        }),
+      )
+
+      expect(restored?.amount).toEqual(10)
+      expect(restored?.doubled).toEqual(20)
+    })
+
+    it('rolls back a GENERATED ALWAYS AS IDENTITY key', async () => {
+      portal = await mockPortal(forkAtBlockTwo())
+
+      let restored: typeof identity.$inferSelect | undefined
+
+      await evmPortalStream({
+        id: 'test',
+        portal: portal.url,
+        outputs: blockDecoder({ from: 0, to: 3 }),
+      }).pipeTo(
+        drizzleTarget({
+          db,
+          tables: [identity],
+          onData: async ({ tx, data }) => {
+            for (const b of data) {
+              if (b.number === 1) {
+                await tx.insert(identity).values({ amount: 10 })
+              } else if (b.number === 2) {
+                await tx.update(identity).set({ amount: 20 }).where(eq(identity.id, 1))
+              }
+            }
+          },
+          onAfterRollback: async ({ tx }) => {
+            const [row] = await tx.select().from(identity).where(eq(identity.id, 1))
+            restored = row
+          },
+        }),
+      )
+
+      expect(restored?.id).toEqual(1)
+      expect(restored?.amount).toEqual(10)
     })
   })
 })

--- a/packages/pipes/src/targets/drizzle/node-postgres/drizzle-target.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/drizzle-target.ts
@@ -60,7 +60,7 @@ export function drizzleTarget<T>({
   onBeforeRollback?: (ctx: { tx: Transaction; cursor: BlockCursor }) => Promise<unknown> | unknown
   onAfterRollback?: (ctx: { tx: Transaction; cursor: BlockCursor }) => Promise<unknown> | unknown
 }) {
-  const tracker = new DrizzleTracker()
+  const tracker = new DrizzleTracker(db)
   const client = (db as any).$client
   if (!client) {
     throw new PostgresTargetError(

--- a/packages/pipes/src/targets/drizzle/node-postgres/drizzle-tracker.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/drizzle-tracker.ts
@@ -1,82 +1,62 @@
-import { Table, and, eq } from 'drizzle-orm'
-import { PgColumn } from 'drizzle-orm/pg-core'
+import { Column, Table } from 'drizzle-orm'
 
 import { BlockCursor } from '~/core/index.js'
 
-import { SQD_PRIMARY_COLS, getDrizzleTableName } from './consts.js'
+import { createColumnNameResolver, getDrizzleTableName } from './consts.js'
 import { Transaction } from './drizzle-target.js'
 import { POSTGRES_ERROR_CODES, PostgresTargetError } from './errors.js'
-import { generateTriggerSQL } from './rollback.js'
+import {
+  SNAPSHOT_BLOCK_COLUMN,
+  SnapshotPlan,
+  buildSnapshotPlan,
+  generateForkDeleteSQL,
+  generateForkRestoreSQL,
+  generateTriggerSQL,
+} from './rollback.js'
 
 /** @internal */
 export class DrizzleTracker {
-  #knownTables = new Map<Table, boolean>()
+  // Insertion order is the FK-safe delete order (children → parents); reversed, it is the insert order.
+  #plans = new Map<Table, SnapshotPlan>()
+  readonly #resolveColumnName: (col: Column) => string
+
+  constructor(db: unknown) {
+    this.#resolveColumnName = createColumnNameResolver(db)
+  }
 
   add(table: Table) {
-    if (this.#knownTables.has(table)) return
+    if (this.#plans.has(table)) {
+      return
+    }
 
-    const from = getDrizzleTableName(table)
-    const to = `${from}__snapshots`
+    const plan = buildSnapshotPlan(table, this.#resolveColumnName)
 
-    const sql = generateTriggerSQL(from, to, table)
+    this.#plans.set(table, plan)
 
-    this.#knownTables.set(table, true)
-
-    return sql
+    return generateTriggerSQL(plan)
   }
 
   async cleanup(tx: Transaction, blockNumber: number) {
-    for (const table of this.#knownTables.keys()) {
-      const from = getDrizzleTableName(table)
-      const to = `${from}__snapshots`
-      await tx.execute<
-        {
-          ___sqd__block_number: number
-          ___sqd__operation: 'INSERT' | 'UPDATE' | 'DELETE'
-        } & Record<string, unknown>
-      >(`DELETE FROM "${to}" WHERE "___sqd__block_number" <= ${blockNumber};`)
+    for (const plan of this.#plans.values()) {
+      await tx.execute(`DELETE FROM "${plan.snapshotName}" WHERE "${SNAPSHOT_BLOCK_COLUMN}" <= ${blockNumber};`)
     }
   }
 
   async fork(tx: Transaction, cursor: BlockCursor) {
-    for (const table of this.#knownTables.keys()) {
-      const snapshots = `${getDrizzleTableName(table)}__snapshots`
-      const primaryCols: PgColumn[] = (table as any)[SQD_PRIMARY_COLS]
-      const pkList = primaryCols.map((col) => `"${col.name}"`).join(', ')
+    const plans = [...this.#plans.values()]
 
-      // The earliest snapshot per row above the fork point holds that row's before-image at the
-      // fork boundary, so replaying it rewinds the row to its state at the cursor block — even when
-      // the prior value came from a finalized block that was never snapshotted. A row first seen
-      // above the fork ('INSERT') had no prior value and is dropped.
-      const res = await tx.execute<
-        {
-          ___sqd__block_number: number
-          ___sqd__operation: 'INSERT' | 'UPDATE' | 'DELETE'
-        } & Record<string, unknown>
-      >(
-        `SELECT DISTINCT ON (${pkList}) *
-         FROM "${snapshots}"
-         WHERE "___sqd__block_number" > ${cursor.number}
-         ORDER BY ${pkList}, "___sqd__block_number" ASC`,
-      )
+    for (const plan of plans) {
+      await tx.execute(generateForkDeleteSQL(plan, cursor.number))
+    }
 
-      for (const row of res.rows) {
-        const { ___sqd__block_number, ___sqd__operation, ...snapshot } = row
+    // Reversed: a restored child row needs its parent back first.
+    for (const plan of plans.slice().reverse()) {
+      await tx.execute(generateForkRestoreSQL(plan, cursor.number))
+    }
 
-        const filter = and(...primaryCols.map((col) => eq(col, snapshot[col.name])))
-
-        if (___sqd__operation === 'INSERT') {
-          await tx.delete(table).where(filter)
-        } else {
-          await tx.insert(table).values(snapshot).onConflictDoUpdate({
-            target: primaryCols,
-            set: snapshot,
-          })
-        }
-      }
-
-      // Drop the consumed snapshots; those at or below the cursor stay for a later deeper rollback.
-      await tx.execute(`DELETE FROM "${snapshots}" WHERE "___sqd__block_number" > ${cursor.number}`)
+    // Drop the consumed snapshots; those at or below the cursor stay for a later deeper rollback.
+    for (const plan of plans) {
+      await tx.execute(`DELETE FROM "${plan.snapshotName}" WHERE "${SNAPSHOT_BLOCK_COLUMN}" > ${cursor.number}`)
     }
   }
 
@@ -85,7 +65,7 @@ export class DrizzleTracker {
       const orig = tx[method].bind(tx)
 
       tx[method] = (table: Table, ...args: any[]) => {
-        if (!this.#knownTables.has(table)) {
+        if (!this.#plans.has(table)) {
           throw new PostgresTargetError(
             POSTGRES_ERROR_CODES.UNTRACKED_TABLE,
             `Table "${getDrizzleTableName(table)}" is not tracked for rollbacks. Make sure to include it in the "tables" array when creating the target.`,

--- a/packages/pipes/src/targets/drizzle/node-postgres/errors.test.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/errors.test.ts
@@ -3,10 +3,11 @@ import { describe, expect, it } from 'vitest'
 
 import { PipeError } from '~/core/errors.js'
 
+import { createColumnNameResolver } from './consts.js'
 import { drizzleTarget } from './drizzle-target.js'
 import { POSTGRES_ERROR_CODES, PostgresTargetError } from './errors.js'
 import { PostgresState } from './postgres-state.js'
-import { generateTriggerSQL } from './rollback.js'
+import { buildSnapshotPlan } from './rollback.js'
 
 describe('PostgresTargetError', () => {
   it('carries the given E21xx code and a docs link', () => {
@@ -38,14 +39,25 @@ describe('PostgresTargetError', () => {
     }
   })
 
-  it('generateTriggerSQL on a table without a primary key throws MISSING_PRIMARY_KEY (E2105)', () => {
+  it('buildSnapshotPlan on a table without a primary key throws MISSING_PRIMARY_KEY (E2105)', () => {
     const table = pgTable('t', { a: integer('a') })
     try {
-      generateTriggerSQL('t', 'snap', table)
+      buildSnapshotPlan(table, (col) => col.name)
       throw new Error('expected throw')
     } catch (e) {
       expect(e).toBeInstanceOf(PostgresTargetError)
       expect((e as PostgresTargetError).code).toBe(POSTGRES_ERROR_CODES.MISSING_PRIMARY_KEY)
+    }
+  })
+
+  it('an unnamed column with no dialect to resolve it throws COLUMN_NAME_UNRESOLVED (E2107)', () => {
+    const table = pgTable('t', { someKey: integer().primaryKey() })
+    try {
+      buildSnapshotPlan(table, createColumnNameResolver({}))
+      throw new Error('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(PostgresTargetError)
+      expect((e as PostgresTargetError).code).toBe(POSTGRES_ERROR_CODES.COLUMN_NAME_UNRESOLVED)
     }
   })
 })

--- a/packages/pipes/src/targets/drizzle/node-postgres/errors.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/errors.ts
@@ -29,4 +29,6 @@ export const POSTGRES_ERROR_CODES = {
   MISSING_PRIMARY_KEY: 'E2105',
   /** Foreign keys form a cycle, so a safe delete order cannot be determined. */
   CIRCULAR_DEPENDENCY: 'E2106',
+  /** A column's real database name could not be resolved from the Drizzle dialect. */
+  COLUMN_NAME_UNRESOLVED: 'E2107',
 } as const

--- a/packages/pipes/src/targets/drizzle/node-postgres/rollback.test.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/rollback.test.ts
@@ -1,0 +1,248 @@
+import { sql } from 'drizzle-orm'
+import { PgDialect, integer, pgTable, primaryKey, text } from 'drizzle-orm/pg-core'
+import { describe, expect, it } from 'vitest'
+
+import { createColumnNameResolver } from './consts.js'
+import { POSTGRES_ERROR_CODES, PostgresTargetError } from './errors.js'
+import { buildSnapshotPlan, generateForkDeleteSQL, generateForkRestoreSQL, generateTriggerSQL } from './rollback.js'
+
+// A dialect is all `createColumnNameResolver` needs, so these stay free of a real connection.
+const resolver = (casing?: 'snake_case') => createColumnNameResolver({ dialect: new PgDialect({ casing }) })
+
+describe('buildSnapshotPlan', () => {
+  it('takes the database name from an explicitly named column', () => {
+    const items = pgTable('items', {
+      itemId: integer('item_id').primaryKey(),
+      itemValue: integer('item_value').notNull(),
+    })
+
+    expect(buildSnapshotPlan(items, resolver())).toMatchInlineSnapshot(`
+      {
+        "columns": [
+          {
+            "generated": false,
+            "identityAlways": false,
+            "name": "item_id",
+            "sqlType": "integer",
+          },
+          {
+            "generated": false,
+            "identityAlways": false,
+            "name": "item_value",
+            "sqlType": "integer",
+          },
+        ],
+        "name": "items",
+        "primaryKeys": [
+          "item_id",
+        ],
+        "snapshotName": "items__snapshots",
+      }
+    `)
+  })
+
+  // `col.name` is the JS property key here; only the dialect knows the real column.
+  it('takes the database name from the dialect when the column is unnamed', () => {
+    const items = pgTable('items', {
+      itemId: integer().primaryKey(),
+      itemValue: integer().notNull(),
+    })
+
+    expect(buildSnapshotPlan(items, resolver('snake_case'))).toMatchInlineSnapshot(`
+      {
+        "columns": [
+          {
+            "generated": false,
+            "identityAlways": false,
+            "name": "item_id",
+            "sqlType": "integer",
+          },
+          {
+            "generated": false,
+            "identityAlways": false,
+            "name": "item_value",
+            "sqlType": "integer",
+          },
+        ],
+        "name": "items",
+        "primaryKeys": [
+          "item_id",
+        ],
+        "snapshotName": "items__snapshots",
+      }
+    `)
+  })
+
+  it('resolves composite primary key columns through the dialect too', () => {
+    const balances = pgTable(
+      'balances',
+      {
+        accountId: integer(),
+        tokenId: integer(),
+        balanceValue: integer().notNull(),
+      },
+      (t) => [primaryKey({ columns: [t.accountId, t.tokenId] })],
+    )
+
+    const plan = buildSnapshotPlan(balances, resolver('snake_case'))
+
+    expect(plan.primaryKeys).toEqual(['account_id', 'token_id'])
+    expect(plan.columns.map((c) => c.name)).toEqual(['account_id', 'token_id', 'balance_value'])
+  })
+
+  it('throws MISSING_PRIMARY_KEY when no primary key is declared', () => {
+    const table = pgTable('t', { a: integer('a') })
+
+    try {
+      buildSnapshotPlan(table, resolver())
+      throw new Error('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(PostgresTargetError)
+      expect((e as PostgresTargetError).code).toBe(POSTGRES_ERROR_CODES.MISSING_PRIMARY_KEY)
+    }
+  })
+})
+
+describe('generateTriggerSQL', () => {
+  it('addresses the base table by its real column names under dialect casing', () => {
+    const items = pgTable('items', {
+      itemId: integer().primaryKey(),
+      itemValue: integer().notNull(),
+    })
+
+    const sql = generateTriggerSQL(buildSnapshotPlan(items, resolver('snake_case')))
+
+    expect(sql).toContain('VALUES (NEW."item_id", NEW."item_value", block_num, \'INSERT\')')
+    expect(sql).toContain('VALUES (OLD."item_id", OLD."item_value", block_num, TG_OP)')
+    expect(sql).not.toContain('itemId')
+    expect(sql).not.toContain('itemValue')
+  })
+
+  it('builds the snapshot table and trigger', () => {
+    const items = pgTable('items', {
+      itemId: integer('item_id').primaryKey(),
+      itemValue: integer('item_value').notNull(),
+    })
+
+    expect(generateTriggerSQL(buildSnapshotPlan(items, resolver()))).toMatchInlineSnapshot(`
+      "
+      -- ===== SNAPSHOT SETUP FOR items__snapshots =====
+      CREATE TABLE IF NOT EXISTS "items__snapshots" (
+        "item_id" integer,
+        "item_value" integer,
+        "___sqd__operation" TEXT NOT NULL,
+        "___sqd__block_number" BIGINT NOT NULL,
+        PRIMARY KEY ("___sqd__block_number","item_id")
+      );
+
+      CREATE OR REPLACE FUNCTION maybe_snapshot_items() RETURNS trigger AS $$
+      DECLARE
+        snapshot_enabled BOOLEAN := COALESCE(NULLIF(current_setting('sqd.snapshot_enabled', true), '')::boolean, false);
+        block_num BIGINT := COALESCE(NULLIF(current_setting('sqd.snapshot_block_number', true), '')::BIGINT, -1);
+      BEGIN
+         IF snapshot_enabled = true THEN
+           IF TG_OP = 'INSERT' THEN
+              -- No prior value exists; record the key under 'INSERT' so undo drops the row.
+              INSERT INTO "items__snapshots" ("item_id", "item_value", "___sqd__block_number", "___sqd__operation")
+              VALUES (NEW."item_id", NEW."item_value", block_num, 'INSERT')
+              ON CONFLICT ("___sqd__block_number","item_id") DO NOTHING;
+           ELSE
+              -- UPDATE/DELETE: keep the before-image (OLD) so undo restores the pre-change row.
+              -- DO NOTHING preserves the earliest before-image when a row changes twice in one block.
+              INSERT INTO "items__snapshots" ("item_id", "item_value", "___sqd__block_number", "___sqd__operation")
+              VALUES (OLD."item_id", OLD."item_value", block_num, TG_OP)
+              ON CONFLICT ("___sqd__block_number","item_id") DO NOTHING;
+           END IF;
+         END IF;
+
+         IF TG_OP = 'DELETE' THEN
+           RETURN OLD;
+         END IF;
+
+         RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+
+      DROP TRIGGER IF EXISTS items_snapshot_trigger ON "items";
+
+      CREATE TRIGGER items_snapshot_trigger
+      AFTER INSERT OR UPDATE OR DELETE ON "items"
+      FOR EACH ROW EXECUTE FUNCTION maybe_snapshot_items();
+      "
+    `)
+  })
+})
+
+describe('fork statements', () => {
+  const items = pgTable('items', {
+    itemId: integer().primaryKey(),
+    itemValue: integer().notNull(),
+  })
+
+  it('drops rows whose earliest snapshot above the fork is an INSERT', () => {
+    expect(generateForkDeleteSQL(buildSnapshotPlan(items, resolver('snake_case')), 7)).toMatchInlineSnapshot(`
+      "
+      DELETE FROM "items" t
+      USING (
+        SELECT DISTINCT ON ("item_id") "item_id", "___sqd__operation"
+        FROM "items__snapshots"
+        WHERE "___sqd__block_number" > 7
+        ORDER BY "item_id", "___sqd__block_number" ASC
+      ) s
+      WHERE s."___sqd__operation" = 'INSERT' AND t."item_id" = s."item_id";"
+    `)
+  })
+
+  it('restores before-images without routing values through the ORM', () => {
+    expect(generateForkRestoreSQL(buildSnapshotPlan(items, resolver('snake_case')), 7)).toMatchInlineSnapshot(`
+      "
+      INSERT INTO "items" ("item_id", "item_value")
+      SELECT "item_id", "item_value"
+      FROM (
+        SELECT DISTINCT ON ("item_id") *
+        FROM "items__snapshots"
+        WHERE "___sqd__block_number" > 7
+        ORDER BY "item_id", "___sqd__block_number" ASC
+      ) s
+      WHERE s."___sqd__operation" <> 'INSERT'
+      ON CONFLICT ("item_id") DO UPDATE SET "item_value" = EXCLUDED."item_value";"
+    `)
+  })
+
+  // Postgres derives the value itself and rejects an explicit write in both clauses.
+  it('leaves a stored generated column out of the restore entirely', () => {
+    const gen = pgTable('gen', {
+      id: integer('id').primaryKey(),
+      amount: integer('amount').notNull(),
+      doubled: integer('doubled').generatedAlwaysAs(sql`"amount" * 2`),
+    })
+
+    const sql_ = generateForkRestoreSQL(buildSnapshotPlan(gen, resolver()), 1)
+
+    expect(sql_).not.toContain('doubled')
+    expect(sql_).toContain('INSERT INTO "gen" ("id", "amount")')
+    expect(sql_).toContain('ON CONFLICT ("id") DO UPDATE SET "amount" = EXCLUDED."amount"')
+  })
+
+  it('claims a GENERATED ALWAYS AS IDENTITY key with OVERRIDING SYSTEM VALUE', () => {
+    const ident = pgTable('ident', {
+      id: integer('id').generatedAlwaysAsIdentity().primaryKey(),
+      amount: integer('amount').notNull(),
+    })
+
+    expect(generateForkRestoreSQL(buildSnapshotPlan(ident, resolver()), 1)).toContain(
+      'INSERT INTO "ident" ("id", "amount") OVERRIDING SYSTEM VALUE',
+    )
+  })
+
+  // An all-key table has nothing to overwrite, and an empty SET list is not valid SQL.
+  it('falls back to DO NOTHING when every column is part of the primary key', () => {
+    const edges = pgTable('edges', { from: text().notNull(), to: text().notNull() }, (t) => [
+      primaryKey({ columns: [t.from, t.to] }),
+    ])
+
+    expect(generateForkRestoreSQL(buildSnapshotPlan(edges, resolver()), 1)).toContain(
+      'ON CONFLICT ("from", "to") DO NOTHING',
+    )
+  })
+})

--- a/packages/pipes/src/targets/drizzle/node-postgres/rollback.ts
+++ b/packages/pipes/src/targets/drizzle/node-postgres/rollback.ts
@@ -1,8 +1,7 @@
-import { Table, is } from 'drizzle-orm'
+import { Column, Table, is } from 'drizzle-orm'
 import { PrimaryKeyBuilder } from 'drizzle-orm/pg-core'
 
 import {
-  SQD_PRIMARY_COLS,
   getDrizzleForeignKeys,
   getDrizzleTableColumns,
   getDrizzleTableExtraColumns,
@@ -11,14 +10,38 @@ import {
 } from './consts.js'
 import { POSTGRES_ERROR_CODES, PostgresTargetError } from './errors.js'
 
-export function generateTriggerSQL(from: string, to: string, table: Table) {
+export const SNAPSHOT_BLOCK_COLUMN = '___sqd__block_number'
+export const SNAPSHOT_OPERATION_COLUMN = '___sqd__operation'
+
+const quote = (name: string) => `"${name}"`
+
+/**
+ * Everything the trigger and the rollback statements need about a table, in real Postgres column
+ * names. Resolving names once here keeps every generated statement in database space, so nothing
+ * downstream has to translate between Drizzle property keys and column names.
+ */
+export type SnapshotPlan = {
+  name: string
+  snapshotName: string
+  columns: SnapshotColumn[]
+  primaryKeys: string[]
+}
+
+export type SnapshotColumn = {
+  name: string
+  sqlType: string
+  /** Postgres derives the value and rejects any explicit write, so undo must leave it alone. */
+  generated: boolean
+  /** `GENERATED ALWAYS AS IDENTITY`: insertable only via OVERRIDING SYSTEM VALUE, never updatable. */
+  identityAlways: boolean
+}
+
+export function buildSnapshotPlan(table: Table, resolveColumnName: (col: Column) => string): SnapshotPlan {
+  const name = getDrizzleTableName(table)
   const columns = getDrizzleTableColumns(table)
 
-  const colsDDL = Object.entries(columns)
-    .map(([name, col]) => `"${name}" ${col.getSQLType()}`)
-    .join(',\n  ')
+  let primaryCols: Column[] = Object.values(columns).filter((c) => c.primary)
 
-  let primaryCols = Object.values(columns).filter((c) => c.primary)
   if (primaryCols.length === 0) {
     const extraConfigFn = getDrizzleTableExtraConfig(table)
 
@@ -26,11 +49,11 @@ export function generateTriggerSQL(from: string, to: string, table: Table) {
       const extra = extraConfigFn(getDrizzleTableExtraColumns(table))
 
       for (const fn of extra) {
-        if (!is(fn, PrimaryKeyBuilder)) continue
+        if (!is(fn, PrimaryKeyBuilder)) {
+          continue
+        }
 
-        const primaryKeyBuilder = fn as any
-
-        primaryCols = primaryKeyBuilder.columns
+        primaryCols = (fn as any).columns
       }
     }
   }
@@ -38,34 +61,42 @@ export function generateTriggerSQL(from: string, to: string, table: Table) {
   if (primaryCols.length === 0) {
     throw new PostgresTargetError(
       POSTGRES_ERROR_CODES.MISSING_PRIMARY_KEY,
-      `Cannot generate snapshot trigger for table ${from} without primary key columns`,
+      `Cannot generate snapshot trigger for table ${name} without primary key columns`,
     )
   }
 
-  ;(table as any)[SQD_PRIMARY_COLS] = primaryCols
+  return {
+    name,
+    snapshotName: `${name}__snapshots`,
+    columns: Object.values(columns).map((col) => ({
+      name: resolveColumnName(col),
+      sqlType: col.getSQLType(),
+      // Mirrors Drizzle's own insert filter: a 'byDefault' generated column is writable.
+      generated: col.generated !== undefined && col.generated.type !== 'byDefault',
+      identityAlways: col.generatedIdentity?.type === 'always',
+    })),
+    primaryKeys: primaryCols.map(resolveColumnName),
+  }
+}
 
-  const primaryKey = [{ name: '___sqd__block_number' }, ...primaryCols].map((c) => `"${c.name}"`).join(',')
+export function generateTriggerSQL({ name, snapshotName, columns, primaryKeys }: SnapshotPlan) {
+  const colsDDL = columns.map((col) => `${quote(col.name)} ${col.sqlType}`).join(',\n  ')
+  const snapshotKey = [SNAPSHOT_BLOCK_COLUMN, ...primaryKeys].map(quote).join(',')
 
-  const colNames = Object.keys(columns)
-    .map((c) => `"${c}"`)
-    .join(', ')
-  const oldCols = Object.keys(columns)
-    .map((c) => `OLD."${c}"`)
-    .join(', ')
-  const newCols = Object.keys(columns)
-    .map((c) => `NEW."${c}"`)
-    .join(', ')
+  const colNames = columns.map((c) => quote(c.name)).join(', ')
+  const oldCols = columns.map((c) => `OLD.${quote(c.name)}`).join(', ')
+  const newCols = columns.map((c) => `NEW.${quote(c.name)}`).join(', ')
 
   return `
--- ===== SNAPSHOT SETUP FOR ${to} =====
-CREATE TABLE IF NOT EXISTS "${to}" (
+-- ===== SNAPSHOT SETUP FOR ${snapshotName} =====
+CREATE TABLE IF NOT EXISTS "${snapshotName}" (
   ${colsDDL},
-  "___sqd__operation" TEXT NOT NULL,
-  "___sqd__block_number" BIGINT NOT NULL,
-  PRIMARY KEY (${primaryKey})
+  "${SNAPSHOT_OPERATION_COLUMN}" TEXT NOT NULL,
+  "${SNAPSHOT_BLOCK_COLUMN}" BIGINT NOT NULL,
+  PRIMARY KEY (${snapshotKey})
 );
 
-CREATE OR REPLACE FUNCTION maybe_snapshot_${from}() RETURNS trigger AS $$
+CREATE OR REPLACE FUNCTION maybe_snapshot_${name}() RETURNS trigger AS $$
 DECLARE
   snapshot_enabled BOOLEAN := COALESCE(NULLIF(current_setting('sqd.snapshot_enabled', true), '')::boolean, false);
   block_num BIGINT := COALESCE(NULLIF(current_setting('sqd.snapshot_block_number', true), '')::BIGINT, -1);
@@ -73,15 +104,15 @@ BEGIN
    IF snapshot_enabled = true THEN
      IF TG_OP = 'INSERT' THEN
         -- No prior value exists; record the key under 'INSERT' so undo drops the row.
-        INSERT INTO "${to}" (${colNames}, "___sqd__block_number", "___sqd__operation")
+        INSERT INTO "${snapshotName}" (${colNames}, "${SNAPSHOT_BLOCK_COLUMN}", "${SNAPSHOT_OPERATION_COLUMN}")
         VALUES (${newCols}, block_num, 'INSERT')
-        ON CONFLICT (${primaryKey}) DO NOTHING;
+        ON CONFLICT (${snapshotKey}) DO NOTHING;
      ELSE
         -- UPDATE/DELETE: keep the before-image (OLD) so undo restores the pre-change row.
         -- DO NOTHING preserves the earliest before-image when a row changes twice in one block.
-        INSERT INTO "${to}" (${colNames}, "___sqd__block_number", "___sqd__operation")
+        INSERT INTO "${snapshotName}" (${colNames}, "${SNAPSHOT_BLOCK_COLUMN}", "${SNAPSHOT_OPERATION_COLUMN}")
         VALUES (${oldCols}, block_num, TG_OP)
-        ON CONFLICT (${primaryKey}) DO NOTHING;
+        ON CONFLICT (${snapshotKey}) DO NOTHING;
      END IF;
    END IF;
 
@@ -93,12 +124,67 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-DROP TRIGGER IF EXISTS ${from}_snapshot_trigger ON "${from}";
+DROP TRIGGER IF EXISTS ${name}_snapshot_trigger ON "${name}";
 
-CREATE TRIGGER ${from}_snapshot_trigger
-AFTER INSERT OR UPDATE OR DELETE ON "${from}"
-FOR EACH ROW EXECUTE FUNCTION maybe_snapshot_${from}();
+CREATE TRIGGER ${name}_snapshot_trigger
+AFTER INSERT OR UPDATE OR DELETE ON "${name}"
+FOR EACH ROW EXECUTE FUNCTION maybe_snapshot_${name}();
 `
+}
+
+/**
+ * The earliest snapshot per row above the fork point holds that row's before-image at the fork
+ * boundary, so replaying it rewinds the row to its state at the cursor block — even when the prior
+ * value came from a finalized block that was never snapshotted.
+ *
+ * The operation is filtered *after* `DISTINCT ON`, never inside it: a row inserted and then updated
+ * above the fork must still be judged by its first snapshot, otherwise the later UPDATE would
+ * resurrect a row that never existed at the cursor.
+ */
+const earliestSnapshotPerRow = (plan: SnapshotPlan, blockNumber: number, selection: string) => `
+  SELECT DISTINCT ON (${plan.primaryKeys.map(quote).join(', ')}) ${selection}
+  FROM ${quote(plan.snapshotName)}
+  WHERE ${quote(SNAPSHOT_BLOCK_COLUMN)} > ${blockNumber}
+  ORDER BY ${plan.primaryKeys.map(quote).join(', ')}, ${quote(SNAPSHOT_BLOCK_COLUMN)} ASC`
+
+/** A row first seen above the fork ('INSERT') had no prior value, so rewinding drops it. */
+export function generateForkDeleteSQL(plan: SnapshotPlan, blockNumber: number) {
+  const primaryKeys = plan.primaryKeys.map(quote).join(', ')
+  const matchKey = plan.primaryKeys.map((c) => `t.${quote(c)} = s.${quote(c)}`).join(' AND ')
+
+  return `
+DELETE FROM ${quote(plan.name)} t
+USING (${earliestSnapshotPerRow(plan, blockNumber, `${primaryKeys}, ${quote(SNAPSHOT_OPERATION_COLUMN)}`)}
+) s
+WHERE s.${quote(SNAPSHOT_OPERATION_COLUMN)} = 'INSERT' AND ${matchKey};`
+}
+
+/**
+ * Restores the before-image kept for an UPDATE/DELETE. The copy stays inside Postgres on purpose:
+ * pulling rows into JS and writing them back through the ORM would re-encode values that the driver
+ * already returned in wire format.
+ */
+export function generateForkRestoreSQL(plan: SnapshotPlan, blockNumber: number) {
+  const primaryKeys = plan.primaryKeys.map(quote).join(', ')
+
+  const writable = plan.columns.filter((c) => !c.generated)
+  const colNames = writable.map((c) => quote(c.name)).join(', ')
+
+  const updatable = writable.filter((c) => !c.identityAlways && !plan.primaryKeys.includes(c.name))
+  const onConflict = updatable.length
+    ? `DO UPDATE SET ${updatable.map((c) => `${quote(c.name)} = EXCLUDED.${quote(c.name)}`).join(', ')}`
+    : 'DO NOTHING'
+
+  // Restoring an identity key means writing a value the sequence owns, which Postgres allows only here.
+  const overriding = writable.some((c) => c.identityAlways) ? ' OVERRIDING SYSTEM VALUE' : ''
+
+  return `
+INSERT INTO ${quote(plan.name)} (${colNames})${overriding}
+SELECT ${colNames}
+FROM (${earliestSnapshotPerRow(plan, blockNumber, '*')}
+) s
+WHERE s.${quote(SNAPSHOT_OPERATION_COLUMN)} <> 'INSERT'
+ON CONFLICT (${primaryKeys}) ${onConflict};`
 }
 
 /**


### PR DESCRIPTION
## Summary

The reorg-snapshot trigger and its rollback path addressed columns by Drizzle's JS property keys instead of the actual Postgres column names, so a schema whose keys differ from its columns failed with `42703` once snapshotting activated at the finalized head.

**Explicitly named columns.** `generateTriggerSQL` built the snapshot table's DDL and the trigger's `INSERT`/`NEW.`/`OLD.` clauses from property keys, so `itemId: integer('item_id')` produced `NEW."itemId"` against a table that only has `item_id`.

**Columns named by the dialect.** `col.name` carries the database name only when the column was declared with one. A column declared as `integer()` keeps its JS property key there and gets its real name from the dialect's casing cache, so `drizzle(..., { casing: 'snake_case' })` schemas reproduced exactly the same failure. Every generated statement now resolves names through the dialect, and an unresolvable name raises `E2107` rather than silently falling back to a wrong one.

**Fork undo now runs inside Postgres.** `fork()` read snapshot rows into JS and wrote them back through the ORM. Drizzle disables the driver's type parsers for raw `execute()`, so those rows arrive in wire format, and passing them to `.values()` re-encoded already-encoded values — `mapToDriverValue` threw `value.toISOString is not a function` for any table with a `timestamp` column, regardless of how its columns were named. The undo is now two SQL statements that copy before-images entirely in database space, so values never round-trip through JS and no key translation is needed at all.

**Columns Postgres writes itself.** Restoring a before-image wrote every column back, but Postgres owns the value of a stored generated column and of a `GENERATED ALWAYS AS IDENTITY` key and rejects an explicit write, so rolling back such a table failed. Generated columns are now left out of the restore so Postgres recomputes them, and an identity key is claimed with `OVERRIDING SYSTEM VALUE`. This was broken before this PR as well — Drizzle filtered generated columns out of the `INSERT` list but not out of the `ON CONFLICT DO UPDATE SET` clause, so the update path failed with `column "…" can only be updated to DEFAULT`, and identity-always keys were never filtered at all.

#58 reported both of these together — an explicitly named column and a `casing: 'snake_case'` schema.
#148 covers the explicitly named half.

Fixes #58
Fixes #148

### Notes

- The snapshot trigger is unchanged in role: it still captures before-images on `INSERT`/`UPDATE`/`DELETE`. Only the undo path was rewritten.
- `generateTriggerSQL(from, to, table)` is split into `buildSnapshotPlan(table, resolve)` + `generateTriggerSQL(plan)`. Names are resolved once into a `SnapshotPlan`, which makes the generated SQL unit-testable without a database, and the `SQD_PRIMARY_COLS` symbol that `generateTriggerSQL` used to write onto the table object is gone.
- Rollback runs in two phases — delete children→parents, then restore parents→children — instead of interleaving both per table, which is the foreign-key-safe order in each direction.
- The operation filter is applied after `DISTINCT ON`, never inside it: a row inserted and then updated above the fork must still be judged by its first snapshot, otherwise the later `UPDATE` would resurrect a row that never existed at the cursor.

### Upgrade note

`CREATE TABLE IF NOT EXISTS` does not rename columns, so a snapshot table left behind by a previous build keeps its old property-key columns. This affects only schemas that were already failing, and only those where the primary key name happened to match its property key while another column did not. Those deployments need to re-sync.

## Coverage

`src/targets/drizzle`, `main` vs. this branch:

| Module | Stmts | Δ | Branch | Δ |
|--------|-------|---|--------|---|
| **All files** | 91.7% | +2.2 | 85.5% | +2.1 |
| consts.ts | 88.9% | +13.0 | 76.5% | +19.3 |
| rollback.ts | 94.4% | +7.0 | 82.0% | +12.0 |
| drizzle-tracker.ts | 88.0% | −1.1 | 92.3% | −1.0 |

`drizzle-tracker.ts` dips because most of its body moved into `rollback.ts`; what remains uncovered is the duplicate-`add()` guard and `cleanup()`.

## Test plan

- [x] `rollback.test.ts` — 11 unit tests needing no Postgres: snapshot plan and trigger SQL for explicitly named columns and for dialect casing, composite primary keys resolved through the dialect, `DO NOTHING` for a table whose columns are all part of the key, exclusion of a generated column and `OVERRIDING SYSTEM VALUE` for an identity key, and `E2105` for a table without a primary key.
- [x] Integration tests for a `pgTable` mapping a camelCase key to a snake_case column (`itemId` → `item_id`), for a schema relying on `casing: 'snake_case'`, for rollback of `jsonb` / `numeric` / `timestamptz` values, and for rollback of a stored generated column and a `GENERATED ALWAYS AS IDENTITY` key.
- [x] Each regression test verified to fail without its fix: the camelCase test fails with `column "item_id" named in key does not exist`; neutering the name resolver to `col.name` fails the casing test with `record "new" has no field "itemId"` while the other 12 stay green; the value round-trip was reproduced against the previous ORM-based undo with `value.toISOString is not a function`; the generated and identity cases were reproduced on both the ORM-based and the SQL-based undo before the filter was added.
- [x] `pnpm vitest run src/targets/drizzle` — 47/47 passing (30 on `main`).
- [x] `tsc --noEmit` and `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
