### PR TITLE
fix(monitoring): export LatencySample and RpcObservation from chain entrypoints

### DIFF
--- a/packages/pipes/src/bitcoin/bitcoin-rpc-latency-watcher.ts
+++ b/packages/pipes/src/bitcoin/bitcoin-rpc-latency-watcher.ts
@@ -2,6 +2,8 @@ import { PollingClient, RpcLatencyWatcher, rpcLatencyWatcher } from '~/monitorin
 
 import { bitcoinQuery } from './bitcoin-query-builder.js'
 
+export type { LatencySample, RpcObservation } from '~/monitoring/index.js'
+
 const DEFAULT_INTERVAL_MS = 4_000
 
 type BlockHeader = {

--- a/packages/pipes/src/bitcoin/index.ts
+++ b/packages/pipes/src/bitcoin/index.ts
@@ -1,3 +1,4 @@
 export * from './bitcoin-portal-source.js'
 export * from './bitcoin-query-builder.js'
+export type { LatencySample, RpcObservation } from './bitcoin-rpc-latency-watcher.js'
 export { bitcoinRpcLatencyWatcher } from './bitcoin-rpc-latency-watcher.js'

--- a/packages/pipes/src/evm/evm-rpc-latency-watcher.ts
+++ b/packages/pipes/src/evm/evm-rpc-latency-watcher.ts
@@ -1,6 +1,8 @@
 import { evmQuery } from '~/evm/evm-query-builder.js'
 import { RpcLatencyWatcher, WebSocketListener, rpcLatencyWatcher } from '~/monitoring/index.js'
 
+export type { LatencySample, RpcObservation } from '~/monitoring/index.js'
+
 class EvmRpcLatencyWatcher extends RpcLatencyWatcher {
   watch(url: string): WebSocketListener {
     const listener = new WebSocketListener(url)

--- a/packages/pipes/src/monitoring/rpc-latency/public-types.test.ts
+++ b/packages/pipes/src/monitoring/rpc-latency/public-types.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import type { RpcObservation as BitcoinObservation, LatencySample as BitcoinSample } from '~/bitcoin/index.js'
+import type { RpcObservation as EvmObservation, LatencySample as EvmSample } from '~/evm/index.js'
+import type { RpcObservation as SolanaObservation, LatencySample as SolanaSample } from '~/solana/index.js'
+
+import type { LatencySample, RpcObservation } from './rpc-latency-watcher.js'
+
+/**
+ * The watchers emit these types, so consumers must be able to name them from the same
+ * entrypoint they import the watcher from. `~/{chain}/index.js` is what the package's
+ * `./{chain}` export maps to — a type that stops resolving here stops resolving for them.
+ */
+describe('rpc latency public types', () => {
+  it('re-exports LatencySample and RpcObservation from every chain entrypoint', () => {
+    const sample: LatencySample = {
+      number: 1,
+      timestamp: new Date(),
+      portal: { receivedAt: new Date() },
+      rpc: [{ url: 'https://rpc.example', unresolved: 'rpc-behind' }],
+    }
+
+    const evm: EvmSample = sample
+    const solana: SolanaSample = sample
+    const bitcoin: BitcoinSample = sample
+
+    const observation: RpcObservation = sample.rpc[0]
+    const evmObservation: EvmObservation = observation
+    const solanaObservation: SolanaObservation = observation
+    const bitcoinObservation: BitcoinObservation = observation
+
+    expect([evm, solana, bitcoin]).toHaveLength(3)
+    expect([evmObservation, solanaObservation, bitcoinObservation]).toHaveLength(3)
+  })
+})

--- a/packages/pipes/src/solana/solana-rpc-latency-watcher.ts
+++ b/packages/pipes/src/solana/solana-rpc-latency-watcher.ts
@@ -1,6 +1,8 @@
 import { RpcLatencyWatcher, WebSocketListener, rpcLatencyWatcher } from '~/monitoring/index.js'
 import { solanaQuery } from '~/solana/solana-query-builder.js'
 
+export type { LatencySample, RpcObservation } from '~/monitoring/index.js'
+
 type Notification = {
   params?: {
     result?: {


### PR DESCRIPTION
## Problem

The 1.0.0-beta.6 release notes state that `LatencySample` and `RpcObservation` "are now exported", but they are not reachable from any published entrypoint. `src/evm/browser.ts`, `src/solana/index.ts` and `src/bitcoin/index.ts` only surface the watcher functions themselves, and the package exports map has no `./monitoring` subpath — so the types stay in `dist/monitoring/rpc-latency/` with no way to name them under NodeNext resolution. Consumers of the watchers have to redeclare a structural copy of the type the watcher emits.

Reported against `@subsquid/pipes@1.0.0-beta.6`.

## Fix

`export type { LatencySample, RpcObservation }` added to the three chain watcher modules, so the types travel with the watcher a consumer already imports. The bitcoin barrel uses a named export rather than `export *`, so it needs the re-export listed explicitly as well.

No `./monitoring` subpath was added: that would be a new public entrypoint also exposing `RpcLatencyWatcher`, `WebSocketListener` and `PollingClient`, which is an API-surface decision separate from this fix. Worth doing if we want custom watchers to be a supported extension point — happy to add it here if reviewers prefer that shape.

## Verification

A consumer project compiled against the built package under `module`/`moduleResolution: NodeNext` now resolves `import type { LatencySample, RpcObservation }` from `@subsquid/pipes/evm`, `/solana` and `/bitcoin` with a clean `tsc`. Watcher tests pass (32/32), `tsc --noEmit` over the package is clean, and Biome reports no findings.

## Test coverage

`src/monitoring/rpc-latency/public-types.test.ts` is a compile-time guard asserting both types are nameable from `~/{chain}/index.js` — the same modules the `./evm`, `./solana` and `./bitcoin` subpaths map to — and that they stay assignable to the definitions in `rpc-latency-watcher.ts`. Confirmed it fails on regression: dropping the re-export from the EVM watcher produces `TS2305: Module '"~/evm/index.js"' has no exported member 'RpcObservation'`, which the package typecheck catches.

No coverage diff is included because the change emits no runtime code — `export type` is erased at compile time, so the line and branch coverage of both base and head are identical by construction. The guard above covers the dimension that actually broke, which line coverage cannot observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0122HsEAXX7MgsWRCtgsZUZ4
