### PR TITLE
feat(pubsub): add signal routes

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -734,3 +734,26 @@ precision loss, or a sequence outside that supported range reached the encoder. 
 would make later changes look stale to BigQuery.
 
 **Fix** — start a new feed with fresh state and a fresh namespace, then re-bootstrap its destination.
+
+### E2425 · No routes configured
+
+The target was constructed with neither a `topics` entry nor a `signals` entry, so it would open a
+state file, take its exclusive lock, and publish nothing.
+
+**Fix** — configure at least one CDC topic route or one signal route.
+
+### E2426 · Signal draft without a usable block
+
+A signal route produced a draft whose `block.number` is missing, negative, or not an integer. Every
+signal is attributed to a block so the go-live cut and the `finalized-only` check can be applied.
+
+**Fix** — set `block` on the draft to the block the signal describes.
+
+### E2427 · Finalized-only signal from an unfinalized block
+
+A route declaring `fork.mode: 'finalized-only'` mapped a block above the dataset's finalized head.
+That mode is a promise that the route publishes nothing a fork could orphan, and a signal cannot be
+retracted once it is on the wire.
+
+**Fix** — read the finalized stream, withhold the signal until its block finalizes, or switch the
+route to `fork.mode: 'boundary'` and publish a compensating boundary message on a fork.

--- a/docs/examples/evm/18.pubsub.example.ts
+++ b/docs/examples/evm/18.pubsub.example.ts
@@ -39,7 +39,10 @@
  * `_uid`; enabling the SDK option alone does not configure Dataflow.
  *
  * The state file holds the cursor, rollback data, outbox, and sequence counter. Keep it on durable
- * storage and run one producer per path. State schemas are not migrated in place.
+ * storage and run one producer per path.
+ *
+ * `19.pubsub-signals.example.ts` covers signal routes — messages published without the CDC
+ * envelope, for consumers that fold their own state instead of mirroring rows.
  *
  * To run:
  *

--- a/docs/examples/evm/19.pubsub-signals.example.ts
+++ b/docs/examples/evm/19.pubsub-signals.example.ts
@@ -1,0 +1,124 @@
+/**
+ * Google PubSub signal routes — publish application messages without the CDC envelope.
+ *
+ * A `topics` route (see `18.pubsub.example.ts`) publishes row mutations: every message carries
+ * `_id`, `_CHANGE_TYPE`, and `_CHANGE_SEQUENCE_NUMBER`, and a fork is repaired per row with a
+ * compensating `DELETE` or restoring `UPSERT`. That is the right shape when the consumer mirrors
+ * a table — a BigQuery subscription applies it with no code.
+ *
+ * A `signals` route publishes the payload verbatim instead. Use it when the consumer is not a
+ * table: a stateful fold, a control channel, a watermark announcement. The route owns the whole
+ * schema, so anything the consumer needs — a type tag, an id, the fork epoch — has to be in
+ * `data`.
+ *
+ * The trade is fork repair. A signal has no row identity and no compensating message, so a reorg
+ * cannot be repaired per message. Each route declares how it copes:
+ *
+ * - `fork: { mode: 'boundary', map }` — the route publishes unfinalized data and accepts that
+ *   some of it gets orphaned. On a fork the target publishes ONE message built by `map`, ahead of
+ *   every CDC compensation, carrying the new epoch and the block the feed rewound to. The
+ *   consumer discards what it received above that block from the previous epoch. That is the
+ *   whole repair: one boundary message instead of one compensation per row.
+ *
+ * - `fork: { mode: 'finalized-only' }` — the route never publishes anything a fork could orphan,
+ *   so no boundary message is needed. Enforced, not assumed: a draft above the finalized head is
+ *   a fatal `E2427` rather than an unretractable message on the wire.
+ *
+ * `epoch` is a durable counter incremented once per fork, in the same transaction that rewinds
+ * the cursor. It is what lets an unordered consumer tell a late duplicate from live data: a
+ * message stamped with an epoch below the last boundary it saw is from an orphaned branch.
+ *
+ * Delivery stays at-least-once, as for CDC routes. The guarantee is one durable boundary message
+ * per route per committed fork — not exactly-once delivery, and not ordering across topics.
+ *
+ * A signal topic must NOT be attached to a BigQuery subscription: the payload has no CDC fields,
+ * so every message would fail schema validation and land in the dead-letter topic.
+ *
+ * A stream may feed both a `topics` route and a `signals` route — they are independent maps over
+ * the same batch, publishing to different topics.
+ *
+ * To run:
+ *
+ * ```bash
+ * GOOGLE_CLOUD_PROJECT=my-project tsx docs/examples/evm/19.pubsub-signals.example.ts
+ * ```
+ */
+
+import { PubSub } from '@google-cloud/pubsub'
+import { commonAbis, evmEventDecoder, evmPortalStream } from '@subsquid/pipes/evm'
+import { pubsubTarget } from '@subsquid/pipes/targets/pubsub'
+
+const PROJECT = process.env['GOOGLE_CLOUD_PROJECT'] ?? 'demo'
+const TRANSFERS_TOPIC = process.env['PUBSUB_TRANSFERS_TOPIC'] ?? 'evm.base.erc20-transfers.raw'
+const STATE = process.env['PUBSUB_STATE'] ?? './state/base-erc20-signals.sqlite'
+
+async function main() {
+  await evmPortalStream({
+    id: 'base-erc20-signals',
+    portal: 'https://portal.sqd.dev/datasets/base-mainnet',
+    outputs: evmEventDecoder({
+      range: { from: 'latest' },
+      events: {
+        transfers: commonAbis.erc20.events.Transfer,
+      },
+    }),
+  }).pipeTo(
+    pubsubTarget({
+      pubsub: new PubSub({ projectId: PROJECT }),
+      state: { path: STATE },
+      namespace: 'base-erc20',
+
+      signals: {
+        transfers: {
+          topic: TRANSFERS_TOPIC,
+
+          // Pure and deterministic, exactly as for a CDC route: a replay after a crash must
+          // reproduce identical bytes, or the consumer cannot recognise the duplicate.
+          map: ({ data, epoch }) =>
+            data.map((t) => ({
+              // Published verbatim. No `_id`, no `_CHANGE_TYPE` — the consumer reads this shape.
+              data: {
+                type: 'transfer',
+                // Stamped so a message from a branch the feed has since abandoned is
+                // recognisable after the boundary message raises the consumer's epoch.
+                epoch,
+                token: t.rawEvent.address,
+                from: t.event.from,
+                to: t.event.to,
+                amount: t.event.value.toString(),
+                block: t.block.number,
+                logIndex: t.rawEvent.logIndex,
+              },
+              // Required: drives the go-live cut and the fork-mode check.
+              block: t.block,
+              // Subscription filters work the same as on a CDC route.
+              attributes: {
+                token: t.rawEvent.address,
+              },
+            })),
+
+          // The alternative is `fork: { mode: 'finalized-only' }`, with no `map`: it publishes
+          // nothing a fork can orphan, so the consumer never unwinds — at the cost of trailing
+          // the finalized head. Reading the finalized stream satisfies it trivially.
+          fork: {
+            mode: 'boundary',
+            // Called once per fork, inside the transaction that rewinds the cursor and persists
+            // the new epoch — so this message and the rewind are committed together or not at
+            // all. `rollbackTo` is the last block that survived; `deadEnd` means nothing local
+            // proved which branch is canonical and the consumer needs a full rebuild.
+            map: ({ epoch, rollbackTo, deadEnd }) => ({
+              data: {
+                type: 'fork',
+                epoch,
+                rollbackTo: rollbackTo?.number ?? null,
+                deadEnd,
+              },
+            }),
+          },
+        },
+      },
+    }),
+  )
+}
+
+void main()

--- a/docs/pubsub-bigquery.md
+++ b/docs/pubsub-bigquery.md
@@ -256,13 +256,56 @@ per path, and watch the `sqd_pubsub_cold_start` gauge.
 **Schema changes must be additive and nullable.** Dropping or retyping a column, or adding
 a `REQUIRED` one, breaks subscribers whose tables no longer match.
 
-**No finality signal.** The feed converges after a chain reorg — a fork publishes a
-`DELETE` or a restoring `UPSERT` with a higher sequence number — but nothing on the wire
-says when a row became reorg-proof. "Act only on finalized values" is not expressible
-here.
+**No finality marker on a CDC row.** The feed converges after a chain reorg — a fork
+publishes a `DELETE` or a restoring `UPSERT` with a higher sequence number — but nothing in
+the CDC envelope says when a row became reorg-proof. "Act only on finalized values" is not
+expressible on a `topics` route. A signal route can carry that announcement on its own
+topic (see below); a BigQuery subscription still cannot act on it.
 
 **Quotas.** 10 000 attached subscriptions per topic, and a per-region cap on BigQuery
 subscription throughput.
+
+## Signal routes are not for BigQuery
+
+Alongside `topics`, the target accepts `signals`: routes that publish an application-defined
+payload with no CDC envelope — no `_id`, no `_CHANGE_TYPE`, no `_CHANGE_SEQUENCE_NUMBER`.
+They exist for consumers that fold their own state rather than mirror a table: raw event
+streams, watermark and finality announcements, control messages.
+
+**Do not attach a BigQuery subscription to a signal topic.** Every message would fail schema
+validation and land in the dead-letter topic. Signal topics take ordinary pull or push
+subscriptions.
+
+The fork story also differs. A signal has no row identity, so it cannot be repaired per
+message. Each route declares how it copes: `fork: { mode: 'boundary', map }` publishes one
+boundary message per fork — carrying a durable epoch counter and the block the feed rewound
+to — ahead of every CDC compensation, and the consumer unwinds its own state from that.
+`fork: { mode: 'finalized-only' }` promises the route never publishes anything a fork could
+orphan, and that promise is enforced rather than assumed.
+
+`docs/examples/evm/19.pubsub-signals.example.ts` is a runnable example.
+
+## Producer metrics
+
+Exported by the pipe's metrics server. Alert on the first two.
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `sqd_pubsub_block_to_commit_lag_seconds` | histogram | Seconds from the committed block's chain timestamp to the Pub/Sub ack. End-to-end freshness, including block production and chain-to-portal propagation — a service level, not an attribution. Empty below the go-live block, or when the pipe's query selects no block `timestamp`. |
+| `sqd_pubsub_portal_to_commit_lag_seconds` | histogram | Seconds from the portal stamping the batch to the Pub/Sub ack. In-process latency, covering stream-buffer dwell and the pipe's transformers as well as this target. |
+| `sqd_pubsub_operations_total` | counter | Operations enqueued, by `topic`, `kind` (`cdc`/`signal`) and `operation` (`upsert`/`delete`, or `data`/`fork`). |
+| `sqd_pubsub_publish_duration_seconds` | histogram | Wallclock of one outbox drain. Split a `portal_to_commit` regression against this. |
+| `sqd_pubsub_published_bytes_total` | counter | Payload bytes confirmed published, attributes excluded. |
+| `sqd_pubsub_outbox_depth` | gauge | Rows queued but unconfirmed. Sustained growth means the publisher is not keeping up. |
+| `sqd_pubsub_compensations_per_fork` | histogram | Compensating operations per resolved fork — fork blast radius. Signals are excluded; they compensate nothing. |
+| `sqd_pubsub_manifest_rows` | gauge | Rows in the rollback manifest — the unfinalized window the target can still repair. |
+| `sqd_pubsub_publish_saturation_seconds` | counter | Message ordering only: seconds spent publishing a partition at ≥80% of Pub/Sub's 1 MB/s per-ordering-key cap. Growth means the headroom is eroding. |
+| `sqd_pubsub_cold_start` | gauge | 1 when the state file started empty. See the lost-sequencer limit above. |
+
+Both lag histograms are observed once per batch above the go-live block, including a batch
+whose routes mapped nothing: they measure how current the destination is, and a route that
+legitimately publishes nothing for a stretch is still current. Gating them on a non-empty
+publish would make a sparse feed's freshness series go silent and read as a dead pipe.
 
 ## When a shared dataset is the better answer
 

--- a/packages/pipes/src/targets/pubsub/errors.ts
+++ b/packages/pipes/src/targets/pubsub/errors.ts
@@ -80,4 +80,10 @@ export const PUBSUB_ERROR_CODES = {
   ROUTE_NOT_CONFIGURED: 'E2423',
   /** The producer-wide BigQuery CDC change sequence cannot advance safely. */
   SEQUENCE_EXHAUSTED: 'E2424',
+  /** No CDC or signal routes were configured. */
+  NO_ROUTES: 'E2425',
+  /** A signal draft lacks a usable chain attribution. */
+  INVALID_SIGNAL_BLOCK: 'E2426',
+  /** A finalized-only signal was mapped from an unfinalized block. */
+  SIGNAL_NOT_FINALIZED: 'E2427',
 } as const

--- a/packages/pipes/src/targets/pubsub/index.ts
+++ b/packages/pipes/src/targets/pubsub/index.ts
@@ -18,16 +18,21 @@ export {
 export {
   type CommitInput,
   type OutboxRow,
+  type PendingCdcOperation,
   type PendingOperation,
+  type PendingSignalOperation,
   type PubsubState,
   type RouteMode,
   type RowIdSource,
+  type SignalForkContext,
   SqlitePubsubState,
 } from './pubsub-state.js'
 export {
   type MessageDraft,
   type PubsubTargetOptions,
   type RollbackInverse,
+  type SignalDraft,
+  type SignalRoute,
   type TopicRoute,
   pubsubTarget,
 } from './pubsub-target.js'

--- a/packages/pipes/src/targets/pubsub/pubsub-signal.test.ts
+++ b/packages/pipes/src/targets/pubsub/pubsub-signal.test.ts
@@ -1,0 +1,350 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { evmPortalStream } from '~/evm/evm-portal-source.js'
+import { MockPortal, mockMetricsServer, mockPortal, testLogger } from '~/testing/index.js'
+
+import { PUBSUB_ERROR_CODES } from './errors.js'
+import { SqlitePubsubState } from './pubsub-state.js'
+import { SignalRoute, pubsubTarget } from './pubsub-target.js'
+import {
+  FakePublisher,
+  cleanupTempState,
+  keyedBlockDecoder,
+  makeBatchContext,
+  portalBlocks,
+  tempStatePath,
+} from './test-support.js'
+
+type Output = { blocks: { number: number; hash: string }[] }
+
+const body = (message: FakePublisher['published'][number]) => JSON.parse(message.payload)
+
+let portal: MockPortal | undefined
+
+afterEach(async () => {
+  await portal?.close()
+  portal = undefined
+  cleanupTempState()
+})
+
+/** Drives one batch through a signal-only target, with the finalized head under the caller's control. */
+async function driveSignals({
+  route,
+  current,
+  finalized = current,
+  publisher = new FakePublisher(),
+  finalizedStream,
+  publishFrom = 0,
+}: {
+  route: SignalRoute<Output['blocks']>
+  current: { number: number; hash: string }
+  finalized?: { number: number; hash: string }
+  publisher?: FakePublisher
+  finalizedStream?: boolean
+  publishFrom?: number | 'latest'
+}) {
+  const target = pubsubTarget<Output>({
+    pubsub: {} as never,
+    publisher,
+    state: { path: tempStatePath() },
+    publishFrom,
+    signals: { blocks: route },
+  })
+
+  async function* read() {
+    yield {
+      data: { blocks: [current] },
+      ctx: makeBatchContext({ current, finalized, rollbackChain: [current] }),
+    }
+  }
+
+  await target.write({ read: read as never, logger: testLogger(), id: 'test-pipe', finalized: finalizedStream })
+
+  return publisher
+}
+
+const boundaryFork = { mode: 'boundary', map: () => ({ data: { type: 'fork' } }) } as const
+
+describe('pubsubTarget signals', () => {
+  it('publishes a signal-only route without CDC fields', async () => {
+    const publisher = new FakePublisher()
+    const target = pubsubTarget<Output>({
+      pubsub: {} as never,
+      publisher,
+      state: { path: tempStatePath() },
+      publishFrom: 0,
+      signals: {
+        blocks: {
+          topic: 'raw-blocks',
+          map: ({ data, epoch }) =>
+            data.map((block) => ({ block, data: { type: 'block', epoch, _id: 'application-owned', block } })),
+          fork: boundaryFork,
+        },
+      },
+    })
+
+    async function* read() {
+      const current = { number: 10, hash: '0x10' }
+      yield {
+        data: { blocks: [current] },
+        ctx: makeBatchContext({ current, finalized: current, rollbackChain: [current] }),
+      }
+    }
+
+    await target.write({ read: read as never, logger: testLogger(), id: 'test-pipe', finalized: true })
+
+    expect(publisher.published).toHaveLength(1)
+    expect(publisher.published[0]).toMatchObject({ topic: 'raw-blocks' })
+    expect(JSON.parse(publisher.published[0].payload)).toEqual({
+      _id: 'application-owned',
+      block: { hash: '0x10', number: 10 },
+      epoch: 0,
+      type: 'block',
+    })
+  })
+
+  it('enqueues one boundary signal with the new durable epoch during a fork', async () => {
+    const state = new SqlitePubsubState({ path: tempStatePath() })
+    await state.open({ cursorKey: 'test-pipe', logger: testLogger() })
+    await state.commit({
+      operations: [],
+      ledger: [{ number: 10, hash: '0x10' }],
+      cursor: { number: 10, hash: '0x10' },
+      finalized: { number: 9, hash: '0x9' },
+      forkCapable: true,
+    })
+
+    const safe = await state.fork([{ number: 10, hash: '0x10b' }], ({ epoch, rollbackTo, deadEnd }) => [
+      {
+        kind: 'signal',
+        route: 'blocks',
+        topic: 'raw-blocks',
+        orderingKey: '',
+        attributes: {},
+        payload: new TextEncoder().encode(JSON.stringify({ epoch, rollbackTo, deadEnd })),
+        blockNumber: rollbackTo?.number ?? 0,
+        signalType: 'fork',
+      },
+    ])
+
+    expect(safe).toBeNull()
+    expect(await state.getMeta('fork_epoch')).toBe('1')
+    expect(new TextDecoder().decode((await state.pending())[0].payload)).toContain('"epoch":1')
+    await state.close()
+  })
+
+  describe('fork boundary, end to end', () => {
+    /**
+     * Blocks 1–2 on branch `a` (1 finalized), then a 409 whose canonical view keeps only block 1 —
+     * the same shallow fork the CDC fork suite uses.
+     */
+    const shallowFork = [
+      {
+        statusCode: 200,
+        data: portalBlocks([1, 2]),
+        head: { finalized: { number: 1, hash: '0x1' }, latest: { number: 4 } },
+      },
+      {
+        statusCode: 409,
+        data: {
+          previousBlocks: [
+            { number: 1, hash: '0x1' },
+            { number: 2, hash: '0x2b' },
+            { number: 3, hash: '0x3b' },
+          ],
+        },
+      },
+      {
+        statusCode: 200,
+        data: portalBlocks([2, 3], 'b'),
+        head: { finalized: { number: 1, hash: '0x1' }, latest: { number: 4 } },
+      },
+    ]
+
+    async function runFork(route: SignalRoute<Output['blocks']>, metrics?: ReturnType<typeof mockMetricsServer>) {
+      const publisher = new FakePublisher()
+      portal = await mockPortal(shallowFork as never)
+
+      await evmPortalStream({
+        id: 'test-pipe',
+        portal: portal.url,
+        outputs: keyedBlockDecoder({ from: 0, to: 3 }),
+        metrics: metrics?.server,
+      }).pipeTo(
+        pubsubTarget<Output>({
+          pubsub: {} as never,
+          publisher,
+          state: { path: tempStatePath() },
+          publishFrom: 0,
+          signals: { blocks: route },
+        }),
+      )
+
+      return publisher
+    }
+
+    it('publishes one boundary message carrying the raised epoch and the rewind point', async () => {
+      const publisher = await runFork({
+        topic: 'raw-blocks',
+        map: ({ data, epoch }) => data.map((block) => ({ block, data: { type: 'block', epoch, at: block.number } })),
+        fork: {
+          mode: 'boundary',
+          map: ({ epoch, rollbackTo, deadEnd }) => ({
+            data: { type: 'fork', epoch, rollbackTo: rollbackTo?.number ?? null, deadEnd },
+          }),
+        },
+      })
+
+      const forks = publisher.published.map(body).filter((message) => message.type === 'fork')
+
+      expect(forks).toEqual([{ type: 'fork', epoch: 1, rollbackTo: 1, deadEnd: false }])
+    })
+
+    it('stamps data published after the fork with the raised epoch', async () => {
+      const publisher = await runFork({
+        topic: 'raw-blocks',
+        map: ({ data, epoch }) => data.map((block) => ({ block, data: { type: 'block', epoch, at: block.number } })),
+        fork: {
+          mode: 'boundary',
+          map: ({ epoch }) => ({ data: { type: 'fork', epoch } }),
+        },
+      })
+
+      const messages = publisher.published.map(body)
+      const forkIndex = messages.findIndex((message) => message.type === 'fork')
+
+      expect(forkIndex).toBeGreaterThan(0)
+      expect(forkIndex).toBeLessThan(messages.length - 1)
+
+      // The re-streamed blocks carry epoch 1, so a consumer can drop the epoch-0 copies it
+      // already received for the same block numbers.
+      expect(messages.slice(0, forkIndex).map((message) => message.epoch)).toEqual([0, 0])
+      expect(messages.slice(forkIndex + 1).map((message) => message.epoch)).toEqual([1, 1])
+    })
+
+    it('publishes no boundary message for a finalized-only route', async () => {
+      const publisher = await runFork({
+        topic: 'raw-blocks',
+        // Only finalized blocks, so the fork cannot orphan anything this route published.
+        map: ({ data, ctx }) =>
+          data
+            .filter((block) => block.number <= (ctx.stream.head.finalized?.number ?? -1))
+            .map((block) => ({ block, data: { type: 'block', at: block.number } })),
+        fork: { mode: 'finalized-only' },
+      })
+
+      const messages = publisher.published.map(body)
+
+      // The route published block 1 (finalized) and the fork still resolved — it just produced
+      // no boundary message, because nothing this route sent could have been orphaned.
+      expect(messages).not.toHaveLength(0)
+      expect(messages.filter((message) => message.type === 'fork')).toEqual([])
+    })
+
+    it('keeps the boundary message out of the compensations histogram', async () => {
+      const metrics = mockMetricsServer()
+
+      const publisher = await runFork(
+        {
+          topic: 'raw-blocks',
+          map: ({ data }) => data.map((block) => ({ block, data: { type: 'block', at: block.number } })),
+          fork: { mode: 'boundary', map: ({ epoch }) => ({ data: { type: 'fork', epoch } }) },
+        },
+        metrics,
+      )
+
+      // A signal route enters no manifest, so the fork repairs nothing — but it does publish one
+      // boundary message on that drain. Counting it would report phantom fork blast radius.
+      expect(publisher.published.map(body).filter((message) => message.type === 'fork')).toHaveLength(1)
+      expect(metrics.histogram('sqd_pubsub_compensations_per_fork').observations).toEqual([0])
+    })
+  })
+
+  describe('route validation', () => {
+    it('refuses a target with neither topics nor signals', () => {
+      expect(() =>
+        pubsubTarget<Output>({
+          pubsub: {} as never,
+          publisher: new FakePublisher(),
+          state: { path: tempStatePath() },
+        }),
+      ).toThrowError(expect.objectContaining({ code: PUBSUB_ERROR_CODES.NO_ROUTES }))
+    })
+
+    it('refuses a draft without a usable block', async () => {
+      await expect(
+        driveSignals({
+          route: {
+            topic: 'raw-blocks',
+            map: () => [{ data: { type: 'block' } } as never],
+            fork: boundaryFork,
+          },
+          current: { number: 10, hash: '0x10' },
+        }),
+      ).rejects.toMatchObject({ code: PUBSUB_ERROR_CODES.INVALID_SIGNAL_BLOCK })
+    })
+
+    it('refuses an ordering key while message ordering is disabled', async () => {
+      await expect(
+        driveSignals({
+          route: {
+            topic: 'raw-blocks',
+            map: ({ data }) => data.map((block) => ({ block, data: { at: block.number }, orderingKey: 'shard-1' })),
+            fork: boundaryFork,
+          },
+          current: { number: 10, hash: '0x10' },
+        }),
+      ).rejects.toMatchObject({ code: PUBSUB_ERROR_CODES.ORDERING_KEY_NOT_SUPPORTED })
+    })
+  })
+
+  describe('finalized-only enforcement', () => {
+    const finalizedOnlyRoute: SignalRoute<Output['blocks']> = {
+      topic: 'raw-blocks',
+      map: ({ data }) => data.map((block) => ({ block, data: { at: block.number } })),
+      fork: { mode: 'finalized-only' },
+    }
+
+    it('refuses a draft above the finalized head', async () => {
+      await expect(
+        driveSignals({
+          route: finalizedOnlyRoute,
+          current: { number: 10, hash: '0x10' },
+          finalized: { number: 9, hash: '0x9' },
+        }),
+      ).rejects.toMatchObject({ code: PUBSUB_ERROR_CODES.SIGNAL_NOT_FINALIZED })
+    })
+
+    it('publishes a draft at the finalized head', async () => {
+      const publisher = await driveSignals({
+        route: finalizedOnlyRoute,
+        current: { number: 9, hash: '0x9' },
+        finalized: { number: 9, hash: '0x9' },
+      })
+
+      expect(publisher.published).toHaveLength(1)
+    })
+
+    it('accepts any block on the finalized stream, where nothing can be unfinalized', async () => {
+      const publisher = await driveSignals({
+        route: finalizedOnlyRoute,
+        current: { number: 10, hash: '0x10' },
+        finalized: { number: 9, hash: '0x9' },
+        finalizedStream: true,
+      })
+
+      expect(publisher.published).toHaveLength(1)
+    })
+
+    it('checks finality after the go-live cut, so a skipped draft cannot fail the run', async () => {
+      const publisher = await driveSignals({
+        route: finalizedOnlyRoute,
+        current: { number: 10, hash: '0x10' },
+        finalized: { number: 9, hash: '0x9' },
+        publishFrom: 1_000_000,
+      })
+
+      expect(publisher.published).toEqual([])
+    })
+  })
+})

--- a/packages/pipes/src/targets/pubsub/pubsub-state.test.ts
+++ b/packages/pipes/src/targets/pubsub/pubsub-state.test.ts
@@ -8,7 +8,7 @@ import { BlockCursor } from '~/core/index.js'
 import { testLogger } from '~/testing/index.js'
 
 import { PUBSUB_ERROR_CODES, PubsubTargetError } from './errors.js'
-import { CommitInput, PendingOperation, SqlitePubsubState } from './pubsub-state.js'
+import { CommitInput, PendingCdcOperation, SqlitePubsubState } from './pubsub-state.js'
 
 const encoder = new TextEncoder()
 const text = (bytes: Uint8Array) => new TextDecoder().decode(bytes)
@@ -49,8 +49,9 @@ function block(number: number, suffix = 'a'): BlockCursor {
   return { number, hash: `0x${number}${suffix}`, timestamp: 1_700_000_000 + number }
 }
 
-function operation(overrides: Partial<PendingOperation> & { id?: string } = {}): PendingOperation {
+function operation(overrides: Partial<PendingCdcOperation> & { id?: string } = {}): PendingCdcOperation {
   return {
+    kind: 'cdc',
     route: 'transfers',
     topic: 'transfers',
     orderingKey: '',
@@ -235,7 +236,8 @@ describe('SqlitePubsubState', () => {
     expect(result.coldStart).toBe(false)
   })
 
-  it('refuses the previous schema instead of migrating it in place', async () => {
+  // Only v2 has an in-place migration to v3; anything older is refused rather than guessed at.
+  it('refuses a schema older than the one it can migrate', async () => {
     const path = statePath()
     const first = await openState(path)
     await first.state.setMeta('schema_version', '1')
@@ -552,7 +554,7 @@ describe('SqlitePubsubState', () => {
   })
 
   describe('materialized identity', () => {
-    async function revise(state: SqlitePubsubState, overrides: Partial<PendingOperation>) {
+    async function revise(state: SqlitePubsubState, overrides: Partial<PendingCdcOperation>) {
       await commit(state, {
         operations: [operation({ id: 'candle-1', mode: 'materialized', blockNumber: 101, ...overrides })],
         ledger: [block(100), block(101)],

--- a/packages/pipes/src/targets/pubsub/pubsub-state.ts
+++ b/packages/pipes/src/targets/pubsub/pubsub-state.ts
@@ -12,7 +12,7 @@ import { SqliteSync, loadSqlite } from '~/drivers/sqlite/sqlite.js'
 import { PUBSUB_ERROR_CODES, PubsubTargetError } from './errors.js'
 import { MAX_SEQUENCE_VALUE, PubsubOp } from './protocol.js'
 
-export const STATE_SCHEMA_VERSION = '2'
+export const STATE_SCHEMA_VERSION = '3'
 
 export type RouteMode = 'event' | 'materialized'
 export type RowIdSource = 'row' | 'draft' | 'derived' | 'generated'
@@ -21,7 +21,8 @@ export type RowIdSource = 'row' | 'draft' | 'derived' | 'generated'
  * One wire operation on its way out: everything the state needs to sequence it, publish it,
  * and — when it sits above the finalized watermark — compensate it after a fork.
  */
-export type PendingOperation = {
+export type PendingCdcOperation = {
+  kind: 'cdc'
   /** Route name selects the encoder after recovery. */
   route: string
   topic: string
@@ -47,16 +48,38 @@ export type PendingOperation = {
   inverse?: { op: 'upsert' | 'delete'; payload: Uint8Array }
 }
 
-export type OutboxRow = {
-  rowId: number
+/** A non-CDC application message. Its bytes are final before the state transaction commits. */
+export type PendingSignalOperation = {
+  kind: 'signal'
   route: string
   topic: string
-  op: PubsubOp
-  id: string
+  orderingKey: string
+  attributes: Record<string, string>
+  payload: Uint8Array
+  blockNumber: number
+  /** Distinguishes ordinary mapped data from the one boundary message emitted for a fork. */
+  signalType: 'data' | 'fork'
+}
+
+export type PendingOperation = PendingCdcOperation | PendingSignalOperation
+
+export type OutboxRow = {
+  rowId: number
+  kind: 'cdc' | 'signal'
+  route: string
+  topic: string
+  op?: PubsubOp
+  id?: string
   orderingKey: string
   seq: number
   attributes: Record<string, string>
   payload: Uint8Array
+}
+
+export type SignalForkContext = {
+  epoch: number
+  rollbackTo: BlockCursor | null
+  deadEnd: boolean
 }
 
 export type CommitInput = {
@@ -96,7 +119,10 @@ export interface PubsubState {
    * cursor, enqueue the compensations, and rewind. Returns the safe cursor, or `null` on a
    * dead-end fork (the whole rollbackable manifest is compensated first).
    */
-  fork(canonicalBlocks: BlockCursor[]): Promise<BlockCursor | null>
+  fork(
+    canonicalBlocks: BlockCursor[],
+    buildSignals?: (context: SignalForkContext) => PendingSignalOperation[],
+  ): Promise<BlockCursor | null>
   stats(): Promise<{ outbox: number; manifest: number }>
   close(): Promise<void>
 }
@@ -107,8 +133,9 @@ type OutboxDbRow = {
   row_id: number
   route: string
   topic: string
-  op: string
-  id: string
+  kind: 'cdc' | 'signal'
+  op: string | null
+  id: string | null
   ordering_key: string
   seq: number
   attributes: string
@@ -130,6 +157,7 @@ type ManifestDbRow = {
 const META_SEQUENCE = 'sequence'
 const META_CURSOR_KEY = 'cursor_key'
 const META_MATERIALIZED_ID_SOURCE = 'materialized_id_source:'
+export const META_FORK_EPOCH = 'fork_epoch'
 
 /**
  * An unambiguous key for a composite identity. A separator-joined string is not one:
@@ -230,7 +258,11 @@ export class SqlitePubsubState implements PubsubState {
       this.#lock()
       this.#initializeSchema()
 
-      const version = this.getMetaSync('schema_version')
+      let version = this.getMetaSync('schema_version')
+      if (version === '2') {
+        this.#migrateV2ToV3()
+        version = STATE_SCHEMA_VERSION
+      }
       if (version && version !== STATE_SCHEMA_VERSION) {
         throw new PubsubTargetError(PUBSUB_ERROR_CODES.STATE_SCHEMA_VERSION, [
           `The PubSub state at "${this.#options.path}" was written with schema version ${version}, ` +
@@ -242,6 +274,7 @@ export class SqlitePubsubState implements PubsubState {
       if (coldStart) {
         this.setMetaSync('schema_version', STATE_SCHEMA_VERSION)
         this.setMetaSync(META_SEQUENCE, '0')
+        this.setMetaSync(META_FORK_EPOCH, '0')
         this.setMetaSync(META_CURSOR_KEY, this.#key.value)
       } else {
         this.#assertSameProducer()
@@ -307,6 +340,7 @@ export class SqlitePubsubState implements PubsubState {
       db.exec(`
         CREATE TABLE IF NOT EXISTS outbox (
           row_id        INTEGER PRIMARY KEY AUTOINCREMENT,
+          kind          TEXT NOT NULL DEFAULT 'cdc',
           route         TEXT,
           topic         TEXT,
           op            TEXT,
@@ -379,6 +413,20 @@ export class SqlitePubsubState implements PubsubState {
     }
   }
 
+  #migrateV2ToV3(): void {
+    const db = this.#db!
+    db.exec('BEGIN IMMEDIATE')
+    try {
+      db.exec("ALTER TABLE outbox ADD COLUMN kind TEXT NOT NULL DEFAULT 'cdc'")
+      this.setMetaSync(META_FORK_EPOCH, '0')
+      this.setMetaSync('schema_version', STATE_SCHEMA_VERSION)
+      db.exec('COMMIT')
+    } catch (e) {
+      db.exec('ROLLBACK')
+      throw e
+    }
+  }
+
   // ─── meta ───────────────────────────────────────────────────────────────────
 
   getMetaSync(key: string): string | undefined {
@@ -442,14 +490,16 @@ export class SqlitePubsubState implements PubsubState {
   }
 
   #enqueue(operation: PendingOperation, seq: number): void {
+    const isSignal = operation.kind === 'signal'
     this.#db!.exec(
-      `INSERT INTO outbox (route, topic, op, id, ordering_key, seq, attributes, payload, block_number)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO outbox (kind, route, topic, op, id, ordering_key, seq, attributes, payload, block_number)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
+        isSignal ? 'signal' : 'cdc',
         operation.route,
         operation.topic,
-        operation.op,
-        operation.id,
+        isSignal ? null : operation.op,
+        isSignal ? null : operation.id,
         operation.orderingKey,
         seq,
         stableAttributes(operation.attributes),
@@ -469,6 +519,8 @@ export class SqlitePubsubState implements PubsubState {
       for (const operation of operations) {
         const seq = this.#nextSeq(operation)
         this.#enqueue(operation, seq)
+
+        if (operation.kind === 'signal') continue
 
         if (operation.mode === 'materialized') {
           this.#assertIdentitySourceStable(operation)
@@ -557,7 +609,7 @@ export class SqlitePubsubState implements PubsubState {
    * A route emits one homogeneous materialized row family. Switching between `_id`, draft `id`,
    * `deriveId`, and generated ids would make one revision unreachable under the next one's key.
    */
-  #assertIdentitySourceStable(operation: PendingOperation): void {
+  #assertIdentitySourceStable(operation: PendingCdcOperation): void {
     const key = `${META_MATERIALIZED_ID_SOURCE}${operation.route}`
     const known = this.getMetaSync(key) as RowIdSource | undefined
 
@@ -582,7 +634,7 @@ export class SqlitePubsubState implements PubsubState {
    * never receives a revision carrying new ones; if a fork is possible, its repair also uses the
    * identity the row was first published under.
    */
-  #assertIdentityStable(operation: PendingOperation): void {
+  #assertIdentityStable(operation: PendingCdcOperation): void {
     const db = this.#db!
     const id = operation.id
 
@@ -633,7 +685,7 @@ export class SqlitePubsubState implements PubsubState {
    * Without forks there is no manifest or payload baseline, but filter safety still needs one
    * durable identity per live materialized id. A delete ends that lifetime and frees the id.
    */
-  #updateMaterializedIdentity(operation: PendingOperation): void {
+  #updateMaterializedIdentity(operation: PendingCdcOperation): void {
     const db = this.#db!
     const id = operation.id
 
@@ -726,10 +778,10 @@ export class SqlitePubsubState implements PubsubState {
 
     return rows.map((row) => ({
       rowId: row.row_id,
+      kind: row.kind ?? 'cdc',
       route: row.route,
       topic: row.topic,
-      op: row.op as PubsubOp,
-      id: row.id,
+      ...(row.kind === 'signal' ? {} : { op: row.op as PubsubOp, id: row.id ?? undefined }),
       orderingKey: row.ordering_key,
       seq: row.seq,
       attributes: JSON.parse(row.attributes) as Record<string, string>,
@@ -764,7 +816,10 @@ export class SqlitePubsubState implements PubsubState {
 
   // ─── fork (CN-35) ───────────────────────────────────────────────────────────
 
-  async fork(canonicalBlocks: BlockCursor[]): Promise<BlockCursor | null> {
+  async fork(
+    canonicalBlocks: BlockCursor[],
+    buildSignals: (context: SignalForkContext) => PendingSignalOperation[] = () => [],
+  ): Promise<BlockCursor | null> {
     const db = this.#db!
 
     const persisted = await this.getCursor()
@@ -774,10 +829,24 @@ export class SqlitePubsubState implements PubsubState {
     // Dead end: nothing local proves which published operations are canonical, so fold the
     // ENTIRE rollbackable manifest back to the finalized baselines and stop. Fail-closed —
     // if the fork invalidated the finalized floor itself, the consumer needs a rebuild.
-    const floor = safe ? safe.number : (finalized?.number ?? -1)
+    const rollbackTo = safe ?? finalized ?? null
+    const floor = rollbackTo?.number ?? -1
 
     db.exec('BEGIN IMMEDIATE')
     try {
+      const currentEpoch = Number(this.getMetaSync(META_FORK_EPOCH) ?? '0')
+      if (!Number.isSafeInteger(currentEpoch) || currentEpoch < 0 || currentEpoch >= MAX_SEQUENCE_VALUE) {
+        throw new PubsubTargetError(
+          PUBSUB_ERROR_CODES.SEQUENCE_EXHAUSTED,
+          'The PubSub fork epoch cannot advance safely.',
+        )
+      }
+      const epoch = currentEpoch + 1
+      const signals = buildSignals({ epoch, rollbackTo, deadEnd: !safe })
+      for (const signal of signals) {
+        this.#enqueue(signal, this.#nextSeq(signal))
+      }
+      this.setMetaSync(META_FORK_EPOCH, String(epoch))
       const compensations = this.#compensate(floor)
       this.#logger?.debug(
         `fork at block ${floor}: ${compensations} compensating operation(s) enqueued${safe ? '' : ' (dead-end fork)'}`,
@@ -794,9 +863,8 @@ export class SqlitePubsubState implements PubsubState {
             AND m.id = rollback_inverse.id
         )`)
 
-      const rewound = safe ?? finalized
-      if (rewound) {
-        this.#saveCursor(rewound, finalized ?? null)
+      if (rollbackTo) {
+        this.#saveCursor(rollbackTo, finalized ?? null)
       }
 
       db.exec('COMMIT')
@@ -928,8 +996,8 @@ export class SqlitePubsubState implements PubsubState {
     const seq = this.#nextSeq(compensation)
 
     this.#db!.exec(
-      `INSERT INTO outbox (route, topic, op, id, ordering_key, seq, attributes, payload, block_number)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO outbox (kind, route, topic, op, id, ordering_key, seq, attributes, payload, block_number)
+       VALUES ('cdc', ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         compensation.route,
         compensation.topic,

--- a/packages/pipes/src/targets/pubsub/pubsub-target.test.ts
+++ b/packages/pipes/src/targets/pubsub/pubsub-target.test.ts
@@ -490,8 +490,12 @@ describe('pubsubTarget', () => {
         metrics,
       })
 
-      expect(metrics.counter('sqd_pubsub_ops_total').total).toBe(2)
-      expect(metrics.counter('sqd_pubsub_ops_total').calls[0].labels).toMatchObject({ topic: 'blocks', op: 'upsert' })
+      expect(metrics.counter('sqd_pubsub_operations_total').total).toBe(2)
+      expect(metrics.counter('sqd_pubsub_operations_total').calls[0].labels).toMatchObject({
+        topic: 'blocks',
+        kind: 'cdc',
+        operation: 'upsert',
+      })
     })
 
     describe('commit-lag histograms', () => {
@@ -931,13 +935,24 @@ describe('pubsubTarget', () => {
         'network down',
       )
 
+      // The stream keeps a route, so the target itself is valid — but the pending row's route is
+      // now a signal route, and its CDC encoder is gone. Same failure as deleting it outright.
       await expect(
         driveBatches({
           statePath,
           publisher: new FakePublisher(),
           blocks: [],
           finalized: 0,
-          targetOptions: { topics: {} },
+          targetOptions: {
+            topics: {},
+            signals: {
+              blocks: {
+                topic: 'blocks',
+                map: () => [],
+                fork: { mode: 'finalized-only' },
+              },
+            },
+          },
         }),
       ).rejects.toMatchObject({ code: PUBSUB_ERROR_CODES.ROUTE_NOT_CONFIGURED })
     })
@@ -1080,6 +1095,32 @@ describe('pubsubTarget', () => {
       await expect(
         driveBatches({ statePath, publisher: new FakePublisher(), blocks: [], finalized: 0 }),
       ).rejects.toMatchObject({ code: PUBSUB_ERROR_CODES.STATE_WIRE_CONFIG_MISMATCH })
+    })
+
+    it('drains a pending v2 CDC outbox after migrating its route metadata', async () => {
+      const statePath = tempStatePath()
+      const failing = new FakePublisher()
+      failing.failOn = () => new Error('network down')
+
+      await expect(driveBatches({ statePath, publisher: failing, blocks: [1], finalized: 0 })).rejects.toThrow(
+        'network down',
+      )
+
+      const state = new SqlitePubsubState({ path: statePath })
+      await state.open({ cursorKey: 'test-pipe', logger: testLogger() })
+      await state.setMeta('wire_config', JSON.stringify(['test-pipe', false, false, [['blocks', 'canonical']]]))
+      await state.close()
+
+      const restarted = new FakePublisher()
+      await driveBatches({ statePath, publisher: restarted, blocks: [], finalized: 0 })
+
+      expect(restarted.published).toHaveLength(1)
+      const migrated = new SqlitePubsubState({ path: statePath })
+      await migrated.open({ cursorKey: 'test-pipe', logger: testLogger() })
+      expect(await migrated.getMeta('wire_config')).toBe(
+        JSON.stringify(['test-pipe', false, false, [['cdc:blocks', 'canonical']]]),
+      )
+      await migrated.close()
     })
 
     it('rechecks a custom encoder output size during recovery', async () => {

--- a/packages/pipes/src/targets/pubsub/pubsub-target.ts
+++ b/packages/pipes/src/targets/pubsub/pubsub-target.ts
@@ -23,6 +23,7 @@ import {
   assertWireLimits,
   buildAttributes,
   canonicalCdcMessageBytes,
+  canonicalJson,
   encodeCdcMessage,
   encodeRow,
   readRowId,
@@ -37,7 +38,18 @@ import {
   partitionRows,
   resolvePubsubClient,
 } from './publisher.js'
-import { OutboxRow, PendingOperation, PubsubState, RouteMode, RowIdSource, SqlitePubsubState } from './pubsub-state.js'
+import {
+  META_FORK_EPOCH,
+  OutboxRow,
+  PendingCdcOperation,
+  PendingOperation,
+  PendingSignalOperation,
+  PubsubState,
+  RouteMode,
+  RowIdSource,
+  SignalForkContext,
+  SqlitePubsubState,
+} from './pubsub-state.js'
 
 export type MessageDraft = {
   /**
@@ -112,6 +124,64 @@ export type TopicRoute<Data> = {
   rollbackWhenMissing?: (draft: MessageDraft & { id: string }) => RollbackInverse
 }
 
+export type SignalDraft = {
+  /**
+   * The message body, published verbatim as canonical JSON. No CDC envelope is added, so the
+   * route owns the whole schema — including any id, type tag, or epoch a consumer needs.
+   */
+  data: object
+  /**
+   * The block this signal describes. Drives the go-live cut and the `finalized-only` check; it
+   * is never used to retract the message, because a signal has no compensating operation.
+   */
+  block: BlockCursor
+  /** User attributes for subscription filtering. `_`-prefixed names are reserved, `goog…` by GCP. */
+  attributes?: Record<string, string>
+  /**
+   * Available only when `publish.messageOrdering` is enabled. Defaults to the topic name, so a
+   * route that does not set one publishes its whole topic on a single ordered partition.
+   */
+  orderingKey?: string
+}
+
+/** A boundary signal is emitted by the fork itself, so it has no block of its own to declare. */
+export type ForkSignalDraft = Omit<SignalDraft, 'block'>
+
+/**
+ * A route that publishes application messages instead of BigQuery CDC rows.
+ *
+ * Signals are fire-and-forget: they carry no row identity, never enter the rollback manifest,
+ * and cannot be retracted. That is the whole trade — a signal route buys an arbitrary payload
+ * schema at the cost of the fork repair a `TopicRoute` gets for free. `fork` is how the route
+ * pays for it, and there is no default: every route states which of the two strategies it uses.
+ */
+export type SignalRoute<Data> = {
+  topic: string
+  /**
+   * Map one batch of this stream's data to signals. Must be pure and deterministic (no wall
+   * clock, no randomness): a replay after a crash must reproduce identical bytes.
+   *
+   * `epoch` is the durable fork counter, incremented once per fork and readable by consumers to
+   * discard messages from a branch that has since been orphaned. Include it in `data` if the
+   * consumer needs to reason about forks at all.
+   */
+  map: (batch: { data: Data; ctx: BatchContext; epoch: number }) => SignalDraft[]
+  /**
+   * How this route survives a chain reorg.
+   *
+   * `boundary` — the route publishes unfinalized data and accepts that some of it is orphaned.
+   * On a fork the target publishes one message built by `map` ahead of every CDC compensation,
+   * carrying the new `epoch` and the block the feed rewound to. The consumer is expected to
+   * discard everything it received above that block, from the previous epoch, on its own.
+   *
+   * `finalized-only` — the route never publishes anything a fork could orphan, so no boundary
+   * message is needed. Enforced: a draft above the finalized head is a fatal `E2427` rather
+   * than an unretractable message on the wire. Reading the finalized stream satisfies this
+   * trivially.
+   */
+  fork: { mode: 'boundary'; map: (context: SignalForkContext) => ForkSignalDraft } | { mode: 'finalized-only' }
+}
+
 export type PubsubTargetOptions<T> = {
   /** A constructed client, or `ClientConfig` passed to `new PubSub(...)`. Auth = ADC / emulator. */
   pubsub: PubSub | ClientConfig
@@ -124,7 +194,12 @@ export type PubsubTargetOptions<T> = {
    * pipe `pipeTo` hands over, otherwise TypeScript would read the route map itself as the
    * stream shape and every `map` callback would land on `unknown`.
    */
-  topics: { [K in keyof NoInfer<T>]?: TopicRoute<NoInfer<T>[K]> }
+  topics?: { [K in keyof NoInfer<T>]?: TopicRoute<NoInfer<T>[K]> }
+  /**
+   * Routes that publish application messages without the CDC envelope. Same stream keys as
+   * `topics`, and a stream may feed both. At least one route across the two is required.
+   */
+  signals?: { [K in keyof NoInfer<T>]?: SignalRoute<NoInfer<T>[K]> }
   /** Cursor key inside the state file. Defaults to the pipe id (the CursorKey rule, ADR-2). */
   settings?: { id?: string }
   publish?: {
@@ -185,6 +260,7 @@ const PIPELINE_LAG_BUCKETS = [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60]
 type DrainSample = { elapsed: number; bytes: number; saturation: number }
 
 type ResolvedRoute = {
+  kind: 'cdc'
   stream: string
   topic: string
   mode: RouteMode
@@ -192,7 +268,16 @@ type ResolvedRoute = {
   route: TopicRoute<any>
 }
 
-type EncoderKind = 'canonical' | 'custom'
+type ResolvedSignalRoute = {
+  kind: 'signal'
+  stream: string
+  topic: string
+  route: SignalRoute<any>
+}
+
+type AnyResolvedRoute = ResolvedRoute | ResolvedSignalRoute
+
+type EncoderKind = 'canonical' | 'custom' | 'signal'
 
 export function pubsubTarget<T>(options: PubsubTargetOptions<T>) {
   const messageOrdering = options.publish?.messageOrdering ?? false
@@ -201,12 +286,23 @@ export function pubsubTarget<T>(options: PubsubTargetOptions<T>) {
   const routes: ResolvedRoute[] = Object.entries(options.topics ?? {})
     .filter((entry): entry is [string, TopicRoute<any>] => Boolean(entry[1]))
     .map(([stream, route]) => ({
+      kind: 'cdc' as const,
       stream,
       topic: route.topic,
       mode: route.mode ?? 'event',
       encoderKind: route.encode ? 'custom' : 'canonical',
       route,
     }))
+  const signals: ResolvedSignalRoute[] = Object.entries(options.signals ?? {})
+    .filter((entry): entry is [string, SignalRoute<any>] => Boolean(entry[1]))
+    .map(([stream, route]) => ({ kind: 'signal' as const, stream, topic: route.topic, route }))
+  const allRoutes: AnyResolvedRoute[] = [...routes, ...signals]
+
+  // Refused here rather than at first write: with no routes there is nothing the state file can
+  // be opened for, and taking its exclusive lock only to fail would strand a concurrent retry.
+  if (!allRoutes.length) {
+    throw new PubsubTargetError(PUBSUB_ERROR_CODES.NO_ROUTES, 'Configure at least one CDC topic or signal route.')
+  }
 
   const state: PubsubState =
     'path' in options.state
@@ -233,7 +329,10 @@ export function pubsubTarget<T>(options: PubsubTargetOptions<T>) {
           namespace,
           uidAttribute,
           messageOrdering,
-          encoders: routes.map(({ stream, encoderKind }) => [stream, encoderKind]),
+          encoders: [
+            ...routes.map(({ stream, encoderKind }) => [`cdc:${stream}`, encoderKind] as [string, EncoderKind]),
+            ...signals.map(({ stream }) => [`signal:${stream}`, 'signal'] as [string, EncoderKind]),
+          ],
         })
         await run()
       } finally {
@@ -253,14 +352,14 @@ export function pubsubTarget<T>(options: PubsubTargetOptions<T>) {
           publisher = new GooglePubsubPublisher(client, publisherOptions)
         }
 
-        await publisher.setup([...new Set(routes.map((r) => r.topic))], logger)
+        await publisher.setup([...new Set(allRoutes.map((r) => r.topic))], logger)
 
         logger.info({
           message:
-            `publishing ${routes.length} route(s) to PubSub — message ordering ${messageOrdering ? 'enabled' : 'disabled'}, ` +
+            `publishing ${allRoutes.length} route(s) to PubSub — message ordering ${messageOrdering ? 'enabled' : 'disabled'}, ` +
             `namespace "${namespace}", ` +
             `state "${'path' in options.state ? options.state.path : 'custom'}"`,
-          topics: routes.map((r) => `${r.stream} → ${r.topic} (${r.mode})`),
+          topics: allRoutes.map((r) => `${r.kind}:${r.stream} → ${r.topic}${r.kind === 'cdc' ? ` (${r.mode})` : ''}`),
         })
 
         if (coldStart) {
@@ -284,7 +383,7 @@ export function pubsubTarget<T>(options: PubsubTargetOptions<T>) {
         context = new WriteContext({
           state,
           publisher,
-          routes,
+          routes: allRoutes,
           namespace,
           messageOrdering,
           logger,
@@ -317,7 +416,7 @@ export function pubsubTarget<T>(options: PubsubTargetOptions<T>) {
         ])
       }
 
-      const safe = await state.fork(canonicalBlocks)
+      const safe = await state.fork(canonicalBlocks, (fork) => context?.forkSignals(fork) ?? [])
 
       // Compensations go out before anything later on their partitions, and before the source
       // re-streams the canonical blocks.
@@ -331,7 +430,7 @@ export function pubsubTarget<T>(options: PubsubTargetOptions<T>) {
 type WriteContextOptions = {
   state: PubsubState
   publisher: Publisher
-  routes: ResolvedRoute[]
+  routes: AnyResolvedRoute[]
   namespace: string
   messageOrdering: boolean
   logger: Logger
@@ -344,7 +443,9 @@ type WriteContextOptions = {
 
 class WriteContext {
   readonly #options: WriteContextOptions
-  readonly #routesByStream: Map<string, ResolvedRoute>
+  readonly #routesByIdentity: Map<string, AnyResolvedRoute>
+  readonly #cdcRoutes: ResolvedRoute[]
+  readonly #signalRoutes: ResolvedSignalRoute[]
   #metrics?: PubsubMetrics
   #goLive?: number
   #batches = 0
@@ -355,7 +456,9 @@ class WriteContext {
 
   constructor(options: WriteContextOptions) {
     this.#options = options
-    this.#routesByStream = new Map(options.routes.map((route) => [route.stream, route]))
+    this.#routesByIdentity = new Map(options.routes.map((route) => [`${route.kind}:${route.stream}`, route]))
+    this.#cdcRoutes = options.routes.filter((route): route is ResolvedRoute => route.kind === 'cdc')
+    this.#signalRoutes = options.routes.filter((route): route is ResolvedSignalRoute => route.kind === 'signal')
   }
 
   async write({ data, ctx }: { data: any; ctx: BatchContext }): Promise<void> {
@@ -395,7 +498,15 @@ class WriteContext {
       )
 
       for (const operation of operations) {
-        this.#metrics.ops.inc({ id: ctx.id, topic: operation.topic, op: operation.op }, 1)
+        this.#metrics.ops.inc(
+          {
+            id: ctx.id,
+            topic: operation.topic,
+            kind: operation.kind,
+            operation: operation.kind === 'cdc' ? operation.op : operation.signalType,
+          },
+          1,
+        )
       }
 
       let publishAckAt: number | undefined
@@ -436,8 +547,17 @@ class WriteContext {
     const wire = rows.map((row) => this.#wireMessage(row, { namespace, uidAttribute }))
 
     if (fork) {
-      this.#metrics?.compensations.observe(rows.length)
-      logger.info(`publishing ${rows.length} compensating operation(s) after a fork`)
+      // A signal never compensates anything, so it is not fork blast radius and must not land in
+      // this histogram. The CDC remainder can still include rows a failed pre-fork publish left
+      // queued — the outbox does not mark compensations, so this stays an upper bound.
+      const compensations = rows.filter((row) => row.kind === 'cdc').length
+      const signals = rows.length - compensations
+
+      this.#metrics?.compensations.observe(compensations)
+      logger.info(
+        `publishing ${compensations} compensating operation(s) after a fork` +
+          (signals ? ` and ${signals} boundary signal(s)` : ''),
+      )
     }
 
     const startedAt = Date.now()
@@ -561,13 +681,19 @@ class WriteContext {
    * Both histograms measure the same interval from two different anchors, so they are observed
    * together or not at all. `drain()` flushes whatever the outbox holds, which on a restart or a
    * fork is more than this batch — the readings are batch-level, not a per-row ack.
+   *
+   * Observed on every batch above go-live, including one whose routes mapped nothing. These
+   * measure how current the destination is, and a route that legitimately publishes nothing for
+   * a stretch is still current; gating on a non-empty drain would make a sparse feed's freshness
+   * series go silent and read as a dead pipe. `publish_duration` is the publish-attempt metric.
    */
   #observeCommitLag(ctx: BatchContext, publishAckAtMs: number): void {
     if (!this.#metrics) return
 
-    // Below go-live `#map` drops every draft and nothing is published, so a reading here would
-    // describe a stage that never ran — and a cold-start backfill would push years of chain
-    // distance into a `_sum` that never decays.
+    // Below go-live `#map` drops every draft and nothing is ever published, so a reading here
+    // would describe a stage that never runs at all. This is not a general backfill guard: an
+    // explicit historic `publishFrom` does publish, and its readings then carry the chain
+    // distance the pipe is genuinely behind by.
     if (ctx.stream.state.current.number < (this.#goLive ?? 0)) return
 
     const publishAckAt = publishAckAtMs / 1000
@@ -600,12 +726,12 @@ class WriteContext {
     )
   }
 
-  #map(data: any, ctx: BatchContext): PendingOperation[] {
+  async #map(data: any, ctx: BatchContext): Promise<PendingOperation[]> {
     const operations: PendingOperation[] = []
     const finalizedNumber = ctx.stream.head.finalized?.number
     const goLive = this.#goLive ?? 0
 
-    for (const resolved of this.#options.routes) {
+    for (const resolved of this.#cdcRoutes) {
       const streamData = data?.[resolved.stream]
       if (streamData === undefined) continue
 
@@ -643,7 +769,124 @@ class WriteContext {
       }
     }
 
+    // Read once per batch, and only when a route can use it: the fork counter lives in the same
+    // state file every commit already touches.
+    const epoch = this.#signalRoutes.length ? await this.#forkEpoch() : 0
+
+    for (const resolved of this.#signalRoutes) {
+      const streamData = data?.[resolved.stream]
+      if (streamData === undefined) continue
+
+      for (const draft of resolved.route.map({ data: streamData, ctx, epoch })) {
+        this.#assertSignalDraftBlock(draft, resolved)
+
+        if (draft.block.number < goLive) continue
+
+        this.#assertSignalFinality(draft, resolved, finalizedNumber)
+
+        operations.push(this.#toSignalOperation({ draft, resolved, signalType: 'data' }))
+      }
+    }
+
     return operations
+  }
+
+  async #forkEpoch(): Promise<number> {
+    return Number((await this.#options.state.getMeta(META_FORK_EPOCH)) ?? '0')
+  }
+
+  /**
+   * One boundary message per `boundary` route, built inside the fork transaction so it shares the
+   * epoch the fork is about to persist. A `finalized-only` route publishes nothing a fork can
+   * orphan, so it needs no boundary.
+   */
+  forkSignals(context: SignalForkContext): PendingSignalOperation[] {
+    return this.#signalRoutes.flatMap((resolved) => {
+      if (resolved.route.fork.mode !== 'boundary') return []
+
+      const draft = resolved.route.fork.map(context)
+
+      // A dead-end fork rewinds below every recorded block, so there is no cursor to attribute
+      // the boundary to. Block 0 is the honest floor — `deadEnd` in the payload carries the rest.
+      const block = context.rollbackTo ?? { number: 0 }
+
+      return [this.#toSignalOperation({ draft: { ...draft, block }, resolved, signalType: 'fork' })]
+    })
+  }
+
+  #assertSignalDraftBlock(draft: SignalDraft, resolved: ResolvedSignalRoute): void {
+    if (draft.block && Number.isInteger(draft.block.number) && draft.block.number >= 0) return
+
+    throw new PubsubTargetError(
+      PUBSUB_ERROR_CODES.INVALID_SIGNAL_BLOCK,
+      `Signal route "${resolved.stream}" produced a draft without a usable block.number.`,
+    )
+  }
+
+  /**
+   * A `finalized-only` route trades the boundary message for a promise that it never publishes
+   * anything a fork could orphan. Broken here, the message would already be unretractable on the
+   * wire, so it is refused before the batch commits.
+   */
+  #assertSignalFinality(draft: SignalDraft, resolved: ResolvedSignalRoute, finalizedNumber?: number): void {
+    if (resolved.route.fork.mode !== 'finalized-only') return
+    if (this.#options.finalizedStream) return
+    if (draft.block.number <= (finalizedNumber ?? -1)) return
+
+    throw new PubsubTargetError(PUBSUB_ERROR_CODES.SIGNAL_NOT_FINALIZED, [
+      `Signal route "${resolved.stream}" mapped block ${formatBlock(draft.block.number)}, above the ` +
+        `finalized head ${finalizedNumber === undefined ? '(none reported)' : formatBlock(finalizedNumber)}, ` +
+        'while declaring `fork.mode: "finalized-only"`.',
+      'Read the finalized stream, hold the signal until its block finalizes, or switch the route to ' +
+        '`fork.mode: "boundary"` and publish a compensating boundary message on a fork.',
+    ])
+  }
+
+  #toSignalOperation({
+    draft,
+    resolved,
+    signalType,
+  }: {
+    draft: SignalDraft
+    resolved: ResolvedSignalRoute
+    signalType: 'data' | 'fork'
+  }): PendingSignalOperation {
+    const { messageOrdering, namespace, uidAttribute } = this.#options
+    const where = { topic: resolved.topic, route: resolved.stream }
+
+    if (draft.orderingKey !== undefined && !messageOrdering) {
+      throw new PubsubTargetError(
+        PUBSUB_ERROR_CODES.ORDERING_KEY_NOT_SUPPORTED,
+        `Signal route "${resolved.stream}" set an ordering key while message ordering is disabled.`,
+      )
+    }
+
+    const orderingKey = messageOrdering ? (draft.orderingKey ?? resolved.topic) : ''
+    const attributes = draft.attributes ?? {}
+
+    validateUserAttributes(attributes, { ...where, protocolAttributes: uidAttribute ? 1 : 0 })
+    assertWireLimits({ orderingKey, uidNamespace: uidAttribute ? namespace : undefined }, where)
+
+    const operation: PendingSignalOperation = {
+      kind: 'signal',
+      route: resolved.stream,
+      topic: resolved.topic,
+      orderingKey,
+      attributes,
+      payload: new TextEncoder().encode(canonicalJson(draft.data)),
+      blockNumber: draft.block.number,
+      signalType,
+    }
+
+    // Sized at the worst case the row can reach once the state assigns it a sequence: PubSub
+    // rejects an oversized request at publish time, by which point the operation is durable.
+    const wire = this.#wireSignalMessage(
+      { ...operation, rowId: 0, seq: MAX_SEQUENCE_VALUE },
+      { namespace, uidAttribute },
+    )
+    assertPublishRequestSize({ ...wire, payloadBytes: wire.payload.byteLength }, { route: resolved.stream })
+
+    return operation
   }
 
   #assertDraftBlock(draft: MessageDraft, resolved: ResolvedRoute): void {
@@ -667,7 +910,7 @@ class WriteContext {
     index: number
     finalizedNumber?: number
     ctx: BatchContext
-  }): PendingOperation {
+  }): PendingCdcOperation {
     const { namespace, messageOrdering, uidAttribute } = this.#options
     const op: PubsubOp = draft.op ?? 'upsert'
 
@@ -709,6 +952,7 @@ class WriteContext {
         : undefined
 
     const operation: PendingOperation = {
+      kind: 'cdc',
       route: resolved.stream,
       topic: resolved.topic,
       orderingKey,
@@ -805,7 +1049,7 @@ class WriteContext {
   }: {
     draft: MessageDraft & { id: string }
     resolved: ResolvedRoute
-  }): PendingOperation['inverse'] {
+  }): PendingCdcOperation['inverse'] {
     const inverse = resolved.route.rollbackWhenMissing!(draft)
 
     if (inverse.op === 'delete') {
@@ -816,7 +1060,7 @@ class WriteContext {
   }
 
   #wireMessage(row: OutboxRow, options: { namespace: string; uidAttribute: boolean }) {
-    const route = this.#routesByStream.get(row.route)
+    const route = this.#routesByIdentity.get(`${row.kind}:${row.route}`)
     if (!route) {
       throw new PubsubTargetError(PUBSUB_ERROR_CODES.ROUTE_NOT_CONFIGURED, [
         `The durable PubSub outbox contains an operation for route "${row.route}", but that route is not configured.`,
@@ -824,13 +1068,20 @@ class WriteContext {
       ])
     }
 
-    const wire = this.#wireMessageWithEncoder(row, route.route.encode, options)
+    const wire =
+      row.kind === 'signal'
+        ? this.#wireSignalMessage(row, options)
+        : this.#wireMessageWithEncoder(
+            row as OutboxRow & { op: PubsubOp; id: string },
+            (route as ResolvedRoute).route.encode,
+            options,
+          )
     assertPublishRequestSize({ ...wire, payloadBytes: wire.payload.byteLength }, { route: route.stream })
 
     return wire
   }
 
-  #assertOperationSize(operation: PendingOperation, encode: CdcEncoder | undefined, route: string): void {
+  #assertOperationSize(operation: PendingCdcOperation, encode: CdcEncoder | undefined, route: string): void {
     const preview = { ...operation, rowId: 0, seq: MAX_SEQUENCE_VALUE }
     const options = {
       namespace: this.#options.namespace,
@@ -848,7 +1099,7 @@ class WriteContext {
   }
 
   #wireMessageWithEncoder(
-    row: OutboxRow,
+    row: OutboxRow & { op: PubsubOp; id: string },
     encode: CdcEncoder | undefined,
     options: { namespace: string; uidAttribute: boolean },
   ) {
@@ -857,6 +1108,30 @@ class WriteContext {
 
     return { rowId: row.rowId, topic: row.topic, orderingKey: row.orderingKey, attributes, payload }
   }
+
+  /**
+   * A signal's payload is final before it reaches the outbox, so this only attaches attributes.
+   * `buildAttributes` derives `_uid` from topic/orderingKey/seq alone; the `op` and `id` it takes
+   * are inert here and exist only to satisfy the shared CDC shape.
+   */
+  #wireSignalMessage(
+    row: Pick<OutboxRow, 'rowId' | 'topic' | 'orderingKey' | 'attributes' | 'payload' | 'seq'>,
+    options: { namespace: string; uidAttribute: boolean },
+  ) {
+    const attributes = buildAttributes({ ...row, op: 'upsert', id: '' }, options)
+
+    return { rowId: row.rowId, topic: row.topic, orderingKey: row.orderingKey, attributes, payload: row.payload }
+  }
+}
+
+/**
+ * Read a stored encoder key as a route identity. Schema 2 keyed these by bare stream name, before
+ * signal routes made a stream ambiguous; anything without a kind prefix is one of those and was a
+ * CDC route by construction. Decided from the stored key's own shape, so the reading does not
+ * shift with whatever the current configuration happens to contain.
+ */
+function routeIdentity(stream: string): string {
+  return stream.startsWith('cdc:') || stream.startsWith('signal:') ? stream : `cdc:${stream}`
 }
 
 async function bindWireConfig(
@@ -886,8 +1161,10 @@ async function bindWireConfig(
     previous[0] === config.namespace && previous[1] === config.uidAttribute && previous[2] === config.messageOrdering
 
   if (sameCore) {
-    const previousEncoders = new Map(previous[3] ?? [])
-    const pendingRoutes = new Set((await state.pending()).map((row) => row.route))
+    const previousEncoders = new Map((previous[3] ?? []).map(([stream, kind]) => [routeIdentity(stream), kind]))
+    // A route whose kind flipped, or that was dropped outright, has no entry here to compare
+    // against and falls through to E2423 when recovery tries to encode its rows.
+    const pendingRoutes = new Set((await state.pending()).map((row) => `${row.kind}:${row.route}`))
     const changedPendingRoute = encoders.find(
       ([stream, kind]) =>
         pendingRoutes.has(stream) && (!previousEncoders.has(stream) || previousEncoders.get(stream) !== kind),
@@ -915,7 +1192,7 @@ async function bindWireConfig(
 }
 
 type PubsubMetrics = {
-  ops: Counter<'id' | 'topic' | 'op'>
+  ops: Counter<'id' | 'topic' | 'kind' | 'operation'>
   publishedBytes: Counter<string>
   publishDuration: Histogram<string>
   outboxDepth: Gauge<'id'>
@@ -930,9 +1207,11 @@ type PubsubMetrics = {
 function registerPubsubMetrics(metrics: Metrics): PubsubMetrics {
   return {
     ops: metrics.counter({
-      name: 'sqd_pubsub_ops_total',
-      help: 'Wire operations enqueued for publishing, by topic and operation.',
-      labelNames: ['id', 'topic', 'op'] as const,
+      name: 'sqd_pubsub_operations_total',
+      help:
+        'Wire operations enqueued for publishing. `kind` separates CDC rows from signals; ' +
+        '`operation` is the CDC op (upsert/delete) or the signal type (data/fork).',
+      labelNames: ['id', 'topic', 'kind', 'operation'] as const,
     }),
     publishedBytes: metrics.counter({
       name: 'sqd_pubsub_published_bytes_total',


### PR DESCRIPTION
## Summary

- Add signal-only and mixed Pub/Sub routes with canonical application payloads.
- Persist signal operations and fork boundary messages in the existing durable outbox.
- Add signal route validation, state migration, and focused coverage.

## Coverage

| Module | Stmts | Δ | Branch | Δ |
|---|---:|---:|---:|---:|
| **All files** | 34.23% | +0.57 | 70.78% | +0.18 |

## Test plan

- [x] Pub/Sub state, target, fork, and signal suites (84 tests)
- [x] Focused coverage comparison against `feat/pubsub-commit-lag-metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)