### PR TITLE
fix(pubsub): report the storage failure instead of the rollback that follows it

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -753,6 +753,16 @@ exclusive lock, and publish nothing.
 
 **Fix** — configure at least one topic route.
 
+### E2426 · State write failed
+
+A write to the producer's state file failed because the volume that holds it is full, gone,
+unreadable, or has been remounted read-only. The transaction was rolled back; the message says
+whether the batch had already been published, which decides whether anything needs redelivering.
+
+**Fix** — free space on the volume that holds the state file, or check its health, and restart.
+The state is the producer's sequencer: it must live on a persistent volume sized for the outbox
+backlog, not on ephemeral container storage.
+
 ### E2428 · Producer feeds more than one topic
 
 The change sequence is one producer-wide counter, so a producer that feeds several topics leaves

--- a/packages/pipes/src/drivers/sqlite/sqlite.test.ts
+++ b/packages/pipes/src/drivers/sqlite/sqlite.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { SqliteSync, isStorageFailure, loadSqlite, rollbackQuietly } from './sqlite.js'
+
+const dirs: string[] = []
+const opened: SqliteSync[] = []
+
+afterEach(() => {
+  for (const client of opened.splice(0)) {
+    client.close()
+  }
+  for (const dir of dirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+async function open(): Promise<SqliteSync> {
+  const dir = mkdtempSync(join(tmpdir(), 'sqlite-driver-'))
+  dirs.push(dir)
+
+  const client = await loadSqlite({ path: join(dir, 'test.sqlite') })
+  opened.push(client)
+
+  return client
+}
+
+function sqliteError(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code })
+}
+
+describe('rollbackQuietly', () => {
+  it('unwinds an open transaction and reports the connection clean', async () => {
+    const client = await open()
+    client.exec('CREATE TABLE t (id INTEGER PRIMARY KEY)')
+
+    client.exec('BEGIN IMMEDIATE')
+    client.exec('INSERT INTO t (id) VALUES (1)')
+
+    expect(rollbackQuietly(client)).toBe(true)
+    expect(client.get<{ n: number }>('SELECT COUNT(*) AS n FROM t')).toMatchObject({ n: 0 })
+
+    // Clean means clean: the next transaction opens without tripping over the last one.
+    client.exec('BEGIN IMMEDIATE')
+    client.exec('COMMIT')
+  })
+
+  it('swallows the rollback SQLite already performed for the failing statement', async () => {
+    const client = await open()
+
+    expect(rollbackQuietly(client)).toBe(true)
+  })
+
+  it('reports the connection unclean when the rollback itself could not run', async () => {
+    const client = await open()
+    const stub: SqliteSync = {
+      ...client,
+      exec: () => {
+        throw sqliteError('SQLITE_BUSY', 'database is locked')
+      },
+    }
+
+    // Swallowed either way — the failure that got us here must reach the caller — but the
+    // transaction is still open, and the caller has to know before its next BEGIN.
+    expect(rollbackQuietly(stub)).toBe(false)
+  })
+})
+
+describe('isStorageFailure', () => {
+  it.each([
+    ['SQLITE_FULL', true],
+    ['SQLITE_IOERR_WRITE', true],
+    ['SQLITE_NOMEM', true],
+    ['SQLITE_READONLY', true],
+    ['SQLITE_READONLY_DBMOVED', true],
+    ['SQLITE_CANTOPEN', true],
+    ['SQLITE_CONSTRAINT_PRIMARYKEY', false],
+    ['SQLITE_BUSY', false],
+  ])('%s → %s', (code, expected) => {
+    expect(isStorageFailure(sqliteError(code, 'boom'))).toBe(expected)
+  })
+
+  it('ignores errors that carry no SQLite code', () => {
+    expect(isStorageFailure(new Error('database or disk is full'))).toBe(false)
+    expect(isStorageFailure(null)).toBe(false)
+  })
+})

--- a/packages/pipes/src/drivers/sqlite/sqlite.ts
+++ b/packages/pipes/src/drivers/sqlite/sqlite.ts
@@ -15,6 +15,43 @@ export interface SqliteSync {
   close(): void
 }
 
+/**
+ * SQLite aborts the transaction itself on SQLITE_FULL, SQLITE_IOERR, SQLITE_NOMEM,
+ * SQLITE_BUSY and SQLITE_INTERRUPT. An unconditional `ROLLBACK` in a catch block then fails
+ * with "cannot rollback - no transaction is active" and replaces the failure that actually
+ * happened, so every rollback path has to swallow it and rethrow the original.
+ *
+ * Returns false when the connection may still hold an open transaction — the rollback failed
+ * for some other reason, and the next `BEGIN` on this connection would fail over the top of
+ * the real error with the previous statements still uncommitted.
+ */
+export function rollbackQuietly(client: SqliteSync): boolean {
+  try {
+    client.exec('ROLLBACK')
+
+    return true
+  } catch (e) {
+    return isNoActiveTransaction(e)
+  }
+}
+
+/** SQLite's own wording when the failing statement already unwound the transaction. */
+function isNoActiveTransaction(e: unknown): boolean {
+  const message = e instanceof Error ? e.message : String(e)
+
+  return /no transaction is active/i.test(message)
+}
+
+/**
+ * Errors for which the store, not the statement, is at fault: the volume is full, gone,
+ * unreadable, or has been remounted read-only under the process.
+ */
+export function isStorageFailure(e: unknown): boolean {
+  const code = (e as { code?: unknown } | null)?.code
+
+  return typeof code === 'string' && /^SQLITE_(FULL|IOERR|NOMEM|READONLY|CANTOPEN)/.test(code)
+}
+
 function setupClient(client: SqliteSync, options: SqliteOptions): SqliteSync {
   if (options.enableWAL ?? true) {
     client.exec('PRAGMA journal_mode = WAL;')

--- a/packages/pipes/src/evm/factory-adapters/sqlite.ts
+++ b/packages/pipes/src/evm/factory-adapters/sqlite.ts
@@ -1,6 +1,6 @@
 import { AbiEvent } from '@subsquid/evm-abi'
 
-import { SqliteOptions, SqliteSync, loadSqlite } from '~/drivers/sqlite/sqlite.js'
+import { SqliteOptions, SqliteSync, loadSqlite, rollbackQuietly } from '~/drivers/sqlite/sqlite.js'
 import { jsonParse, jsonStringify } from '~/internal/json.js'
 
 import { IndexedParams } from '../evm-decoder.js'
@@ -29,29 +29,46 @@ class SqliteFactoryAdapter<T extends EventArgs> implements FactoryPersistentAdap
     this.#db = db
   }
 
-  async migrate(): Promise<void> {
+  /**
+   * Every write goes through here: a transaction left open by a failed statement makes the
+   * next `BEGIN` fail with an error about the transaction rather than about what went wrong.
+   */
+  #transaction(body: () => void): void {
     this.#db.exec('BEGIN TRANSACTION')
-    this.#db.exec(`CREATE TABLE IF NOT EXISTS "metadata" (id TEXT, value TEXT, PRIMARY KEY (id))`)
-    this.#db.exec(
-      `INSERT INTO "metadata" (id, value) VALUES (?, ?)  ON CONFLICT (id) DO UPDATE SET "value" = excluded.value`,
-      ['version', VERSION],
-    )
-    this.#db.exec('COMMIT')
 
-    this.#db.exec('BEGIN TRANSACTION')
-    this.#db.exec(`
-      CREATE TABLE IF NOT EXISTS factory (
-        address             TEXT,
-        factory             TEXT,
-        block_number        INTEGER,
-        transaction_index   INTEGER,
-        log_index           INTEGER,
-        event               BLOB,
-        PRIMARY KEY (address)
+    try {
+      body()
+      this.#db.exec('COMMIT')
+    } catch (error) {
+      rollbackQuietly(this.#db)
+
+      throw error
+    }
+  }
+
+  async migrate(): Promise<void> {
+    this.#transaction(() => {
+      this.#db.exec(`CREATE TABLE IF NOT EXISTS "metadata" (id TEXT, value TEXT, PRIMARY KEY (id))`)
+      this.#db.exec(
+        `INSERT INTO "metadata" (id, value) VALUES (?, ?)  ON CONFLICT (id) DO UPDATE SET "value" = excluded.value`,
+        ['version', VERSION],
       )
-    `)
-    this.#db.exec(`CREATE INDEX IF NOT EXISTS factory_block_number_idx ON factory (block_number)`)
-    this.#db.exec('COMMIT')
+    })
+
+    this.#transaction(() => {
+      this.#db.exec(`
+        CREATE TABLE IF NOT EXISTS factory (
+          address             TEXT,
+          factory             TEXT,
+          block_number        INTEGER,
+          transaction_index   INTEGER,
+          log_index           INTEGER,
+          event               BLOB,
+          PRIMARY KEY (address)
+        )
+      `)
+      this.#db.exec(`CREATE INDEX IF NOT EXISTS factory_block_number_idx ON factory (block_number)`)
+    })
   }
 
   /**
@@ -124,8 +141,7 @@ class SqliteFactoryAdapter<T extends EventArgs> implements FactoryPersistentAdap
   }
 
   async save(entities: InternalFactoryEvent<any>[]): Promise<void> {
-    this.#db.exec('BEGIN TRANSACTION')
-    try {
+    this.#transaction(() => {
       for (const entity of entities) {
         this.#db.exec(
           `INSERT OR IGNORE INTO factory ('address', 'factory', 'block_number', 'transaction_index', 'log_index', 'event') VALUES (?,?,?,?,?,?)`,
@@ -139,11 +155,8 @@ class SqliteFactoryAdapter<T extends EventArgs> implements FactoryPersistentAdap
           ],
         )
       }
-      this.#db.exec('COMMIT')
-    } catch (error) {
-      this.#db.exec('ROLLBACK')
-      throw error
-    }
+    })
+
     this.clearCache()
   }
 

--- a/packages/pipes/src/targets/pubsub/errors.ts
+++ b/packages/pipes/src/targets/pubsub/errors.ts
@@ -88,6 +88,11 @@ export const PUBSUB_ERROR_CODES = {
   /** No routes were configured. */
   NO_ROUTES: 'E2425',
   /**
+   * A state write failed on the store itself rather than on the data: the volume is out of
+   * space, or the file could not be read back. The batch was rolled back and nothing shipped.
+   */
+  STATE_WRITE_FAILED: 'E2426',
+  /**
    * The producer feeds more than one topic, which splits its sequence counter and puts a hole
    * in every topic's run. Declare `sequenceBarrier: false` if no consumer reads the barrier.
    */

--- a/packages/pipes/src/targets/pubsub/pubsub-state.test.ts
+++ b/packages/pipes/src/targets/pubsub/pubsub-state.test.ts
@@ -5,10 +5,11 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { BlockCursor } from '~/core/index.js'
+import { SqliteOptions, SqliteSync, loadSqlite } from '~/drivers/sqlite/sqlite.js'
 import { testLogger } from '~/testing/index.js'
 
 import { PUBSUB_ERROR_CODES, PubsubTargetError } from './errors.js'
-import { CommitInput, PendingOperation, SqlitePubsubState } from './pubsub-state.js'
+import { CommitInput, INTERNAL_DRIVER, PendingOperation, SqlitePubsubState } from './pubsub-state.js'
 
 const encoder = new TextEncoder()
 const text = (bytes: Uint8Array) => new TextDecoder().decode(bytes)
@@ -32,12 +33,58 @@ function statePath(): string {
   return join(dir, 'state.sqlite')
 }
 
-async function openState(path: string) {
-  const state = new SqlitePubsubState({ path })
+async function openState(path: string, driver?: SqlitePubsubStateDriver) {
+  const state = new SqlitePubsubState({ path, [INTERNAL_DRIVER]: driver })
   const { coldStart } = await state.open({ cursorKey: 'test-pipe', logger: testLogger() })
   opened.push(state)
 
   return { state, coldStart }
+}
+
+type SqlitePubsubStateDriver = (options: SqliteOptions) => Promise<SqliteSync>
+
+type Fault = { error: Error; selfRollback: boolean }
+
+/**
+ * A real driver with one statement rigged to fail. `selfRollback` models the SQLITE_FULL /
+ * SQLITE_IOERR class, where SQLite unwinds the transaction before handing the error back.
+ */
+class FaultyDriver {
+  #inner?: SqliteSync
+  faultOn?: (sql: string) => Fault | undefined
+
+  readonly load: SqlitePubsubStateDriver = async (options) => {
+    const inner = await loadSqlite(options)
+    this.#inner = inner
+
+    return {
+      get: (sql, params) => inner.get(sql, params),
+      all: (sql, params) => inner.all(sql, params),
+      stream: (sql, params) => inner.stream(sql, params),
+      close: () => inner.close(),
+      exec: (sql, params) => {
+        const fault = this.faultOn?.(sql)
+        if (!fault) {
+          return inner.exec(sql, params)
+        }
+
+        if (fault.selfRollback) {
+          inner.exec('ROLLBACK')
+        }
+
+        throw fault.error
+      },
+    }
+  }
+
+  /** Reads bypass the fault, so a test can assert what the failed transaction left behind. */
+  count(table: string): number {
+    return this.#inner!.get<{ n: number }>(`SELECT COUNT(*) AS n FROM ${table}`)!.n
+  }
+}
+
+function sqliteError(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code })
 }
 
 /** Every case here exercises a fork-capable pipe; `forkCapable` is the interesting default. */
@@ -781,6 +828,154 @@ describe('SqlitePubsubState', () => {
       const pending = await state.pending()
       expect(pending).toHaveLength(1)
       expect(pending[0].op).toBe('delete')
+    })
+  })
+
+  describe('storage faults', () => {
+    it('reports the disk failure, not the rollback that SQLite already performed', async () => {
+      const driver = new FaultyDriver()
+      const { state } = await openState(statePath(), driver.load)
+
+      driver.faultOn = (sql) =>
+        sql.startsWith('INSERT INTO manifest')
+          ? { error: sqliteError('SQLITE_FULL', 'database or disk is full'), selfRollback: true }
+          : undefined
+
+      const failure = await commit(state, {
+        operations: [operation()],
+        ledger: [block(100)],
+        cursor: block(100),
+        finalized: null,
+      }).catch((e) => e)
+
+      expect(failure).toBeInstanceOf(PubsubTargetError)
+      expect(failure.code).toBe(PUBSUB_ERROR_CODES.STATE_WRITE_FAILED)
+      expect(failure.message).toContain('database or disk is full')
+      expect(failure.message).toContain('nothing was published')
+      expect(failure.message).not.toContain('no transaction is active')
+      expect(failure.cause).toMatchObject({ code: 'SQLITE_FULL' })
+    })
+
+    it('leaves nothing of the failed batch behind', async () => {
+      const driver = new FaultyDriver()
+      const { state } = await openState(statePath(), driver.load)
+
+      driver.faultOn = (sql) =>
+        sql.startsWith('INSERT INTO ledger_blocks')
+          ? { error: sqliteError('SQLITE_FULL', 'database or disk is full'), selfRollback: true }
+          : undefined
+
+      await expect(
+        commit(state, { operations: [operation()], ledger: [block(100)], cursor: block(100), finalized: null }),
+      ).rejects.toThrow(PubsubTargetError)
+
+      driver.faultOn = undefined
+      expect(driver.count('outbox')).toBe(0)
+      expect(driver.count('manifest')).toBe(0)
+      expect(await state.getCursor()).toBeUndefined()
+    })
+
+    it('still rolls back a failure that leaves the transaction open', async () => {
+      const driver = new FaultyDriver()
+      const { state } = await openState(statePath(), driver.load)
+
+      driver.faultOn = (sql) =>
+        sql.startsWith('INSERT INTO manifest')
+          ? { error: sqliteError('SQLITE_CONSTRAINT_PRIMARYKEY', 'UNIQUE constraint failed'), selfRollback: false }
+          : undefined
+
+      const failure = await commit(state, {
+        operations: [operation()],
+        ledger: [block(100)],
+        cursor: block(100),
+        finalized: null,
+      }).catch((e) => e)
+
+      // Not a storage failure: the driver error reaches the caller untranslated.
+      expect(failure).not.toBeInstanceOf(PubsubTargetError)
+      expect(failure.code).toBe('SQLITE_CONSTRAINT_PRIMARYKEY')
+
+      driver.faultOn = undefined
+      expect(driver.count('outbox')).toBe(0)
+    })
+
+    it('reports a disk failure while draining the outbox', async () => {
+      const driver = new FaultyDriver()
+      const { state } = await openState(statePath(), driver.load)
+
+      await commit(state, { operations: [operation()], ledger: [block(100)], cursor: block(100), finalized: null })
+      const [row] = await state.pending()
+
+      driver.faultOn = (sql) =>
+        sql.startsWith('DELETE FROM outbox')
+          ? { error: sqliteError('SQLITE_IOERR_WRITE', 'disk I/O error'), selfRollback: true }
+          : undefined
+
+      const failure = await state.confirm([row.rowId]).catch((e) => e)
+
+      expect(failure.code).toBe(PUBSUB_ERROR_CODES.STATE_WRITE_FAILED)
+      expect(failure.message).toContain('disk I/O error')
+
+      // The batch is already on the wire here. Saying it was not would send an operator
+      // rewinding the cursor and replaying messages consumers have seen.
+      expect(failure.message).toContain('already published')
+      expect(failure.message).not.toContain('nothing was published')
+
+      // The row stays queued: an unconfirmed publish is retried, never dropped.
+      driver.faultOn = undefined
+      expect(await state.pending()).toHaveLength(1)
+    })
+
+    it('reports a volume remounted read-only under the producer', async () => {
+      const driver = new FaultyDriver()
+      const { state } = await openState(statePath(), driver.load)
+
+      driver.faultOn = (sql) =>
+        sql.startsWith('INSERT INTO outbox')
+          ? { error: sqliteError('SQLITE_READONLY', 'attempt to write a readonly database'), selfRollback: false }
+          : undefined
+
+      const failure = await commit(state, {
+        operations: [operation()],
+        ledger: [block(100)],
+        cursor: block(100),
+        finalized: null,
+      }).catch((e) => e)
+
+      expect(failure.code).toBe(PUBSUB_ERROR_CODES.STATE_WRITE_FAILED)
+      expect(failure.message).toContain('attempt to write a readonly database')
+    })
+
+    it('clears a transaction left open by a rollback that could not run', async () => {
+      const driver = new FaultyDriver()
+      const { state } = await openState(statePath(), driver.load)
+
+      // Neither the write nor the rollback after it gets through, so the transaction that the
+      // failed batch opened is still there when the next one starts.
+      driver.faultOn = (sql) => {
+        if (sql.startsWith('INSERT INTO manifest')) {
+          return { error: sqliteError('SQLITE_CONSTRAINT_PRIMARYKEY', 'UNIQUE constraint failed'), selfRollback: false }
+        }
+        if (sql === 'ROLLBACK') {
+          return { error: sqliteError('SQLITE_BUSY', 'database is locked'), selfRollback: false }
+        }
+
+        return undefined
+      }
+
+      await expect(
+        commit(state, { operations: [operation()], ledger: [block(100)], cursor: block(100), finalized: null }),
+      ).rejects.toThrow('UNIQUE constraint failed')
+
+      driver.faultOn = undefined
+      await commit(state, {
+        operations: [operation({ id: 'row-2' })],
+        ledger: [block(101)],
+        cursor: block(101),
+        finalized: null,
+      })
+
+      expect((await state.getCursor())?.latest).toEqual(block(101))
     })
   })
 })

--- a/packages/pipes/src/targets/pubsub/pubsub-state.ts
+++ b/packages/pipes/src/targets/pubsub/pubsub-state.ts
@@ -7,7 +7,7 @@ import {
   normalizeFinalized,
   resolveForkCursor,
 } from '~/core/index.js'
-import { SqliteSync, loadSqlite } from '~/drivers/sqlite/sqlite.js'
+import { SqliteOptions, SqliteSync, isStorageFailure, loadSqlite, rollbackQuietly } from '~/drivers/sqlite/sqlite.js'
 
 import { PUBSUB_ERROR_CODES, PubsubTargetError } from './errors.js'
 import { MAX_SEQUENCE_VALUE, PubsubOp } from './protocol.js'
@@ -183,17 +183,44 @@ function lockedError(path: string, cause: unknown): PubsubTargetError {
   ])
 }
 
+/**
+ * The seam the storage-fault suites inject a driver through — a full or failing volume cannot
+ * be staged against a real file. Symbol-keyed so it stays out of the option surface consumers
+ * see, and absent from the public entrypoint.
+ *
+ * @internal
+ */
+export const INTERNAL_DRIVER: unique symbol = Symbol.for('@subsquid/pipes:pubsub-state:driver')
+
 export type SqlitePubsubStateOptions = {
   path: string
   /** Cursor key override; defaults to the pipe id once `open` binds it (ADR-2). */
   id?: string
+  /** @internal */
+  [INTERNAL_DRIVER]?: (options: SqliteOptions) => Promise<SqliteSync>
 }
+
+/**
+ * What a rolled-back transaction means for whoever reads E2426. `confirm` runs after the
+ * batch is on the wire, so the one message that fits every site would tell an operator the
+ * opposite of what happened and invite a replay.
+ */
+const ROLLED_BACK = {
+  schema: 'The state file is unchanged.',
+  commit: 'The batch was rolled back and nothing was published.',
+  confirm:
+    'The batch was already published — only its outbox acknowledgement was rolled back, so those ' +
+    'rows stay queued and will be delivered again.',
+  fork: 'The fork compensation was rolled back, so the state still describes the pre-fork chain.',
+} as const
 
 export class SqlitePubsubState implements PubsubState {
   readonly #options: SqlitePubsubStateOptions
   readonly #key: CursorKey
   #db?: SqliteSync
   #logger?: Logger
+  /** False once a rollback could not run: the connection may still hold an open transaction. */
+  #unwound = true
 
   constructor(options: SqlitePubsubStateOptions) {
     this.#options = options
@@ -218,7 +245,7 @@ export class SqlitePubsubState implements PubsubState {
 
     let db: SqliteSync
     try {
-      db = await loadSqlite({ path: this.#options.path })
+      db = await (this.#options[INTERNAL_DRIVER] ?? loadSqlite)({ path: this.#options.path })
     } catch (e) {
       // A live producer holds the file in exclusive locking mode, so the second one fails
       // right here — on the driver's own WAL pragma, before any target code runs.
@@ -236,6 +263,11 @@ export class SqlitePubsubState implements PubsubState {
     // file on the way out: otherwise a caller that retries in the same process meets its own
     // dead connection and reads the mismatch as a second producer.
     try {
+      // WAL is the shared driver's own default, re-asserted here because an injected one may
+      // never have been through it, and rollback-journal mode would change the durability the
+      // pragma below is buying.
+      db.exec('PRAGMA journal_mode = WAL;')
+
       // The shared driver defaults to synchronous = NORMAL, under which an OS crash can roll
       // back the most recent commits. Here a rolled-back commit is a published operation the
       // state has no record of, so the target pays for FULL.
@@ -312,11 +344,52 @@ export class SqlitePubsubState implements PubsubState {
     }
   }
 
+  /**
+   * The single write path. On failure the transaction is unwound and the caller sees the
+   * failure that caused it: SQLite has already aborted the transaction itself for a full or
+   * failing volume, and a bare `ROLLBACK` would throw over the top of the real error.
+   */
+  #transaction<T>(begin: 'BEGIN' | 'BEGIN IMMEDIATE', rolledBack: string, body: () => T): T {
+    const db = this.#db!
+
+    // A rollback that could not run at all left the transaction open. Clearing it here keeps
+    // the next BEGIN from failing over the top of that error, one call late.
+    if (!this.#unwound) {
+      this.#unwound = rollbackQuietly(db)
+    }
+
+    try {
+      db.exec(begin)
+      const result = body()
+      db.exec('COMMIT')
+
+      return result
+    } catch (e) {
+      this.#unwound = rollbackQuietly(db)
+
+      throw this.#storageError(e, rolledBack)
+    }
+  }
+
+  /** A full or unreadable volume is the store failing, not the batch — say so by that name. */
+  #storageError(e: unknown, rolledBack: string): unknown {
+    if (!isStorageFailure(e)) return e
+
+    const error = new PubsubTargetError(PUBSUB_ERROR_CODES.STATE_WRITE_FAILED, [
+      `The PubSub state at "${this.#options.path}" could not be written: ` +
+        (e instanceof Error ? e.message : String(e)),
+      `${rolledBack} The state is the producer’s sequencer — check the free space and the ` +
+        'health of the volume that holds it.',
+    ])
+    error.cause = e
+
+    return error
+  }
+
   #initializeSchema(): void {
     const db = this.#db!
 
-    db.exec('BEGIN')
-    try {
+    this.#transaction('BEGIN', ROLLED_BACK.schema, () => {
       db.exec(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)`)
       db.exec(`
         CREATE TABLE IF NOT EXISTS cursor (
@@ -393,11 +466,7 @@ export class SqlitePubsubState implements PubsubState {
           payload       BLOB,
           PRIMARY KEY (topic, ordering_key, id)
         )`)
-      db.exec('COMMIT')
-    } catch (e) {
-      db.exec('ROLLBACK')
-      throw e
-    }
+    })
   }
 
   // ─── meta ───────────────────────────────────────────────────────────────────
@@ -485,8 +554,7 @@ export class SqlitePubsubState implements PubsubState {
   async commit({ operations, ledger, cursor, finalized, forkCapable }: CommitInput): Promise<void> {
     const db = this.#db!
 
-    db.exec('BEGIN IMMEDIATE')
-    try {
+    this.#transaction('BEGIN IMMEDIATE', ROLLED_BACK.commit, () => {
       for (const operation of operations) {
         const seq = this.#nextSeq(operation)
         this.#enqueue(operation, seq)
@@ -566,12 +634,7 @@ export class SqlitePubsubState implements PubsubState {
       if (finalized) {
         this.#foldFinalized(finalized.number)
       }
-
-      db.exec('COMMIT')
-    } catch (e) {
-      db.exec('ROLLBACK')
-      throw e
-    }
+    })
   }
 
   /**
@@ -762,16 +825,12 @@ export class SqlitePubsubState implements PubsubState {
     if (!rowIds.length) return
 
     const db = this.#db!
-    db.exec('BEGIN IMMEDIATE')
-    try {
+
+    this.#transaction('BEGIN IMMEDIATE', ROLLED_BACK.confirm, () => {
       for (const rowId of rowIds) {
         db.exec('DELETE FROM outbox WHERE row_id = ?', [rowId])
       }
-      db.exec('COMMIT')
-    } catch (e) {
-      db.exec('ROLLBACK')
-      throw e
-    }
+    })
   }
 
   async stats(): Promise<{ outbox: number; manifest: number }> {
@@ -798,8 +857,7 @@ export class SqlitePubsubState implements PubsubState {
     const rollbackTo = safe ?? finalized ?? null
     const floor = rollbackTo?.number ?? -1
 
-    db.exec('BEGIN IMMEDIATE')
-    try {
+    this.#transaction('BEGIN IMMEDIATE', ROLLED_BACK.fork, () => {
       const compensations = this.#compensate(floor)
       this.#logger?.debug(
         `fork at block ${floor}: ${compensations} compensating operation(s) enqueued${safe ? '' : ' (dead-end fork)'}`,
@@ -819,12 +877,7 @@ export class SqlitePubsubState implements PubsubState {
       if (rollbackTo) {
         this.#saveCursor(rollbackTo, finalized ?? null)
       }
-
-      db.exec('COMMIT')
-    } catch (e) {
-      db.exec('ROLLBACK')
-      throw e
-    }
+    })
 
     return safe
   }


### PR DESCRIPTION
## Summary

- SQLite unwinds a transaction itself on `SQLITE_FULL`, `SQLITE_IOERR` and `SQLITE_NOMEM`. The unconditional `db.exec('ROLLBACK')` in every `catch` block then failed with `cannot rollback - no transaction is active` and that error replaced the one that actually happened — a producer whose state volume filled up crash-looped on a message that says nothing about the volume.
- All four transaction blocks in `SqlitePubsubState` (`#initializeSchema`, `commit`, `confirm`, `fork`) now go through one `#transaction()` helper that rolls back quietly and rethrows the original failure; a store-level failure is translated into `PubsubTargetError` `E2426 STATE_WRITE_FAILED` carrying the driver error as `cause`. The same bare rollback in the EVM SQLite factory adapter is fixed alongside it.
- `SqlitePubsubState` gained an internal `driver` override. There was previously no seam to reach the catch path with anything but a JS-level throw, which is exactly why the bug survived a 34-case suite: those throws leave the transaction open, so the rollback succeeds and the error propagates correctly. Only the class of errors SQLite aborts on its own hit the masking path, and nothing could stage one.

## Coverage

| Module | Stmts | Δ | Branch | Δ |
|--------|-------|---|--------|---|
| **All files** | 88.1% | +0.1 | 88.2% | +0.1 |
| src/drivers/sqlite | 57.5% | +6.7 | 88.2% | +2.5 |
| src/targets/pubsub | 96.0% | +0.5 | 90.0% | +0.4 |

Both runs exclude `src/targets/delta-db/**`, which is work in progress in the working tree and has no counterpart on `main`.

## Test plan

- New `storage faults` suite in `pubsub-state.test.ts`, driven by a real SQLite driver with one statement rigged to fail. Its `selfRollback` flag models the class of errors SQLite aborts the transaction on before handing the error back.
  - [x] A full volume during `commit()` surfaces `E2426` with the real `database or disk is full` text, never the rollback error, and keeps the driver error as `cause`.
  - [x] The failed batch leaves no outbox row, no manifest row and no cursor behind.
  - [x] A constraint violation — which leaves the transaction open — still rolls back and reaches the caller untranslated.
  - [x] An I/O error while draining the outbox reports `E2426` and leaves the row queued for retry.
- Mutation check: restoring the unconditional `ROLLBACK` fails the first case, so the test pins this bug specifically.
- End-to-end against a real full volume (4 MB RAM disk, real `commit()` loop): before the fix the run died with `SqliteError: cannot rollback - no transaction is active`, after it with `E2426 … could not be written: database or disk is full`.
- Full suite green with ClickHouse and PostgreSQL up: 943 passed, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014tAWQYJPgL1CEwYqkijrg8
