### PR TITLE
fix(monitoring)!: measure RPC latency on both sides of the join

### DIFF
--- a/docs/examples/bitcoin/02.rpc-latency.example.ts
+++ b/docs/examples/bitcoin/02.rpc-latency.example.ts
@@ -15,6 +15,12 @@ import { bitcoinPortalStream, bitcoinRpcLatencyWatcher } from '@subsquid/pipes/b
  * and the watcher will emit `Authorization: Basic <...>` automatically (Node's
  * `fetch` does not honor URL credentials by itself).
  *
+ * A sample is emitted once both sides have reported the head, so `portalDelayMs` is
+ * signed: positive when the portal was later than the node, negative when it was first.
+ * If the node never reports the head within `resolveTimeoutMs` (default 60s), the row
+ * carries `unresolved` instead of a delay — `rpc-behind` when the node had not reached
+ * the head, `rpc-missing` when it is already past it (backfill, reorg, dropped update).
+ *
  * ⚠️ The reported latency includes client-side network RTT and does NOT capture
  * the node's internal block-validation time.
  */
@@ -33,11 +39,11 @@ async function main() {
   })
 
   for await (const { data } of stream) {
-    if (!data) continue
-
-    console.log(`-------------------------------------`)
-    console.log(`BLOCK DATA: ${formatBlock(data.number)} / ${data.timestamp.toString()}`)
-    console.table(data.rpc)
+    for (const sample of data) {
+      console.log(`-------------------------------------`)
+      console.log(`BLOCK DATA: ${formatBlock(sample.number)} / ${sample.timestamp.toString()}`)
+      console.table(sample.rpc)
+    }
   }
 
   /*
@@ -48,6 +54,7 @@ async function main() {
   │   │ url                                   │ receivedAt               │ portalDelayMs │
   ├───┼───────────────────────────────────────┼──────────────────────────┼───────────────┤
   │ 0 │ https://bitcoin-rpc.publicnode.com    │ 2025-01-06T08:34:56.812Z │ 1843          │
+  │ 1 │ https://another-bitcoin-rpc.example   │ 2025-01-06T08:35:00.021Z │ -1366         │
   └───┴───────────────────────────────────────┴──────────────────────────┴───────────────┘
   */
 }

--- a/docs/examples/evm/07.indexing-latency.example.ts
+++ b/docs/examples/evm/07.indexing-latency.example.ts
@@ -17,6 +17,10 @@ import { metricsServer } from '@subsquid/pipes/metrics/node'
 
  * In other words, the results represent end-to-end delays as experienced by the client,
  * not the pure Portal latency or RPC processing performance.
+ *
+ * Each sample is emitted once both sides have reported the head, so `portalDelayMs` is signed:
+ * positive when the portal was later than the RPC, negative when it was first. Rows for a head an
+ * endpoint never reported carry `unresolved` instead of a delay and are skipped here.
  */
 
 async function main() {
@@ -27,17 +31,20 @@ async function main() {
     outputs: evmRpcLatencyWatcher({
       rpcUrl: ['https://base.drpc.org', 'https://base-rpc.publicnode.com'], // RPC endpoints to monitor
     }).pipe((data, { metrics }) => {
-      if (!data) return // Skip if no latency data
+      const gauge = metrics.gauge({
+        name: 'rpc_latency_ms',
+        help: 'Portal delay against an RPC endpoint, in ms (negative: the portal delivered first)',
+        labelNames: ['url'],
+      })
 
-      // For each RPC endpoint, update the latency gauge metric
-      for (const rpc of data.rpc) {
-        metrics
-          .gauge({
-            name: 'rpc_latency_ms',
-            help: 'RPC Latency in ms',
-            labelNames: ['url'],
-          })
-          .set({ url: rpc.url }, data.rpc[0].portalDelayMs)
+      for (const sample of data) {
+        for (const rpc of sample.rpc) {
+          if (rpc.portalDelayMs === undefined) {
+            continue // The endpoint never reported this head — see `unresolved`
+          }
+
+          gauge.set({ url: rpc.url }, rpc.portalDelayMs)
+        }
       }
 
       return data
@@ -50,13 +57,13 @@ async function main() {
 
   // Iterate over the stream, logging block and RPC latency data
   for await (const { data } of stream) {
-    if (!data) continue // Skip if no block data
-
-    // Log block number and timestamp
-    console.log(`-------------------------------------`)
-    console.log(`BLOCK DATA: ${formatBlock(data.number)} / ${data.timestamp.toString()}`)
-    // Log RPC latency table for the block
-    console.table(data.rpc)
+    for (const sample of data) {
+      // Log block number and timestamp
+      console.log(`-------------------------------------`)
+      console.log(`BLOCK DATA: ${formatBlock(sample.number)} / ${sample.timestamp.toString()}`)
+      // Log RPC latency table for the block
+      console.table(sample.rpc)
+    }
   }
   /*
   Example output:

--- a/docs/examples/solana/07.indexing-latency.example.ts
+++ b/docs/examples/solana/07.indexing-latency.example.ts
@@ -16,6 +16,10 @@ import { solanaPortalStream, solanaRpcLatencyWatcher } from '@subsquid/pipes/sol
 
  * In other words, the results represent end-to-end delays as experienced by the client,
  * not the pure Portal latency or RPC processing performance.
+ *
+ * Each sample is emitted once both sides have reported the head, so `portalDelayMs` is signed:
+ * positive when the portal was later than the RPC, negative when it was first. Rows for a head an
+ * endpoint never reported carry `unresolved` instead of a delay and are skipped here.
  */
 
 async function main() {
@@ -28,17 +32,20 @@ async function main() {
     }).pipe({
       profiler: { name: 'expose metrics' },
       transform: (data, { metrics }) => {
-        if (!data) return // Skip if no latency data
+        const gauge = metrics.gauge({
+          name: 'rpc_latency_ms',
+          help: 'Portal delay against an RPC endpoint, in ms (negative: the portal delivered first)',
+          labelNames: ['url'],
+        })
 
-        // For each RPC endpoint, update the latency gauge metric
-        for (const rpc of data.rpc) {
-          metrics
-            .gauge({
-              name: 'rpc_latency_ms',
-              help: 'RPC Latency in ms',
-              labelNames: ['url'],
-            })
-            .set({ url: rpc.url }, data.rpc[0].portalDelayMs)
+        for (const sample of data) {
+          for (const rpc of sample.rpc) {
+            if (rpc.portalDelayMs === undefined) {
+              continue // The endpoint never reported this head — see `unresolved`
+            }
+
+            gauge.set({ url: rpc.url }, rpc.portalDelayMs)
+          }
         }
 
         return data
@@ -48,13 +55,13 @@ async function main() {
 
   // Iterate over the stream, logging block and RPC latency data
   for await (const { data } of stream) {
-    if (!data) continue // Skip if no block data
-
-    // Log block number and timestamp
-    console.log(`-------------------------------------`)
-    console.log(`BLOCK DATA: ${formatBlock(data.number)} / ${data.timestamp.toString()}`)
-    // Log RPC latency table for the block
-    console.table(data.rpc)
+    for (const sample of data) {
+      // Log block number and timestamp
+      console.log(`-------------------------------------`)
+      console.log(`BLOCK DATA: ${formatBlock(sample.number)} / ${sample.timestamp.toString()}`)
+      // Log RPC latency table for the block
+      console.table(sample.rpc)
+    }
 
     /**
     EXAMPLE OUTPUT:

--- a/packages/pipes/MIGRATION.md
+++ b/packages/pipes/MIGRATION.md
@@ -570,6 +570,50 @@ new feed. Reusing the old namespace or destination state can make new CDC change
 
 ---
 
+## 19. RPC latency watcher emits an array of two-sided samples
+
+`evmRpcLatencyWatcher` / `solanaRpcLatencyWatcher` / `bitcoinRpcLatencyWatcher` used to emit
+`LatencySample | null` at the moment the portal delivered a head, joining against whatever the
+reference RPC happened to hold *right then*. Heads the reference had not reported yet produced
+`null` and were dropped — which is precisely the case where the portal won. The delay distribution
+was therefore truncated at zero and its tail described the reference node, not the portal.
+
+Each head is now held until both sides have reported it (or the wait window closes), and every batch
+emits the samples that became decidable, so iterate the result:
+
+```ts
+// before
+for await (const { data } of stream) {
+  if (!data) continue
+  console.table(data.rpc)
+}
+
+// after
+for await (const { data } of stream) {
+  for (const sample of data) {
+    console.table(sample.rpc)
+  }
+}
+```
+
+`rpc[]` now carries one row per configured endpoint — including endpoints that did not report the
+head — and the rows changed shape:
+
+- **`portalDelayMs` is signed.** Negative means the portal delivered the head first. Histogram
+  buckets and any `max(0, …)` clamping downstream must be revisited, or portal leads will be folded
+  back into the zero bucket.
+- **`portalDelayMs` and `receivedAt` are absent when `unresolved` is set.** `rpc-behind` — the
+  endpoint had not reached the head before the window closed, so the portal is ahead by at least
+  that window; `rpc-missing` — the endpoint is already past the head but never recorded it (reorged
+  away, dropped update, or evicted while the portal was backfilling), which carries no latency
+  information at all. Count these, do not chart them, and never read a missing delay as zero.
+
+The window defaults to 60s and is configurable per watcher via `resolveTimeoutMs`. Samples surface
+one portal batch after they become decidable — the delay they carry is computed from recorded
+timestamps and is unaffected by that.
+
+---
+
 ## Quick checklist
 
 - [ ] `evmPortalSource` → `evmPortalStream`
@@ -601,4 +645,6 @@ new feed. Reusing the old namespace or destination state can make new CDC change
 - [ ] Prometheus dashboards: `sqd_current_block` → `sqd_processed_block`, `sqd_last_block` → `sqd_end_block`
 - [ ] Pub/Sub: migrate delivery configuration and consumers to BigQuery CDC rows; use fresh v2 state, a fresh namespace, and a re-bootstrapped destination
 - [ ] Pub/Sub destination tables: `Date` columns are now RFC 3339 `TIMESTAMP`, not `INT64` unix seconds
+- [ ] RPC latency watchers: output is now `LatencySample[]` — iterate it instead of null-checking a single sample
+- [ ] RPC latency consumers: `portalDelayMs` is signed (negative = portal first) and absent on `unresolved` rows; stop treating a missing delay as `0`
 - [ ] Upgrade `@subsquid/pipes-ui` together with the SDK

--- a/packages/pipes/src/bitcoin/bitcoin-rpc-latency-watcher.test.ts
+++ b/packages/pipes/src/bitcoin/bitcoin-rpc-latency-watcher.test.ts
@@ -108,7 +108,7 @@ describe('BitcoinRpcLatencyWatcher', () => {
       expect(call.auth).toBe(expected)
     }
 
-    // Critically: `lookup()` (and therefore the `Latency.rpc[].url` surfaced
+    // Critically: `lookup()` (and therefore the `LatencySample.rpc[].url` surfaced
     // to the pipeline / metrics / logs) must never echo back the credentials.
     const [entry] = watcher!.lookup(1)
     // URL is normalized through WHATWG `URL` (which appends a trailing slash);

--- a/packages/pipes/src/bitcoin/bitcoin-rpc-latency-watcher.ts
+++ b/packages/pipes/src/bitcoin/bitcoin-rpc-latency-watcher.ts
@@ -113,15 +113,19 @@ export function bitcoinRpcLatencyWatcher({
   rpcUrl,
   intervalMs = DEFAULT_INTERVAL_MS,
   requestTimeoutMs,
+  resolveTimeoutMs,
 }: {
   rpcUrl: string[]
   intervalMs?: number
   /** Per-RPC request timeout. Defaults to `max(1000, intervalMs)` so a stalled
    *  endpoint can never block the polling loop indefinitely. */
   requestTimeoutMs?: number
+  /** How long to wait for the node to report a head before recording it as `rpc-behind`. */
+  resolveTimeoutMs?: number
 }) {
   const transformer = rpcLatencyWatcher({
     watcher: new BitcoinRpcLatencyWatcher(rpcUrl, intervalMs, requestTimeoutMs),
+    resolveTimeoutMs,
   })
 
   return bitcoinQuery()

--- a/packages/pipes/src/evm/evm-rpc-latency-watcher.test.ts
+++ b/packages/pipes/src/evm/evm-rpc-latency-watcher.test.ts
@@ -86,8 +86,8 @@ describe('evmRpcLatencyWatcher subscription', () => {
       makeBatchContext(new Date('2026-05-09T00:00:10Z')),
     )
 
-    expect(result?.number).toBe(100)
-    expect(result?.rpc[0]).toMatchObject({ url: 'ws://rpc', hash: '0xabc' })
+    expect(result[0]?.number).toBe(100)
+    expect(result[0]?.rpc[0]).toMatchObject({ url: 'ws://rpc', hash: '0xabc' })
   })
 
   it('ignores a subscription frame with no head instead of crashing', async () => {
@@ -104,7 +104,7 @@ describe('evmRpcLatencyWatcher subscription', () => {
       [{ header: { number: 1, timestamp: 0 } }] as never,
       makeBatchContext(new Date()),
     )
-    expect(result).toBeNull()
+    expect(result[0]?.rpc).toEqual([{ url: 'ws://rpc', unresolved: 'rpc-missing' }])
   })
 
   it('closes the socket on stop', async () => {

--- a/packages/pipes/src/evm/evm-rpc-latency-watcher.ts
+++ b/packages/pipes/src/evm/evm-rpc-latency-watcher.ts
@@ -32,9 +32,10 @@ class EvmRpcLatencyWatcher extends RpcLatencyWatcher {
   }
 }
 
-export function evmRpcLatencyWatcher({ rpcUrl }: { rpcUrl: string[] }) {
+export function evmRpcLatencyWatcher({ rpcUrl, resolveTimeoutMs }: { rpcUrl: string[]; resolveTimeoutMs?: number }) {
   const transformer = rpcLatencyWatcher({
     watcher: new EvmRpcLatencyWatcher(rpcUrl),
+    resolveTimeoutMs,
   })
 
   return evmQuery()

--- a/packages/pipes/src/monitoring/rpc-latency/rpc-latency-watcher.test.ts
+++ b/packages/pipes/src/monitoring/rpc-latency/rpc-latency-watcher.test.ts
@@ -38,6 +38,10 @@ function makeBatchContext(receivedAt: Date): BatchContext {
   } as unknown as BatchContext
 }
 
+function header(number: number, timestamp = 0) {
+  return { header: { number, timestamp } }
+}
+
 describe('rpcLatencyWatcher transformer', () => {
   it('propagates the RPC-observed hash from lookup() into LatencySample.rpc[].hash', async () => {
     // Reorg-safe joining downstream (BigQuery freshness probe) requires the hash to flow
@@ -70,9 +74,9 @@ describe('rpcLatencyWatcher transformer', () => {
       makeBatchContext(portalReceivedAt),
     )
 
-    expect(result).not.toBeNull()
-    expect(result?.number).toBe(100)
-    expect(result?.rpc).toEqual([
+    expect(result).toHaveLength(1)
+    expect(result[0]?.number).toBe(100)
+    expect(result[0]?.rpc).toEqual([
       { url: 'ws://rpc-1', hash: '0xCANONICAL', receivedAt: rpc1ReceivedAt, portalDelayMs: 2000 },
       { url: 'ws://rpc-2', hash: '0xCANONICAL', receivedAt: rpc2ReceivedAt, portalDelayMs: 1000 },
     ])
@@ -97,18 +101,147 @@ describe('rpcLatencyWatcher transformer', () => {
       makeBatchContext(new Date('2026-05-09T00:00:02Z')),
     )
 
-    expect(result?.rpc[0]?.hash).toBeUndefined()
+    expect(result[0]?.rpc[0]?.hash).toBeUndefined()
   })
 
-  it('returns null when no RPC has seen the block (lookup empty)', async () => {
+  it('reports a negative delay for a head the portal delivered before the reference RPC', async () => {
+    // The bug this pins: the sample used to be taken at delivery time and dropped whenever the
+    // reference had not reported the head yet — i.e. exactly when the portal won. Every "portal
+    // is ahead" observation vanished, the distribution was truncated at zero, and its tail
+    // described the reference node's hiccups rather than portal freshness.
     const watcher = new StubWatcher(['ws://rpc'])
     watcher.start()
-    // No addBlock calls — lookup returns [].
+    watcher.addBlock('ws://rpc', { number: 99, timestamp: new Date(), receivedAt: new Date() })
 
     const transformer = rpcLatencyWatcher({ watcher })
-    const result = await transformer.run([{ header: { number: 999, timestamp: 0 } }], makeBatchContext(new Date()))
 
-    expect(result).toBeNull()
+    const portalReceivedAt = new Date()
+    const pendingBatch = await transformer.run([header(100)], makeBatchContext(portalReceivedAt))
+    expect(pendingBatch).toEqual([])
+
+    watcher.addBlock('ws://rpc', {
+      number: 100,
+      timestamp: new Date(),
+      receivedAt: new Date(portalReceivedAt.getTime() + 500),
+    })
+
+    const result = await transformer.run([header(101)], makeBatchContext(new Date()))
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.number).toBe(100)
+    expect(result[0]?.rpc[0]?.portalDelayMs).toBe(-500)
+  })
+
+  it('keeps the first portal receipt when a pending head is delivered again', async () => {
+    // Freshness is "when did the portal first have a block at this height"; a re-delivery must
+    // not re-stamp the sample (and must not push the resolve deadline out forever).
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.start()
+    watcher.addBlock('ws://rpc', { number: 99, timestamp: new Date(), receivedAt: new Date() })
+
+    const transformer = rpcLatencyWatcher({ watcher })
+
+    const firstReceipt = new Date()
+    await transformer.run([header(100)], makeBatchContext(firstReceipt))
+    await transformer.run([header(100)], makeBatchContext(new Date(firstReceipt.getTime() + 2_000)))
+
+    watcher.addBlock('ws://rpc', {
+      number: 100,
+      timestamp: new Date(),
+      receivedAt: new Date(firstReceipt.getTime() + 500),
+    })
+
+    const result = await transformer.run([header(101)], makeBatchContext(new Date()))
+
+    expect(result[0]?.rpc[0]?.portalDelayMs).toBe(-500)
+  })
+
+  it('closes a head as rpc-behind once the resolve window expires', async () => {
+    // A reference that is stuck below the head is a real, one-sided observation: the portal is
+    // ahead by at least the window. Emitting it without a delay keeps it out of the histogram
+    // while still making it countable.
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.start()
+    watcher.addBlock('ws://rpc', { number: 99, timestamp: new Date(), receivedAt: new Date() })
+
+    const transformer = rpcLatencyWatcher({ watcher, resolveTimeoutMs: 0 })
+    const result = await transformer.run([header(100)], makeBatchContext(new Date()))
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.rpc).toEqual([{ url: 'ws://rpc', unresolved: 'rpc-behind' }])
+  })
+
+  it('closes a head as rpc-missing when the reference is already past it', async () => {
+    // Backfill: the portal replays old blocks the reference observed long ago and has since
+    // evicted. Waiting for them would time out as `rpc-behind` and fake a portal lead.
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.start()
+    watcher.addBlock('ws://rpc', { number: 100_000, timestamp: new Date(), receivedAt: new Date() })
+
+    const transformer = rpcLatencyWatcher({ watcher })
+    const result = await transformer.run([header(100)], makeBatchContext(new Date()))
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.rpc).toEqual([{ url: 'ws://rpc', unresolved: 'rpc-missing' }])
+  })
+
+  it('reports rpc-missing for a node that has observed nothing at all', async () => {
+    // A silent reference proves nothing about the portal — it must not read as a portal lead.
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.start()
+
+    const transformer = rpcLatencyWatcher({ watcher })
+    const result = await transformer.run([header(999)], makeBatchContext(new Date()))
+
+    expect(result[0]?.rpc).toEqual([{ url: 'ws://rpc', unresolved: 'rpc-missing' }])
+  })
+
+  it('does not let a head the reference skipped block later ones', async () => {
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.start()
+    watcher.addBlock('ws://rpc', { number: 99, timestamp: new Date(), receivedAt: new Date() })
+
+    const transformer = rpcLatencyWatcher({ watcher })
+    await transformer.run([header(100)], makeBatchContext(new Date()))
+
+    // The reference jumps straight to 101 — 100 will never arrive.
+    const rpcReceivedAt = new Date()
+    watcher.addBlock('ws://rpc', { number: 101, timestamp: new Date(), receivedAt: rpcReceivedAt })
+
+    const result = await transformer.run([header(101)], makeBatchContext(new Date(rpcReceivedAt.getTime() + 300)))
+
+    expect(result.map((s) => [s.number, s.rpc[0]?.unresolved])).toEqual([
+      [100, 'rpc-missing'],
+      [101, undefined],
+    ])
+    expect(result[1]?.rpc[0]?.portalDelayMs).toBe(300)
+  })
+
+  it('drops pending heads above a rollback cursor', async () => {
+    // Heads on the abandoned fork would sit out the resolve window and surface as `rpc-behind`,
+    // i.e. a portal lead that never happened.
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.start()
+    watcher.addBlock('ws://rpc', { number: 99, timestamp: new Date(), receivedAt: new Date() })
+
+    const transformer = rpcLatencyWatcher({ watcher })
+    await transformer.run([header(100)], makeBatchContext(new Date()))
+
+    await transformer.rollback({ number: 99 }, {} as never)
+
+    watcher.addBlock('ws://rpc', { number: 100, timestamp: new Date(), receivedAt: new Date() })
+    const result = await transformer.run([header(101)], makeBatchContext(new Date()))
+
+    expect(result).toEqual([])
+  })
+
+  it('emits nothing while the watcher has no endpoints', async () => {
+    const watcher = new StubWatcher([])
+
+    const transformer = rpcLatencyWatcher({ watcher })
+    const result = await transformer.run([header(1)], makeBatchContext(new Date()))
+
+    expect(result).toEqual([])
   })
 })
 
@@ -181,5 +314,29 @@ describe('RpcLatencyWatcher lifecycle', () => {
     expect(watcher.lookup(88)).toEqual([])
     expect(watcher.lookup(89)).toHaveLength(1)
     expect(watcher.lookup(600)).toHaveLength(1)
+  })
+
+  it('tracks the highest head seen, so an evicted one is not mistaken for a pending one', () => {
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.start()
+
+    for (let i = 1; i <= 600; i++) {
+      watcher.addBlock('ws://rpc', { number: i, timestamp: new Date(), receivedAt: new Date() })
+    }
+
+    expect(watcher.mayObserve('ws://rpc', 88)).toBe(false)
+    expect(watcher.mayObserve('ws://rpc', 601)).toBe(true)
+  })
+
+  it('keeps the high-water mark when an older head arrives late', () => {
+    // A reorg can replay a lower head. Letting it lower the mark would make every head above it
+    // look pending again, and evicted ones would sit out the resolve window as `rpc-behind`.
+    const watcher = new StubWatcher(['ws://rpc'])
+    watcher.start()
+
+    watcher.addBlock('ws://rpc', { number: 200, timestamp: new Date(), receivedAt: new Date() })
+    watcher.addBlock('ws://rpc', { number: 199, timestamp: new Date(), receivedAt: new Date() })
+
+    expect(watcher.mayObserve('ws://rpc', 200)).toBe(false)
   })
 })

--- a/packages/pipes/src/monitoring/rpc-latency/rpc-latency-watcher.ts
+++ b/packages/pipes/src/monitoring/rpc-latency/rpc-latency-watcher.ts
@@ -9,6 +9,13 @@ type RpcHead = { number: number; hash?: string; timestamp: Date; receivedAt: Dat
 /** Lookups only move forward, so older heads are dead weight. */
 const MAX_HEADS_PER_NODE = 512
 
+/**
+ * How long a head the reference RPC has not reported yet is held before it is closed as
+ * `rpc-behind`. This is the horizon of the measurement: a portal lead longer than the window
+ * is reported as "ahead by at least this much" instead of an exact figure.
+ */
+const DEFAULT_RESOLVE_TIMEOUT_MS = 60_000
+
 export interface RpcLatencyListener {
   stop(): void
 }
@@ -16,6 +23,7 @@ export interface RpcLatencyListener {
 export abstract class RpcLatencyWatcher {
   nodes: Map<string, Map<number, RpcHead>> = new Map()
   watchers: RpcLatencyListener[] = []
+  #highest: Map<string, number> = new Map()
   #running = false
 
   constructor(protected rpcUrl: string | string[]) {
@@ -73,11 +81,27 @@ export abstract class RpcLatencyWatcher {
     return res
   }
 
+  /**
+   * Whether `number` can still arrive from this node. A node already past that head — or one
+   * that has reported nothing at all — never will, so a sample waiting on it is closed at once
+   * rather than sitting out the whole resolve window.
+   */
+  mayObserve(url: string, number: number) {
+    const highest = this.#highest.get(url)
+
+    return highest !== undefined && highest < number
+  }
+
   addBlock(url: string, block: RpcHead) {
     const chain = this.nodes.get(url)
     if (!chain) throw new Error('RPC not found')
 
     chain.set(block.number, block)
+
+    const highest = this.#highest.get(url)
+    if (highest === undefined || block.number > highest) {
+      this.#highest.set(url, block.number)
+    }
 
     // Insertion order is ascending, so the first key is the oldest. Evicting here
     // rather than on portal batches holds the bound while the portal side is stalled.
@@ -92,56 +116,152 @@ export abstract class RpcLatencyWatcher {
   abstract watch(url: string): RpcLatencyListener
 }
 
-type Latency = {
+export type RpcObservation = {
+  url: string
+  /** Block hash as observed by this RPC. Omitted on Solana (no hash on slot updates). */
+  hash?: string
+  receivedAt?: Date
+  /**
+   * Signed `portal.receivedAt - rpc.receivedAt`. **Negative means the portal delivered the head
+   * first.** Absent whenever `unresolved` is set — treating a missing value as zero would fold
+   * the two censored cases back into the distribution.
+   */
+  portalDelayMs?: number
+  /**
+   * Set when no delay could be computed:
+   * - `rpc-behind` — the RPC had not reached this head before the resolve window closed, so the
+   *   portal is ahead by at least that window. A real, one-sided latency observation.
+   * - `rpc-missing` — the RPC is past this head but never recorded it: reorged away, a dropped
+   *   notification, a head evicted while the portal was backfilling, or a node that never
+   *   reported anything. Carries no latency information; count it, don't chart it.
+   */
+  unresolved?: 'rpc-behind' | 'rpc-missing'
+}
+
+export type LatencySample = {
   number: number
   timestamp: Date
   portal: {
     receivedAt: Date
   }
-  rpc: {
-    url: string
-    /** Block hash as observed by this RPC. Omitted on Solana (no hash on slot updates). */
-    hash?: string
-    portalDelayMs: number
-    receivedAt?: Date
-  }[]
+  rpc: RpcObservation[]
 }
 
-export function rpcLatencyWatcher({ watcher }: { watcher: RpcLatencyWatcher }) {
+type PendingHead = {
+  number: number
+  timestamp: Date
+  portalReceivedAt: Date
+}
+
+export function rpcLatencyWatcher({
+  watcher,
+  resolveTimeoutMs = DEFAULT_RESOLVE_TIMEOUT_MS,
+}: {
+  watcher: RpcLatencyWatcher
+  /** How long to wait for a reference RPC to report a head before recording it as `rpc-behind`. */
+  resolveTimeoutMs?: number
+}) {
+  /**
+   * Portal-side heads still waiting on the reference RPCs.
+   *
+   * Sampling only what the RPCs happened to hold at delivery time silently dropped every head
+   * the portal won, so the delay distribution was truncated at zero and its tail described the
+   * reference node rather than the portal. Buffering both sides and emitting once the join can
+   * be decided keeps those samples — with a negative delay.
+   */
+  const pending = new Map<number, PendingHead>()
+
+  function resolve(head: PendingHead, now: number): LatencySample | undefined {
+    const observed = new Map(watcher.lookup(head.number).map((r) => [r.url, r]))
+    const expired = now - head.portalReceivedAt.getTime() >= resolveTimeoutMs
+
+    const rpc: RpcObservation[] = []
+
+    for (const url of watcher.nodes.keys()) {
+      const hit = observed.get(url)
+
+      if (hit) {
+        rpc.push({
+          url,
+          hash: hit.hash,
+          receivedAt: hit.receivedAt,
+          portalDelayMs: head.portalReceivedAt.getTime() - hit.receivedAt.getTime(),
+        })
+      } else if (!watcher.mayObserve(url, head.number)) {
+        rpc.push({ url, unresolved: 'rpc-missing' })
+      } else if (expired) {
+        rpc.push({ url, unresolved: 'rpc-behind' })
+      } else {
+        return
+      }
+    }
+
+    return {
+      number: head.number,
+      timestamp: head.timestamp,
+      portal: { receivedAt: head.portalReceivedAt },
+      rpc,
+    }
+  }
+
   return createTransformer<
     {
       header: { number: number; timestamp: number }
     }[],
-    Latency | null
+    LatencySample[]
   >({
     profiler: { name: 'rpc latency' },
     start() {
       watcher.start()
     },
-    transform: (data, ctx): Latency | null => {
-      const receivedAt = ctx.batch.lastBlockReceivedAt
+    transform: (data, ctx): LatencySample[] => {
+      // Never started, or configured with no endpoints: every sample would be an empty join.
+      if (watcher.nodes.size === 0) {
+        return []
+      }
 
       const block = last(data)
-      if (!block) return null
 
-      const lookup = watcher.lookup(block.header.number)
-      if (lookup.length === 0) return null
+      // `lastBlockReceivedAt` timestamps the batch's last block, so that is the only head this
+      // batch can measure. A queued head keeps its first receipt — re-stamping would move the
+      // freshness reading and push the resolve deadline out indefinitely.
+      if (block && !pending.has(block.header.number)) {
+        pending.set(block.header.number, {
+          number: block.header.number,
+          timestamp: new Date(block.header.timestamp * 1000),
+          portalReceivedAt: ctx.batch.lastBlockReceivedAt,
+        })
+      }
 
-      return {
-        number: block.header.number,
-        timestamp: new Date(block.header.timestamp * 1000),
-        portal: { receivedAt },
-        rpc: lookup.map((r) => {
-          return {
-            url: r.url,
-            hash: r.hash,
-            receivedAt: r.receivedAt,
-            portalDelayMs: receivedAt.getTime() - r.receivedAt.getTime(),
-          }
-        }),
+      // Flush is batch-driven — the transformer has no way to emit out of band — so a sample
+      // surfaces one portal batch after it becomes decidable. The delay it carries is computed
+      // from stored timestamps and is unaffected.
+      const now = Date.now()
+      const resolved: LatencySample[] = []
+
+      for (const [number, head] of pending) {
+        const sample = resolve(head, now)
+        if (!sample) {
+          continue
+        }
+
+        pending.delete(number)
+        resolved.push(sample)
+      }
+
+      return resolved
+    },
+    rollback: (cursor) => {
+      // Heads above the fork point are gone; waiting on them would time out as `rpc-behind`
+      // and read as a portal lead that never happened.
+      for (const number of pending.keys()) {
+        if (number > cursor.number) {
+          pending.delete(number)
+        }
       }
     },
     stop() {
+      pending.clear()
       watcher.stop()
     },
   })

--- a/packages/pipes/src/solana/solana-rpc-latency-watcher.test.ts
+++ b/packages/pipes/src/solana/solana-rpc-latency-watcher.test.ts
@@ -86,9 +86,9 @@ describe('solanaRpcLatencyWatcher subscription', () => {
       makeBatchContext(new Date('2026-05-09T00:00:01Z')),
     )
 
-    expect(result?.number).toBe(500)
-    expect(result?.rpc[0]?.url).toBe('ws://rpc')
-    expect(result?.rpc[0]?.hash).toBeUndefined()
+    expect(result[0]?.number).toBe(500)
+    expect(result[0]?.rpc[0]?.url).toBe('ws://rpc')
+    expect(result[0]?.rpc[0]?.hash).toBeUndefined()
   })
 
   it('ignores slot updates that have not reached optimisticConfirmation', async () => {
@@ -103,6 +103,6 @@ describe('solanaRpcLatencyWatcher subscription', () => {
       [{ header: { number: 501, timestamp: 0 } }] as never,
       makeBatchContext(new Date()),
     )
-    expect(result).toBeNull()
+    expect(result[0]?.rpc).toEqual([{ url: 'ws://rpc', unresolved: 'rpc-missing' }])
   })
 })

--- a/packages/pipes/src/solana/solana-rpc-latency-watcher.ts
+++ b/packages/pipes/src/solana/solana-rpc-latency-watcher.ts
@@ -67,9 +67,10 @@ class SolanaRpcLatencyWatcher extends RpcLatencyWatcher {
   }
 }
 
-export function solanaRpcLatencyWatcher({ rpcUrl }: { rpcUrl: string[] }) {
+export function solanaRpcLatencyWatcher({ rpcUrl, resolveTimeoutMs }: { rpcUrl: string[]; resolveTimeoutMs?: number }) {
   const transformer = rpcLatencyWatcher({
     watcher: new SolanaRpcLatencyWatcher(rpcUrl),
+    resolveTimeoutMs,
   })
 
   return solanaQuery()


### PR DESCRIPTION
## Summary

- **The sample was censored, so the metric could only ever blame the reference.** The join ran once, at the moment the portal delivered a head, against whatever the reference RPC happened to hold *right then*. A head the reference had not reported yet produced an empty `lookup()` and returned `null` — the sample was dropped. That is exactly the case where the portal won, so `portalDelayMs` was non-negative by construction, the delay distribution was truncated at zero, and its tail described the reference node's hiccups rather than portal freshness. The per-endpoint series were censored the same way: with several RPCs configured, only those already holding the head appeared in `rpc[]`, so an endpoint that is usually slower than the portal was systematically under-represented in its own series.
- **Both sides are buffered now.** The portal side gets a pending queue to match the RPC side's head buffer, and a head is emitted once the join can be *decided* — either every configured endpoint has reported it, or the wait window closed. `portalDelayMs` is consequently **signed**: negative means the portal delivered the head first. `rpc[]` carries one row per configured endpoint, always, including endpoints that never reported the head.
- **A head the reference never reported is emitted, not dropped — and the two reasons are kept apart.** `rpc-behind` means the endpoint had not reached the head before the window closed, so the portal is ahead by at least that window: a real one-sided observation. `rpc-missing` means the endpoint is already past the head but never recorded it — reorged away, a dropped notification, a head evicted while the portal was backfilling, or an endpoint that reported nothing at all — which carries no latency information. Collapsing these two would have swapped one bias for another: every backfilled block and every reorg would have read as a portal lead. The split rides on a new high-water mark per endpoint (`RpcLatencyWatcher.mayObserve`), which also lets a head the reference skipped resolve immediately instead of wedging the queue for the whole window.
- **Fork handling.** The `rollback` hook drops pending heads above the fork point. Without it they would sit out the window and surface as `rpc-behind` — a portal lead that never happened.
- **A re-delivered head keeps its first portal receipt.** Freshness is when the portal first had a block at that height; re-stamping would also push the resolve deadline out indefinitely.

The wait window defaults to 60s and is configurable per watcher via `resolveTimeoutMs` (threaded through the EVM, Solana and Bitcoin factories). Flushing is batch-driven — the transformer has no way to emit out of band — so a sample surfaces one portal batch after it becomes decidable; the delay it carries is computed from recorded timestamps and is unaffected. In the common case, where the reference is faster, the join still resolves within the same batch as before.

### Breaking changes

| | |
| --- | --- |
| Output shape | `LatencySample \| null` → `LatencySample[]`. Several heads can become decidable in one batch, and emitting at most one would have reintroduced the loss. Iterate the result instead of null-checking it |
| `portalDelayMs` | Signed. Downstream histogram buckets and any `max(0, …)` clamping must be revisited, or portal leads fold back into the zero bucket and the censoring returns one layer up |
| `portalDelayMs` / `receivedAt` | Absent whenever `unresolved` is set. **A missing delay is not zero** — count `rpc-behind` and `rpc-missing` as their own series, do not chart them |
| Exports | `LatencySample` and `RpcObservation` are now public types |

Documented as section 19 of `packages/pipes/MIGRATION.md`, with the checklist entries.

All three shipped examples (`docs/examples/evm/07`, `docs/examples/solana/07`, `docs/examples/bitcoin/02`) now iterate the samples. Rewriting the EVM and Solana loops also surfaced a bug in the gauge they expose: it labelled every endpoint with `rpc[0]`'s delay. It now reports each endpoint's own, and skips heads an endpoint never observed instead of publishing a missing delay as zero — the same trap the `unresolved` split exists to keep consumers out of.

## Coverage

| Module | Stmts | Δ | Branch | Δ |
|--------|-------|---|--------|---|
| src/monitoring/rpc-latency/rpc-latency-watcher.ts | 100% | +0.0 | 95.8% | **+6.2** |
| src/evm/evm-rpc-latency-watcher.ts | 100% | +0.0 | 100% | +0.0 |
| src/solana/solana-rpc-latency-watcher.ts | 100% | +0.0 | 100% | +0.0 |
| src/bitcoin/bitcoin-rpc-latency-watcher.ts | 100% | +0.0 | 85.2% | +0.0 |

Base `main` @ 6a0fdfb vs head, same four touched modules and the same six test files on both sides: 53 passed on head, 44 on base. The two branches still uncovered in the watcher (`if (!chain) throw`, `if (oldest.done) break`) are pre-existing defensive guards. Full suite on head: 834 passed / 19 skipped, excluding the ClickHouse-, Postgres- and Drizzle-gated suites, which need services this machine does not run.

## Test plan

- [x] **The regression itself** — the portal delivers a head the reference has not reached: the first batch emits nothing, and once the reference reports it 500 ms later the sample surfaces with `portalDelayMs: -500`. Under the old code this head produced `null` and vanished.
- [x] **`rpc-behind`** — a reference stuck below the head is closed as `rpc-behind` with no delay once the window expires.
- [x] **`rpc-missing`** — a reference far past the head (backfill), and a reference that has reported nothing at all, both close immediately rather than waiting out the window and faking a portal lead.
- [x] **A skipped head does not wedge the queue** — the reference jumps 99 → 101; head 100 closes as `rpc-missing` in the same batch that resolves 101 with its real delay, and the two are emitted in ascending order.
- [x] **Fork** — pending heads above a rollback cursor are dropped and never resurface, even after the reference reports them.
- [x] **First receipt wins** — a head delivered twice before the reference catches up keeps the earlier portal timestamp.
- [x] **High-water mark** — a replayed older head does not lower it, so heads above it stay resolvable and evicted ones are not mistaken for pending.
- [x] **Unchanged behaviour still pinned** — hash propagation end-to-end, `hash: undefined` on Solana, the watcher lifecycle suite, and head eviction at the retention cap.
- [x] Per `CLAUDE.md`, every test uses the internal testing framework (`StubWatcher` over `RpcLatencyWatcher`, `mockWebSocket` / `MockWebSocket`, `mockBitcoinRpc`, `testLogger`) — no ad-hoc HTTP mocks.
